### PR TITLE
Fix startup failures: bundle OpenAL native libs and resolve asset pat…

### DIFF
--- a/src/Engine/Yaeger/AssetPath.cs
+++ b/src/Engine/Yaeger/AssetPath.cs
@@ -13,18 +13,20 @@ namespace Yaeger;
 public static class AssetPath
 {
     /// <summary>
-    /// Resolves a relative asset path against the application's base directory.
+    /// Resolves an asset path against the application's base directory.
     /// Absolute paths are returned unchanged.
     /// </summary>
-    /// <param name="relativePath">The relative path to the asset file.</param>
+    /// <param name="path">
+    /// The asset path to resolve. May be relative (e.g. <c>"Assets/square.png"</c>) or an absolute path.
+    /// </param>
     /// <returns>The fully resolved absolute path.</returns>
-    public static string Resolve(string relativePath)
+    public static string Resolve(string path)
     {
-        if (Path.IsPathRooted(relativePath))
+        if (Path.IsPathRooted(path))
         {
-            return relativePath;
+            return path;
         }
 
-        return Path.Combine(AppContext.BaseDirectory, relativePath);
+        return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, path));
     }
 }

--- a/src/Engine/Yaeger/AssetPath.cs
+++ b/src/Engine/Yaeger/AssetPath.cs
@@ -1,0 +1,30 @@
+namespace Yaeger;
+
+/// <summary>
+/// Resolves asset file paths relative to the application's base directory.
+/// </summary>
+/// <remarks>
+/// When assets are configured with <c>CopyToOutputDirectory</c> in the project file,
+/// they are placed alongside the application binary. This helper ensures that relative
+/// paths like <c>"Assets/square.png"</c> are resolved against that output directory
+/// rather than the current working directory, which may differ when using
+/// <c>dotnet run</c> or launching from an IDE.
+/// </remarks>
+public static class AssetPath
+{
+    /// <summary>
+    /// Resolves a relative asset path against the application's base directory.
+    /// Absolute paths are returned unchanged.
+    /// </summary>
+    /// <param name="relativePath">The relative path to the asset file.</param>
+    /// <returns>The fully resolved absolute path.</returns>
+    public static string Resolve(string relativePath)
+    {
+        if (Path.IsPathRooted(relativePath))
+        {
+            return relativePath;
+        }
+
+        return Path.Combine(AppContext.BaseDirectory, relativePath);
+    }
+}

--- a/src/Engine/Yaeger/Audio/SoundBuffer.cs
+++ b/src/Engine/Yaeger/Audio/SoundBuffer.cs
@@ -91,12 +91,14 @@ public sealed class SoundBuffer : IDisposable
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(filePath);
 
-        if (!File.Exists(filePath))
+        var resolvedPath = AssetPath.Resolve(filePath);
+
+        if (!File.Exists(resolvedPath))
         {
             throw new FileNotFoundException($"Audio file not found: {filePath}");
         }
 
-        var (data, format, sampleRate) = LoadWavFile(filePath);
+        var (data, format, sampleRate) = LoadWavFile(resolvedPath);
         return Create(context, data, format, sampleRate);
     }
 

--- a/src/Engine/Yaeger/Audio/SoundBuffer.cs
+++ b/src/Engine/Yaeger/Audio/SoundBuffer.cs
@@ -95,7 +95,10 @@ public sealed class SoundBuffer : IDisposable
 
         if (!File.Exists(resolvedPath))
         {
-            throw new FileNotFoundException($"Audio file not found: {filePath}");
+            throw new FileNotFoundException(
+                $"Audio file not found. Requested path: {filePath}, resolved path: {resolvedPath}",
+                resolvedPath
+            );
         }
 
         var (data, format, sampleRate) = LoadWavFile(resolvedPath);

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -1,13 +1,9 @@
-using System.Reflection;
-
 namespace Yaeger.Font;
 
 public class FontManager : IDisposable
 {
     private readonly Dictionary<string, Font> _fonts = new();
     private bool _disposed;
-    private readonly string _assemblyPath =
-        Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
 
     public Font Load(string fontPath)
     {
@@ -16,7 +12,7 @@ public class FontManager : IDisposable
             return existingFont;
         }
 
-        var font = new Font(Path.Combine(_assemblyPath, fontPath));
+        var font = new Font(AssetPath.Resolve(fontPath));
         _fonts[fontPath] = font;
         return font;
     }

