### PR TITLE
docs: add MkDocs Material for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The project includes a comprehensive test suite covering the ECS system and grap
 dotnet test
 ```
 
-For more information about testing, see the [Testing Guide](docs/TESTING.md).
+For more information about testing, see the [Testing Guide](docs/testing.md).
 
 ## Project Structure
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+# Yaeger
+
+**Y**et **A**nother **E**xperimental **G**ame **E**ngine **R**epository
+
+Yaeger is a modular, experimental 2D game engine written in C#. It provides a flexible and extensible platform for rapid prototyping and development of games and interactive applications.
+
+## Features
+
+- **Entity-Component-System (ECS)** architecture
+- **2D rendering** with Silk.NET
+- **Batch rendering** for efficient sprite rendering
+- **Animation system** with frame-based texture cycling
+- **Audio system** with OpenAL support
+- **Input handling** (keyboard, mouse)
+- Extensible component and system design
+
+## Quick Start
+
+### Prerequisites
+
+- .NET 9.0 SDK or later
+- Compatible OS (Windows, macOS, Linux)
+
+### Build & Run
+
+```bash
+# Clone the repository
+git clone https://github.com/Anras573/Yaeger.git
+cd Yaeger
+
+# Build the engine and samples
+dotnet build yaeger.sln
+
+# Run the Pong sample
+dotnet run --project Samples/Pong/Pong.csproj
+```
+
+## Project Structure
+
+```
+src/Engine/Yaeger/
+├── ECS/        # Entity-Component-System framework
+├── Rendering/  # Rendering systems (including batch renderer)
+├── Graphics/   # Graphics primitives and utilities
+├── Audio/      # Audio system (OpenAL)
+├── Input/      # Input handling
+└── Windowing/  # Window management
+
+Samples/
+├── Pong/                    # Classic Pong game
+├── BatchRenderingExample/   # Batch rendering demo
+└── TextRenderingExample/    # Text rendering demo
+```
+
+## License
+
+This project is licensed under the MIT License.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,45 @@
+site_name: Yaeger
+site_description: Yet Another Experimental Game Engine Repository - A modular 2D game engine in C#
+site_url: https://anras573.github.io/Yaeger
+repo_url: https://github.com/Anras573/Yaeger
+repo_name: Anras573/Yaeger
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.sections
+    - content.code.copy
+    - search.highlight
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Animation System: animation-system.md
+      - Audio System: audio-system.md
+      - Batch Rendering: batch-rendering.md
+  - Contributing:
+      - Testing Guide: testing.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary
- Add MkDocs Material configuration for documentation website
- Add GitHub Actions workflow for automatic deployment to GitHub Pages
- Add documentation homepage (`docs/index.md`)
- Fix README link to renamed `testing.md`

## Setup Required
After merging, enable GitHub Pages in repo settings:
1. Go to **Settings → Pages**
2. Set **Source** to **GitHub Actions**

The docs will then be available at https://anras573.github.io/Yaeger

## Test plan
- [x] MkDocs config is valid YAML
- [x] GitHub Action uses secure patterns (no untrusted input in run commands)
- [ ] After merge: verify GitHub Pages deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)