--- a/src/Engine/Yaeger/Rendering/Texture.cs
+++ b/src/Engine/Yaeger/Rendering/Texture.cs
@@ -14,7 +14,7 @@ public class Texture : IDisposable
         _handle = _gl.GenTexture();
         _gl.BindTexture(TextureTarget.Texture2D, _handle);
 
-        using var stream = File.OpenRead(path);
+        using var stream = File.OpenRead(AssetPath.Resolve(path));
         var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
 
         fixed (byte* data = image.Data)

--- a/src/Engine/Yaeger/Yaeger.csproj
+++ b/src/Engine/Yaeger/Yaeger.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="HarfBuzzSharp" Version="8.3.1.2" />
     <PackageReference Include="Silk.NET" Version="2.22.0" />
     <PackageReference Include="Silk.NET.OpenAL" Version="2.22.0" />
+    <PackageReference Include="Silk.NET.OpenAL.Soft.Native" Version="1.23.1" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.1" />
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
   </ItemGroup>

--- a/tests/Yaeger.Tests/AssetPathTests.cs
+++ b/tests/Yaeger.Tests/AssetPathTests.cs
@@ -1,0 +1,71 @@
+namespace Yaeger.Tests;
+
+public class AssetPathTests
+{
+    [Fact]
+    public void Resolve_ShouldReturnAbsolutePathUnchanged()
+    {
+        // Arrange
+        var absolutePath = Path.Combine(Path.GetTempPath(), "Assets", "square.png");
+
+        // Act
+        var result = AssetPath.Resolve(absolutePath);
+
+        // Assert
+        Assert.Equal(absolutePath, result);
+    }
+
+    [Fact]
+    public void Resolve_ShouldResolveRelativePathAgainstBaseDirectory()
+    {
+        // Arrange
+        var relativePath = Path.Combine("Assets", "square.png");
+
+        // Act
+        var result = AssetPath.Resolve(relativePath);
+
+        // Assert
+        var expected = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, relativePath));
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Resolve_ShouldReturnFullyNormalizedPath()
+    {
+        // Arrange
+        var pathWithDotSegments = Path.Combine("Assets", "..", "Assets", "square.png");
+
+        // Act
+        var result = AssetPath.Resolve(pathWithDotSegments);
+
+        // Assert
+        Assert.DoesNotContain("..", result);
+        Assert.True(Path.IsPathRooted(result));
+    }
+
+    [Fact]
+    public void Resolve_ShouldReturnRootedPathForRelativeInput()
+    {
+        // Arrange
+        var relativePath = "square.png";
+
+        // Act
+        var result = AssetPath.Resolve(relativePath);
+
+        // Assert
+        Assert.True(Path.IsPathRooted(result));
+    }
+
+    [Fact]
+    public void Resolve_ShouldStartWithBaseDirectory()
+    {
+        // Arrange
+        var relativePath = Path.Combine("Assets", "square.png");
+
+        // Act
+        var result = AssetPath.Resolve(relativePath);
+
+        // Assert
+        Assert.StartsWith(Path.GetFullPath(AppContext.BaseDirectory), result);
+    }
+}


### PR DESCRIPTION
…hs against output directory

The Pong sample crashed on Windows because OpenAL native libraries were not present. Added Silk.NET.OpenAL.Soft.Native to bundle them. Also introduced a centralized AssetPath helper so that relative asset paths (textures, fonts, audio) are resolved against AppContext.BaseDirectory instead of the current working directory, fixing file-not-found errors when running via dotnet run.