### PR TITLE
feat: add 2D physics engine with ECS integration

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,6 +8,13 @@
         "csharpier"
       ],
       "rollForward": false
+    },
+    "husky": {
+      "version": "0.9.1",
+      "commands": [
+        "husky"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## husky task runner examples -------------------
+## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+
+## run all tasks
+#husky run
+
+### run all tasks with group: 'group-name'
+#husky run --group group-name
+
+## run task with name: 'task-name'
+#husky run --name task-name
+
+## pass hook arguments to task
+#husky run --args "$1" "$2"
+
+## or put your custom commands -------------------
+#echo 'Husky.Net is awesome!'
+
+dotnet husky run --group pre-commit

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,12 @@
+{
+   "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
+   "tasks": [
+      {
+         "name": "csharpier",
+         "group": "pre-commit",
+         "command": "dotnet",
+         "args": ["csharpier", "format", "${staged}"],
+         "include": ["**/*.cs"]
+      }
+   ]
+}

--- a/Samples/Pong/Program.cs
+++ b/Samples/Pong/Program.cs
@@ -2,7 +2,6 @@
 
 using Pong;
 using Pong.Systems;
-using Yaeger.Audio;
 using Yaeger.ECS;
 using Yaeger.Input;
 using Yaeger.Rendering;

--- a/Samples/Pong/Systems/IUpdateSystem.cs
+++ b/Samples/Pong/Systems/IUpdateSystem.cs
@@ -1,6 +1,0 @@
-namespace Pong.Systems;
-
-public interface IUpdateSystem
-{
-    void Update(float deltaTime);
-}

--- a/Samples/Pong/Systems/InputSystem.cs
+++ b/Samples/Pong/Systems/InputSystem.cs
@@ -3,6 +3,7 @@ using Pong.Components;
 using Yaeger.ECS;
 using Yaeger.Graphics;
 using Yaeger.Input;
+using Yaeger.Systems;
 
 namespace Pong.Systems;
 

--- a/Samples/Pong/Systems/MoveSystem.cs
+++ b/Samples/Pong/Systems/MoveSystem.cs
@@ -1,6 +1,7 @@
 using Pong.Components;
 using Yaeger.ECS;
 using Yaeger.Graphics;
+using Yaeger.Systems;
 
 namespace Pong.Systems;
 

--- a/Samples/Pong/Systems/PhysicsSystem.cs
+++ b/Samples/Pong/Systems/PhysicsSystem.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Pong.Components;
 using Yaeger.ECS;
 using Yaeger.Graphics;
+using Yaeger.Systems;
 
 namespace Pong.Systems;
 

--- a/Samples/Pong/Systems/PrintScoreSystem.cs
+++ b/Samples/Pong/Systems/PrintScoreSystem.cs
@@ -1,6 +1,7 @@
 using Pong.Components;
 using Yaeger.ECS;
 using Yaeger.Graphics;
+using Yaeger.Systems;
 
 namespace Pong.Systems;
 

--- a/Samples/Pong/Systems/ResetBallSystem.cs
+++ b/Samples/Pong/Systems/ResetBallSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Pong.Components;
 using Yaeger.ECS;
 using Yaeger.Graphics;
+using Yaeger.Systems;
 
 namespace Pong.Systems;
 

--- a/Samples/Pong/Systems/ScoringSystem.cs
+++ b/Samples/Pong/Systems/ScoringSystem.cs
@@ -1,6 +1,7 @@
 using Pong.Components;
 using Yaeger.ECS;
 using Yaeger.Graphics;
+using Yaeger.Systems;
 
 namespace Pong.Systems;
 

--- a/specs/physics-engine.md
+++ b/specs/physics-engine.md
@@ -1,0 +1,62 @@
+# Physics Engine Spec
+
+A custom, lightweight 2D physics engine for the Yaeger game engine (Yet Another Experimental Game Engine Repository). The engine integrates with the existing ECS architecture and is designed with future 3D extensibility in mind.
+
+## Design Principles
+
+- **Custom implementation** rather than integrating an external library — the engine is 2D, experimental, and ECS-based, making a custom solution the best fit.
+- **Dimensionality-agnostic types** where possible (e.g., `PhysicsMaterial`, `BodyType`) so they can be reused when 3D support is added later.
+- **ECS conventions** — components as `struct` (enforced by ECS), systems as classes taking `World` via primary constructor.
+- **Math** — `System.Numerics` for vectors and math operations.
+- **Testing** — xUnit with Arrange/Act/Assert pattern.
+
+## Phases
+
+### Phase 1: 2D Basics (Complete)
+
+Core 2D physics with brute-force collision detection.
+
+**Components:**
+
+- `RigidBody2D` — Mass, inverse mass, body type, linear drag. Factory methods for Dynamic/Static/Kinematic creation. Validates mass > 0 for dynamic bodies and linearDrag >= 0.
+- `Velocity2D` — Linear velocity (Vector2) and angular velocity (float).
+- `BoxCollider2D` — Axis-aligned box defined by size and offset. Validates width/height > 0.
+- `CircleCollider2D` — Circle defined by radius and offset. Validates radius > 0.
+- `PhysicsMaterial` — Restitution (bounciness, clamped to [0,1]) and friction (>= 0). Default: restitution 0.3, friction 0.4.
+- `BodyType` — Enum: Dynamic, Static, Kinematic. Dimensionality-agnostic.
+
+**Systems:**
+
+- `GravitySystem` — Applies gravity to dynamic bodies. Iterates `RigidBody2D` store, writes `Velocity2D`.
+- `MovementSystem` — Integrates velocity into position (semi-implicit Euler). Applies linear drag with clamped factor. Iterates `RigidBody2D` store, writes `Transform2D` and `Velocity2D`.
+- `CollisionDetectionSystem` — Brute-force O(n^2) narrowphase. Supports Box-Box (AABB), Circle-Circle, and Box-Circle pairs. Reuses entity lists across frames to avoid per-frame allocations.
+- `CollisionResolutionSystem` — Impulse-based resolution with Coulomb friction and positional correction (Baumgarte stabilization). Falls back to `PhysicsMaterial.Default` when component is missing.
+
+**Facade:**
+
+- `PhysicsWorld2D` — Orchestrates all systems in order: Gravity -> Movement -> Detection -> Resolution. Exposes collision events with thread-safe invocation.
+- `CollisionManifold` — Contact data struct: entity pair, normal (unit vector), penetration depth, contact point.
+
+### Phase 2: Broadphase Spatial Partitioning (Future)
+
+Replace the O(n^2) brute-force broadphase with spatial data structures to improve performance for scenes with many entities.
+
+- Uniform grid spatial partitioning
+- QuadTree for non-uniform entity distributions
+- Broadphase/narrowphase separation — broadphase produces candidate pairs, narrowphase confirms collisions
+
+### Phase 3: 3D Foundation (Future)
+
+Extend the physics engine to support 3D simulations, reusing dimensionality-agnostic types from Phase 1.
+
+- `RigidBody3D` — 3D rigid body component (reuses `BodyType`, `PhysicsMaterial`)
+- `BoxCollider3D` — Axis-aligned bounding box in 3D
+- `SphereCollider3D` — Sphere collider
+- Octree for 3D spatial partitioning
+- GJK and/or SAT algorithms for convex collision detection
+
+### Phase 4: Advanced Features (Future)
+
+- Joints and constraints (distance, hinge, spring)
+- Continuous collision detection (CCD) to prevent tunneling at high velocities
+- Collision layers and masks for filtering

--- a/src/Engine/Yaeger/Physics/CollisionManifold.cs
+++ b/src/Engine/Yaeger/Physics/CollisionManifold.cs
@@ -20,6 +20,7 @@ public struct CollisionManifold
 
     /// <summary>
     /// The collision normal pointing from entity A towards entity B.
+    /// Must be a unit vector (length 1). Collision resolution depends on this invariant.
     /// </summary>
     public Vector2 Normal;
 

--- a/src/Engine/Yaeger/Physics/CollisionManifold.cs
+++ b/src/Engine/Yaeger/Physics/CollisionManifold.cs
@@ -1,0 +1,35 @@
+using System.Numerics;
+using Yaeger.ECS;
+
+namespace Yaeger.Physics;
+
+/// <summary>
+/// Contains the contact information from a collision between two entities.
+/// </summary>
+public struct CollisionManifold
+{
+    /// <summary>
+    /// The first entity involved in the collision.
+    /// </summary>
+    public Entity EntityA;
+
+    /// <summary>
+    /// The second entity involved in the collision.
+    /// </summary>
+    public Entity EntityB;
+
+    /// <summary>
+    /// The collision normal pointing from entity A towards entity B.
+    /// </summary>
+    public Vector2 Normal;
+
+    /// <summary>
+    /// How far the two colliders are overlapping.
+    /// </summary>
+    public float PenetrationDepth;
+
+    /// <summary>
+    /// The point of contact between the two colliders.
+    /// </summary>
+    public Vector2 ContactPoint;
+}

--- a/src/Engine/Yaeger/Physics/Components/BodyType.cs
+++ b/src/Engine/Yaeger/Physics/Components/BodyType.cs
@@ -1,0 +1,26 @@
+namespace Yaeger.Physics.Components;
+
+/// <summary>
+/// Defines how a rigid body behaves in the physics simulation.
+/// This enum is dimensionality-agnostic and can be reused for both 2D and 3D physics.
+/// </summary>
+public enum BodyType : byte
+{
+    /// <summary>
+    /// Fully simulated body. Affected by forces, gravity, and collisions.
+    /// </summary>
+    Dynamic,
+
+    /// <summary>
+    /// Immovable body. Not affected by forces or collisions, but other bodies collide with it.
+    /// Useful for walls, floors, and platforms.
+    /// </summary>
+    Static,
+
+    /// <summary>
+    /// Moved manually (e.g. by code or animation). Not affected by forces,
+    /// but pushes dynamic bodies during collisions.
+    /// Useful for moving platforms or elevators.
+    /// </summary>
+    Kinematic,
+}

--- a/src/Engine/Yaeger/Physics/Components/BoxCollider2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/BoxCollider2D.cs
@@ -21,8 +21,18 @@ public struct BoxCollider2D
     /// <summary>
     /// Creates a box collider with the specified size and optional offset.
     /// </summary>
+    /// <param name="size">Full width and height. Both components must be greater than zero.</param>
+    /// <param name="offset">Offset from the entity's position. Defaults to zero.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when size has non-positive components.</exception>
     public BoxCollider2D(Vector2 size, Vector2? offset = null)
     {
+        if (size.X <= 0 || size.Y <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(size),
+                size,
+                "Size components must be greater than zero."
+            );
+
         Size = size;
         Offset = offset ?? Vector2.Zero;
     }
@@ -30,8 +40,24 @@ public struct BoxCollider2D
     /// <summary>
     /// Creates a box collider with the specified width and height.
     /// </summary>
+    /// <param name="width">Width of the box. Must be greater than zero.</param>
+    /// <param name="height">Height of the box. Must be greater than zero.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when width or height is less than or equal to zero.</exception>
     public BoxCollider2D(float width, float height)
     {
+        if (width <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(width),
+                width,
+                "Width must be greater than zero."
+            );
+        if (height <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(height),
+                height,
+                "Height must be greater than zero."
+            );
+
         Size = new Vector2(width, height);
         Offset = Vector2.Zero;
     }

--- a/src/Engine/Yaeger/Physics/Components/BoxCollider2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/BoxCollider2D.cs
@@ -1,0 +1,43 @@
+using System.Numerics;
+
+namespace Yaeger.Physics.Components;
+
+/// <summary>
+/// Axis-aligned box collider for 2D physics.
+/// The box is centered on the entity's Transform2D.Position, offset by <see cref="Offset"/>.
+/// </summary>
+public struct BoxCollider2D
+{
+    /// <summary>
+    /// Full width and height of the box.
+    /// </summary>
+    public Vector2 Size;
+
+    /// <summary>
+    /// Offset from the entity's position to the center of the collider.
+    /// </summary>
+    public Vector2 Offset;
+
+    /// <summary>
+    /// Creates a box collider with the specified size and optional offset.
+    /// </summary>
+    public BoxCollider2D(Vector2 size, Vector2? offset = null)
+    {
+        Size = size;
+        Offset = offset ?? Vector2.Zero;
+    }
+
+    /// <summary>
+    /// Creates a box collider with the specified width and height.
+    /// </summary>
+    public BoxCollider2D(float width, float height)
+    {
+        Size = new Vector2(width, height);
+        Offset = Vector2.Zero;
+    }
+
+    /// <summary>
+    /// Half of the size, useful for AABB calculations.
+    /// </summary>
+    public readonly Vector2 HalfSize => Size / 2.0f;
+}

--- a/src/Engine/Yaeger/Physics/Components/CircleCollider2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/CircleCollider2D.cs
@@ -1,0 +1,29 @@
+using System.Numerics;
+
+namespace Yaeger.Physics.Components;
+
+/// <summary>
+/// Circle collider for 2D physics.
+/// The circle is centered on the entity's Transform2D.Position, offset by <see cref="Offset"/>.
+/// </summary>
+public struct CircleCollider2D
+{
+    /// <summary>
+    /// Radius of the circle.
+    /// </summary>
+    public float Radius;
+
+    /// <summary>
+    /// Offset from the entity's position to the center of the collider.
+    /// </summary>
+    public Vector2 Offset;
+
+    /// <summary>
+    /// Creates a circle collider with the specified radius and optional offset.
+    /// </summary>
+    public CircleCollider2D(float radius, Vector2? offset = null)
+    {
+        Radius = radius;
+        Offset = offset ?? Vector2.Zero;
+    }
+}

--- a/src/Engine/Yaeger/Physics/Components/CircleCollider2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/CircleCollider2D.cs
@@ -21,8 +21,18 @@ public struct CircleCollider2D
     /// <summary>
     /// Creates a circle collider with the specified radius and optional offset.
     /// </summary>
+    /// <param name="radius">Radius of the circle. Must be greater than zero.</param>
+    /// <param name="offset">Offset from the entity's position. Defaults to zero.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when radius is less than or equal to zero.</exception>
     public CircleCollider2D(float radius, Vector2? offset = null)
     {
+        if (radius <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(radius),
+                radius,
+                "Radius must be greater than zero."
+            );
+
         Radius = radius;
         Offset = offset ?? Vector2.Zero;
     }

--- a/src/Engine/Yaeger/Physics/Components/PhysicsMaterial.cs
+++ b/src/Engine/Yaeger/Physics/Components/PhysicsMaterial.cs
@@ -1,0 +1,42 @@
+namespace Yaeger.Physics.Components;
+
+/// <summary>
+/// Defines the physical surface properties of a body.
+/// This component is dimensionality-agnostic and can be reused for both 2D and 3D physics.
+/// </summary>
+public struct PhysicsMaterial
+{
+    /// <summary>
+    /// Bounciness of the surface. 0.0 = no bounce, 1.0 = perfectly elastic.
+    /// </summary>
+    public float Restitution;
+
+    /// <summary>
+    /// Friction coefficient. 0.0 = frictionless, higher values = more friction.
+    /// </summary>
+    public float Friction;
+
+    /// <summary>
+    /// Creates a new physics material with the specified properties.
+    /// </summary>
+    public PhysicsMaterial(float restitution, float friction)
+    {
+        Restitution = restitution;
+        Friction = friction;
+    }
+
+    /// <summary>
+    /// Default material with moderate bounce and friction.
+    /// </summary>
+    public static PhysicsMaterial Default => new(0.3f, 0.4f);
+
+    /// <summary>
+    /// Perfectly bouncy material with no friction.
+    /// </summary>
+    public static PhysicsMaterial Bouncy => new(1.0f, 0.0f);
+
+    /// <summary>
+    /// No bounce, high friction. Useful for floors and walls.
+    /// </summary>
+    public static PhysicsMaterial Sticky => new(0.0f, 1.0f);
+}

--- a/src/Engine/Yaeger/Physics/Components/PhysicsMaterial.cs
+++ b/src/Engine/Yaeger/Physics/Components/PhysicsMaterial.cs
@@ -19,8 +19,25 @@ public struct PhysicsMaterial
     /// <summary>
     /// Creates a new physics material with the specified properties.
     /// </summary>
+    /// <param name="restitution">Bounciness. Must be in range [0, 1].</param>
+    /// <param name="friction">Friction coefficient. Must be non-negative.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when restitution is outside [0, 1] or friction is negative.</exception>
     public PhysicsMaterial(float restitution, float friction)
     {
+        if (restitution < 0.0f || restitution > 1.0f)
+            throw new ArgumentOutOfRangeException(
+                nameof(restitution),
+                restitution,
+                "Restitution must be between 0 and 1."
+            );
+
+        if (friction < 0.0f)
+            throw new ArgumentOutOfRangeException(
+                nameof(friction),
+                friction,
+                "Friction must be non-negative."
+            );
+
         Restitution = restitution;
         Friction = friction;
     }

--- a/src/Engine/Yaeger/Physics/Components/RigidBody2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/RigidBody2D.cs
@@ -12,6 +12,7 @@ public struct RigidBody2D
 
     /// <summary>
     /// Precomputed inverse mass (1 / Mass). Zero for static and kinematic bodies.
+    /// For dynamic bodies, this is always positive since mass must be &gt; 0.
     /// </summary>
     public float InverseMass;
 
@@ -35,16 +36,27 @@ public struct RigidBody2D
     /// <summary>
     /// Creates a dynamic rigid body with the specified mass.
     /// </summary>
+    /// <param name="mass">Mass in kilograms. Must be greater than zero.</param>
+    /// <param name="gravityScale">Multiplier for gravity. Default is 1.0.</param>
+    /// <param name="linearDrag">Linear drag coefficient. Default is 0.0 (no drag).</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when mass is less than or equal to zero.</exception>
     public static RigidBody2D CreateDynamic(
         float mass,
         float gravityScale = 1.0f,
         float linearDrag = 0.0f
     )
     {
+        if (mass <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(mass),
+                mass,
+                "Mass must be greater than zero for dynamic bodies."
+            );
+
         return new RigidBody2D
         {
             Mass = mass,
-            InverseMass = mass > 0 ? 1.0f / mass : 0.0f,
+            InverseMass = 1.0f / mass,
             GravityScale = gravityScale,
             LinearDrag = linearDrag,
             Type = BodyType.Dynamic,

--- a/src/Engine/Yaeger/Physics/Components/RigidBody2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/RigidBody2D.cs
@@ -8,13 +8,13 @@ public struct RigidBody2D
     /// <summary>
     /// Mass of the body in kilograms. Must be positive for dynamic bodies.
     /// </summary>
-    public float Mass;
+    public float Mass { get; init; }
 
     /// <summary>
     /// Precomputed inverse mass (1 / Mass). Zero for static and kinematic bodies.
     /// For dynamic bodies, this is always positive since mass must be &gt; 0.
     /// </summary>
-    public float InverseMass;
+    public float InverseMass { get; init; }
 
     /// <summary>
     /// Multiplier for gravity applied to this body. Default is 1.0.

--- a/src/Engine/Yaeger/Physics/Components/RigidBody2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/RigidBody2D.cs
@@ -38,8 +38,8 @@ public struct RigidBody2D
     /// </summary>
     /// <param name="mass">Mass in kilograms. Must be greater than zero.</param>
     /// <param name="gravityScale">Multiplier for gravity. Default is 1.0.</param>
-    /// <param name="linearDrag">Linear drag coefficient. Default is 0.0 (no drag).</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when mass is less than or equal to zero.</exception>
+    /// <param name="linearDrag">Linear drag coefficient. Must be non-negative. Default is 0.0 (no drag).</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when mass is less than or equal to zero, or linearDrag is negative.</exception>
     public static RigidBody2D CreateDynamic(
         float mass,
         float gravityScale = 1.0f,
@@ -51,6 +51,13 @@ public struct RigidBody2D
                 nameof(mass),
                 mass,
                 "Mass must be greater than zero for dynamic bodies."
+            );
+
+        if (linearDrag < 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(linearDrag),
+                linearDrag,
+                "Linear drag must be non-negative."
             );
 
         return new RigidBody2D

--- a/src/Engine/Yaeger/Physics/Components/RigidBody2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/RigidBody2D.cs
@@ -1,0 +1,83 @@
+namespace Yaeger.Physics.Components;
+
+/// <summary>
+/// Defines the physical properties of a 2D rigid body.
+/// </summary>
+public struct RigidBody2D
+{
+    /// <summary>
+    /// Mass of the body in kilograms. Must be positive for dynamic bodies.
+    /// </summary>
+    public float Mass;
+
+    /// <summary>
+    /// Precomputed inverse mass (1 / Mass). Zero for static and kinematic bodies.
+    /// </summary>
+    public float InverseMass;
+
+    /// <summary>
+    /// Multiplier for gravity applied to this body. Default is 1.0.
+    /// Set to 0.0 to disable gravity for this body.
+    /// </summary>
+    public float GravityScale;
+
+    /// <summary>
+    /// Linear drag coefficient. Reduces velocity over time to simulate air resistance.
+    /// 0.0 = no drag. Higher values = more resistance.
+    /// </summary>
+    public float LinearDrag;
+
+    /// <summary>
+    /// Determines how the body behaves in the simulation.
+    /// </summary>
+    public BodyType Type;
+
+    /// <summary>
+    /// Creates a dynamic rigid body with the specified mass.
+    /// </summary>
+    public static RigidBody2D CreateDynamic(
+        float mass,
+        float gravityScale = 1.0f,
+        float linearDrag = 0.0f
+    )
+    {
+        return new RigidBody2D
+        {
+            Mass = mass,
+            InverseMass = mass > 0 ? 1.0f / mass : 0.0f,
+            GravityScale = gravityScale,
+            LinearDrag = linearDrag,
+            Type = BodyType.Dynamic,
+        };
+    }
+
+    /// <summary>
+    /// Creates a static rigid body (infinite mass, immovable).
+    /// </summary>
+    public static RigidBody2D CreateStatic()
+    {
+        return new RigidBody2D
+        {
+            Mass = 0.0f,
+            InverseMass = 0.0f,
+            GravityScale = 0.0f,
+            LinearDrag = 0.0f,
+            Type = BodyType.Static,
+        };
+    }
+
+    /// <summary>
+    /// Creates a kinematic rigid body (moved manually, pushes dynamic bodies).
+    /// </summary>
+    public static RigidBody2D CreateKinematic()
+    {
+        return new RigidBody2D
+        {
+            Mass = 0.0f,
+            InverseMass = 0.0f,
+            GravityScale = 0.0f,
+            LinearDrag = 0.0f,
+            Type = BodyType.Kinematic,
+        };
+    }
+}

--- a/src/Engine/Yaeger/Physics/Components/Velocity2D.cs
+++ b/src/Engine/Yaeger/Physics/Components/Velocity2D.cs
@@ -1,0 +1,42 @@
+using System.Numerics;
+
+namespace Yaeger.Physics.Components;
+
+/// <summary>
+/// Represents the velocity of a 2D physics body.
+/// </summary>
+public struct Velocity2D
+{
+    /// <summary>
+    /// Linear velocity in units per second.
+    /// </summary>
+    public Vector2 Linear;
+
+    /// <summary>
+    /// Angular velocity in radians per second.
+    /// </summary>
+    public float Angular;
+
+    /// <summary>
+    /// Creates a velocity with the specified linear and angular components.
+    /// </summary>
+    public Velocity2D(Vector2 linear, float angular = 0.0f)
+    {
+        Linear = linear;
+        Angular = angular;
+    }
+
+    /// <summary>
+    /// Creates a velocity with only linear motion.
+    /// </summary>
+    public Velocity2D(float x, float y)
+    {
+        Linear = new Vector2(x, y);
+        Angular = 0.0f;
+    }
+
+    /// <summary>
+    /// Zero velocity.
+    /// </summary>
+    public static Velocity2D Zero => new(Vector2.Zero);
+}

--- a/src/Engine/Yaeger/Physics/PhysicsWorld2D.cs
+++ b/src/Engine/Yaeger/Physics/PhysicsWorld2D.cs
@@ -1,0 +1,78 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Physics.Systems;
+using Yaeger.Systems;
+
+namespace Yaeger.Physics;
+
+/// <summary>
+/// Facade that orchestrates all 2D physics systems in the correct order.
+/// Provides a simple interface for stepping the physics simulation.
+/// </summary>
+public class PhysicsWorld2D : IUpdateSystem
+{
+    private readonly GravitySystem _gravitySystem;
+    private readonly MovementSystem _movementSystem;
+    private readonly CollisionDetectionSystem _collisionDetectionSystem;
+    private readonly CollisionResolutionSystem _collisionResolutionSystem;
+
+    /// <summary>
+    /// The global gravity vector. Default is (0, -9.81).
+    /// </summary>
+    public Vector2 Gravity
+    {
+        get => _gravitySystem.Gravity;
+        set => _gravitySystem.Gravity = value;
+    }
+
+    /// <summary>
+    /// Fired for each collision detected during a step.
+    /// </summary>
+    public event Action<CollisionManifold>? OnCollision;
+
+    /// <summary>
+    /// The collision manifolds from the last physics step.
+    /// </summary>
+    public IReadOnlyList<CollisionManifold> Manifolds => _collisionDetectionSystem.Manifolds;
+
+    /// <summary>
+    /// Creates a new 2D physics world with the specified gravity.
+    /// </summary>
+    public PhysicsWorld2D(World world, Vector2? gravity = null)
+    {
+        var g = gravity ?? new Vector2(0, -9.81f);
+        _gravitySystem = new GravitySystem(world, g);
+        _movementSystem = new MovementSystem(world);
+        _collisionDetectionSystem = new CollisionDetectionSystem(world);
+        _collisionResolutionSystem = new CollisionResolutionSystem(world);
+    }
+
+    /// <summary>
+    /// Steps the physics simulation forward by deltaTime seconds.
+    /// Executes: Gravity -> Movement -> Collision Detection -> Collision Resolution.
+    /// </summary>
+    /// <param name="deltaTime">The time elapsed since the last step, in seconds.</param>
+    public void Update(float deltaTime)
+    {
+        // 1. Apply gravity to dynamic bodies
+        _gravitySystem.Update(deltaTime);
+
+        // 2. Integrate velocity into position
+        _movementSystem.Update(deltaTime);
+
+        // 3. Detect collisions
+        _collisionDetectionSystem.Detect();
+
+        // 4. Resolve collisions
+        _collisionResolutionSystem.Resolve(_collisionDetectionSystem.Manifolds);
+
+        // 5. Fire collision events
+        if (OnCollision is not null)
+        {
+            foreach (var manifold in _collisionDetectionSystem.Manifolds)
+            {
+                OnCollision.Invoke(manifold);
+            }
+        }
+    }
+}

--- a/src/Engine/Yaeger/Physics/PhysicsWorld2D.cs
+++ b/src/Engine/Yaeger/Physics/PhysicsWorld2D.cs
@@ -67,11 +67,12 @@ public class PhysicsWorld2D : IUpdateSystem
         _collisionResolutionSystem.Resolve(_collisionDetectionSystem.Manifolds);
 
         // 5. Fire collision events
-        if (OnCollision is not null)
+        var handler = OnCollision;
+        if (handler is not null)
         {
             foreach (var manifold in _collisionDetectionSystem.Manifolds)
             {
-                OnCollision.Invoke(manifold);
+                handler(manifold);
             }
         }
     }

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -13,6 +13,8 @@ namespace Yaeger.Physics.Systems;
 public class CollisionDetectionSystem(World world)
 {
     private readonly List<CollisionManifold> _manifolds = [];
+    private readonly List<(Entity Entity, Vector2 Center, BoxCollider2D Collider)> _boxEntities = [];
+    private readonly List<(Entity Entity, Vector2 Center, CircleCollider2D Collider)> _circleEntities = [];
 
     /// <summary>
     /// The collision manifolds detected in the last call to <see cref="Detect"/>.
@@ -27,8 +29,8 @@ public class CollisionDetectionSystem(World world)
         _manifolds.Clear();
 
         // Collect all collidable entities with their world positions
-        var boxEntities = new List<(Entity Entity, Vector2 Center, BoxCollider2D Collider)>();
-        var circleEntities = new List<(Entity Entity, Vector2 Center, CircleCollider2D Collider)>();
+        _boxEntities.Clear();
+        _circleEntities.Clear();
 
         foreach (
             (Entity entity, Transform2D transform, BoxCollider2D collider) in world.Query<
@@ -38,7 +40,7 @@ public class CollisionDetectionSystem(World world)
         )
         {
             var center = transform.Position + collider.Offset;
-            boxEntities.Add((entity, center, collider));
+            _boxEntities.Add((entity, center, collider));
         }
 
         foreach (
@@ -49,15 +51,15 @@ public class CollisionDetectionSystem(World world)
         )
         {
             var center = transform.Position + collider.Offset;
-            circleEntities.Add((entity, center, collider));
+            _circleEntities.Add((entity, center, collider));
         }
 
         // Box vs Box
-        for (var i = 0; i < boxEntities.Count; i++)
+        for (var i = 0; i < _boxEntities.Count; i++)
         {
-            for (var j = i + 1; j < boxEntities.Count; j++)
+            for (var j = i + 1; j < _boxEntities.Count; j++)
             {
-                if (TestBoxBox(boxEntities[i], boxEntities[j], out var manifold))
+                if (TestBoxBox(_boxEntities[i], _boxEntities[j], out var manifold))
                 {
                     _manifolds.Add(manifold);
                 }
@@ -65,11 +67,11 @@ public class CollisionDetectionSystem(World world)
         }
 
         // Circle vs Circle
-        for (var i = 0; i < circleEntities.Count; i++)
+        for (var i = 0; i < _circleEntities.Count; i++)
         {
-            for (var j = i + 1; j < circleEntities.Count; j++)
+            for (var j = i + 1; j < _circleEntities.Count; j++)
             {
-                if (TestCircleCircle(circleEntities[i], circleEntities[j], out var manifold))
+                if (TestCircleCircle(_circleEntities[i], _circleEntities[j], out var manifold))
                 {
                     _manifolds.Add(manifold);
                 }
@@ -77,15 +79,15 @@ public class CollisionDetectionSystem(World world)
         }
 
         // Box vs Circle
-        for (var i = 0; i < boxEntities.Count; i++)
+        for (var i = 0; i < _boxEntities.Count; i++)
         {
-            for (var j = 0; j < circleEntities.Count; j++)
+            for (var j = 0; j < _circleEntities.Count; j++)
             {
                 // Skip self-collision (entity has both BoxCollider2D and CircleCollider2D)
-                if (boxEntities[i].Entity == circleEntities[j].Entity)
+                if (_boxEntities[i].Entity == _circleEntities[j].Entity)
                     continue;
 
-                if (TestBoxCircle(boxEntities[i], circleEntities[j], out var manifold))
+                if (TestBoxCircle(_boxEntities[i], _circleEntities[j], out var manifold))
                 {
                     _manifolds.Add(manifold);
                 }

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -13,8 +13,13 @@ namespace Yaeger.Physics.Systems;
 public class CollisionDetectionSystem(World world)
 {
     private readonly List<CollisionManifold> _manifolds = [];
-    private readonly List<(Entity Entity, Vector2 Center, BoxCollider2D Collider)> _boxEntities = [];
-    private readonly List<(Entity Entity, Vector2 Center, CircleCollider2D Collider)> _circleEntities = [];
+    private readonly List<(Entity Entity, Vector2 Center, BoxCollider2D Collider)> _boxEntities =
+    [];
+    private readonly List<(
+        Entity Entity,
+        Vector2 Center,
+        CircleCollider2D Collider
+    )> _circleEntities = [];
 
     /// <summary>
     /// The collision manifolds detected in the last call to <see cref="Detect"/>.

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -1,0 +1,247 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics.Components;
+
+namespace Yaeger.Physics.Systems;
+
+/// <summary>
+/// Detects collisions between entities using narrowphase checks.
+/// Supports Box-Box (AABB), Circle-Circle, and Box-Circle collision pairs.
+/// Phase 1 uses brute-force broadphase (O(n^2)).
+/// </summary>
+public class CollisionDetectionSystem(World world)
+{
+    private readonly List<CollisionManifold> _manifolds = [];
+
+    /// <summary>
+    /// The collision manifolds detected in the last call to <see cref="Detect"/>.
+    /// </summary>
+    public IReadOnlyList<CollisionManifold> Manifolds => _manifolds;
+
+    /// <summary>
+    /// Runs collision detection for all collidable entities.
+    /// </summary>
+    public void Detect()
+    {
+        _manifolds.Clear();
+
+        // Collect all collidable entities with their world positions
+        var boxEntities = new List<(Entity Entity, Vector2 Center, BoxCollider2D Collider)>();
+        var circleEntities = new List<(Entity Entity, Vector2 Center, CircleCollider2D Collider)>();
+
+        foreach (
+            (Entity entity, Transform2D transform, BoxCollider2D collider) in world.Query<
+                Transform2D,
+                BoxCollider2D
+            >()
+        )
+        {
+            var center = transform.Position + collider.Offset;
+            boxEntities.Add((entity, center, collider));
+        }
+
+        foreach (
+            (Entity entity, Transform2D transform, CircleCollider2D collider) in world.Query<
+                Transform2D,
+                CircleCollider2D
+            >()
+        )
+        {
+            var center = transform.Position + collider.Offset;
+            circleEntities.Add((entity, center, collider));
+        }
+
+        // Box vs Box
+        for (var i = 0; i < boxEntities.Count; i++)
+        {
+            for (var j = i + 1; j < boxEntities.Count; j++)
+            {
+                if (TestBoxBox(boxEntities[i], boxEntities[j], out var manifold))
+                {
+                    _manifolds.Add(manifold);
+                }
+            }
+        }
+
+        // Circle vs Circle
+        for (var i = 0; i < circleEntities.Count; i++)
+        {
+            for (var j = i + 1; j < circleEntities.Count; j++)
+            {
+                if (TestCircleCircle(circleEntities[i], circleEntities[j], out var manifold))
+                {
+                    _manifolds.Add(manifold);
+                }
+            }
+        }
+
+        // Box vs Circle
+        for (var i = 0; i < boxEntities.Count; i++)
+        {
+            for (var j = 0; j < circleEntities.Count; j++)
+            {
+                if (TestBoxCircle(boxEntities[i], circleEntities[j], out var manifold))
+                {
+                    _manifolds.Add(manifold);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Tests AABB overlap between two box colliders.
+    /// </summary>
+    internal static bool TestBoxBox(
+        (Entity Entity, Vector2 Center, BoxCollider2D Collider) a,
+        (Entity Entity, Vector2 Center, BoxCollider2D Collider) b,
+        out CollisionManifold manifold
+    )
+    {
+        manifold = default;
+
+        var halfA = a.Collider.HalfSize;
+        var halfB = b.Collider.HalfSize;
+        var delta = b.Center - a.Center;
+
+        var overlapX = halfA.X + halfB.X - MathF.Abs(delta.X);
+        var overlapY = halfA.Y + halfB.Y - MathF.Abs(delta.Y);
+
+        if (overlapX <= 0 || overlapY <= 0)
+            return false;
+
+        // Use the axis of minimum penetration
+        if (overlapX < overlapY)
+        {
+            var normalX = delta.X < 0 ? -1.0f : 1.0f;
+            manifold = new CollisionManifold
+            {
+                EntityA = a.Entity,
+                EntityB = b.Entity,
+                Normal = new Vector2(normalX, 0),
+                PenetrationDepth = overlapX,
+                ContactPoint = new Vector2(
+                    a.Center.X + halfA.X * normalX,
+                    (a.Center.Y + b.Center.Y) / 2.0f
+                ),
+            };
+        }
+        else
+        {
+            var normalY = delta.Y < 0 ? -1.0f : 1.0f;
+            manifold = new CollisionManifold
+            {
+                EntityA = a.Entity,
+                EntityB = b.Entity,
+                Normal = new Vector2(0, normalY),
+                PenetrationDepth = overlapY,
+                ContactPoint = new Vector2(
+                    (a.Center.X + b.Center.X) / 2.0f,
+                    a.Center.Y + halfA.Y * normalY
+                ),
+            };
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Tests overlap between two circle colliders.
+    /// </summary>
+    internal static bool TestCircleCircle(
+        (Entity Entity, Vector2 Center, CircleCollider2D Collider) a,
+        (Entity Entity, Vector2 Center, CircleCollider2D Collider) b,
+        out CollisionManifold manifold
+    )
+    {
+        manifold = default;
+
+        var delta = b.Center - a.Center;
+        var distanceSq = delta.LengthSquared();
+        var radiusSum = a.Collider.Radius + b.Collider.Radius;
+
+        if (distanceSq >= radiusSum * radiusSum)
+            return false;
+
+        var distance = MathF.Sqrt(distanceSq);
+        var normal = distance > 0 ? delta / distance : Vector2.UnitX;
+
+        manifold = new CollisionManifold
+        {
+            EntityA = a.Entity,
+            EntityB = b.Entity,
+            Normal = normal,
+            PenetrationDepth = radiusSum - distance,
+            ContactPoint = a.Center + normal * a.Collider.Radius,
+        };
+
+        return true;
+    }
+
+    /// <summary>
+    /// Tests overlap between a box collider and a circle collider.
+    /// </summary>
+    internal static bool TestBoxCircle(
+        (Entity Entity, Vector2 Center, BoxCollider2D Collider) box,
+        (Entity Entity, Vector2 Center, CircleCollider2D Collider) circle,
+        out CollisionManifold manifold
+    )
+    {
+        manifold = default;
+
+        var halfSize = box.Collider.HalfSize;
+
+        // Find the closest point on the AABB to the circle center
+        var closest = new Vector2(
+            Math.Clamp(circle.Center.X, box.Center.X - halfSize.X, box.Center.X + halfSize.X),
+            Math.Clamp(circle.Center.Y, box.Center.Y - halfSize.Y, box.Center.Y + halfSize.Y)
+        );
+
+        var delta = circle.Center - closest;
+        var distanceSq = delta.LengthSquared();
+
+        if (distanceSq >= circle.Collider.Radius * circle.Collider.Radius)
+            return false;
+
+        var distance = MathF.Sqrt(distanceSq);
+
+        // Handle the case where the circle center is inside the box
+        Vector2 normal;
+        float penetration;
+
+        if (distance > 0)
+        {
+            normal = delta / distance;
+            penetration = circle.Collider.Radius - distance;
+        }
+        else
+        {
+            // Circle center is inside the box — find the shortest axis to push out
+            var dx = halfSize.X - MathF.Abs(circle.Center.X - box.Center.X);
+            var dy = halfSize.Y - MathF.Abs(circle.Center.Y - box.Center.Y);
+
+            if (dx < dy)
+            {
+                normal = new Vector2(circle.Center.X < box.Center.X ? -1.0f : 1.0f, 0);
+                penetration = dx + circle.Collider.Radius;
+            }
+            else
+            {
+                normal = new Vector2(0, circle.Center.Y < box.Center.Y ? -1.0f : 1.0f);
+                penetration = dy + circle.Collider.Radius;
+            }
+        }
+
+        // Normal points from box (A) towards circle (B)
+        manifold = new CollisionManifold
+        {
+            EntityA = box.Entity,
+            EntityB = circle.Entity,
+            Normal = normal,
+            PenetrationDepth = penetration,
+            ContactPoint = closest,
+        };
+
+        return true;
+    }
+}

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -212,11 +212,13 @@ public class CollisionDetectionSystem(World world)
         // Handle the case where the circle center is inside the box
         Vector2 normal;
         float penetration;
+        Vector2 contactPoint;
 
         if (distance > 0)
         {
             normal = delta / distance;
             penetration = circle.Collider.Radius - distance;
+            contactPoint = closest;
         }
         else
         {
@@ -228,11 +230,15 @@ public class CollisionDetectionSystem(World world)
             {
                 normal = new Vector2(circle.Center.X < box.Center.X ? -1.0f : 1.0f, 0);
                 penetration = dx + circle.Collider.Radius;
+                // Contact point on the box face along the normal
+                contactPoint = new Vector2(box.Center.X + halfSize.X * normal.X, circle.Center.Y);
             }
             else
             {
                 normal = new Vector2(0, circle.Center.Y < box.Center.Y ? -1.0f : 1.0f);
                 penetration = dy + circle.Collider.Radius;
+                // Contact point on the box face along the normal
+                contactPoint = new Vector2(circle.Center.X, box.Center.Y + halfSize.Y * normal.Y);
             }
         }
 
@@ -243,7 +249,7 @@ public class CollisionDetectionSystem(World world)
             EntityB = circle.Entity,
             Normal = normal,
             PenetrationDepth = penetration,
-            ContactPoint = closest,
+            ContactPoint = contactPoint,
         };
 
         return true;

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -27,11 +27,10 @@ public class CollisionDetectionSystem(World world)
     public void Detect()
     {
         _manifolds.Clear();
-
-        // Collect all collidable entities with their world positions
         _boxEntities.Clear();
         _circleEntities.Clear();
 
+        // Collect all collidable entities with their world positions
         foreach (
             (Entity entity, Transform2D transform, BoxCollider2D collider) in world.Query<
                 Transform2D,

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -81,6 +81,10 @@ public class CollisionDetectionSystem(World world)
         {
             for (var j = 0; j < circleEntities.Count; j++)
             {
+                // Skip self-collision (entity has both BoxCollider2D and CircleCollider2D)
+                if (boxEntities[i].Entity == circleEntities[j].Entity)
+                    continue;
+
                 if (TestBoxCircle(boxEntities[i], circleEntities[j], out var manifold))
                 {
                     _manifolds.Add(manifold);

--- a/src/Engine/Yaeger/Physics/Systems/CollisionResolutionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionResolutionSystem.cs
@@ -34,6 +34,13 @@ public class CollisionResolutionSystem(World world)
 
     private void ResolveManifold(CollisionManifold manifold)
     {
+        // Ensure Normal is a unit vector; skip degenerate manifolds
+        var normalLenSq = manifold.Normal.LengthSquared();
+        if (normalLenSq < 1e-10f)
+            return;
+        if (MathF.Abs(normalLenSq - 1.0f) > 1e-4f)
+            manifold.Normal = manifold.Normal / MathF.Sqrt(normalLenSq);
+
         var hasBodyA = world.TryGetComponent<RigidBody2D>(manifold.EntityA, out var bodyA);
         var hasBodyB = world.TryGetComponent<RigidBody2D>(manifold.EntityB, out var bodyB);
 

--- a/src/Engine/Yaeger/Physics/Systems/CollisionResolutionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionResolutionSystem.cs
@@ -1,0 +1,228 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics.Components;
+
+namespace Yaeger.Physics.Systems;
+
+/// <summary>
+/// Resolves collisions using impulse-based resolution with positional correction.
+/// </summary>
+public class CollisionResolutionSystem(World world)
+{
+    /// <summary>
+    /// Percentage of penetration to correct per frame (0.2 - 0.8 typical). Prevents jitter.
+    /// </summary>
+    public float CorrectionPercent { get; set; } = 0.4f;
+
+    /// <summary>
+    /// Minimum penetration threshold before positional correction is applied.
+    /// Prevents micro-corrections that cause jitter.
+    /// </summary>
+    public float CorrectionSlop { get; set; } = 0.005f;
+
+    /// <summary>
+    /// Resolves a list of collision manifolds by applying impulses and positional corrections.
+    /// </summary>
+    public void Resolve(IReadOnlyList<CollisionManifold> manifolds)
+    {
+        foreach (var manifold in manifolds)
+        {
+            ResolveManifold(manifold);
+        }
+    }
+
+    private void ResolveManifold(CollisionManifold manifold)
+    {
+        var hasBodyA = world.TryGetComponent<RigidBody2D>(manifold.EntityA, out var bodyA);
+        var hasBodyB = world.TryGetComponent<RigidBody2D>(manifold.EntityB, out var bodyB);
+
+        // Default to static if no rigid body component
+        if (!hasBodyA)
+            bodyA = RigidBody2D.CreateStatic();
+        if (!hasBodyB)
+            bodyB = RigidBody2D.CreateStatic();
+
+        // Skip if both are static or kinematic (nothing to resolve)
+        if (bodyA.Type != BodyType.Dynamic && bodyB.Type != BodyType.Dynamic)
+            return;
+
+        var inverseMassA = bodyA.Type == BodyType.Dynamic ? bodyA.InverseMass : 0.0f;
+        var inverseMassB = bodyB.Type == BodyType.Dynamic ? bodyB.InverseMass : 0.0f;
+        var inverseMassSum = inverseMassA + inverseMassB;
+
+        if (inverseMassSum <= 0)
+            return;
+
+        // Get velocities
+        world.TryGetComponent<Velocity2D>(manifold.EntityA, out var velocityA);
+        world.TryGetComponent<Velocity2D>(manifold.EntityB, out var velocityB);
+
+        // Get physics materials for restitution and friction
+        world.TryGetComponent<PhysicsMaterial>(manifold.EntityA, out var materialA);
+        world.TryGetComponent<PhysicsMaterial>(manifold.EntityB, out var materialB);
+
+        // Use minimum restitution (more conservative bounce)
+        var restitution = MathF.Min(materialA.Restitution, materialB.Restitution);
+
+        // --- Impulse resolution ---
+        var relativeVelocity = velocityB.Linear - velocityA.Linear;
+        var velocityAlongNormal = Vector2.Dot(relativeVelocity, manifold.Normal);
+
+        // Don't resolve if objects are separating
+        if (velocityAlongNormal > 0)
+        {
+            // Still apply positional correction even if separating
+            ApplyPositionalCorrection(
+                manifold,
+                bodyA,
+                bodyB,
+                inverseMassA,
+                inverseMassB,
+                inverseMassSum
+            );
+            return;
+        }
+
+        // Calculate impulse magnitude
+        var impulseMagnitude = -(1.0f + restitution) * velocityAlongNormal / inverseMassSum;
+        var impulse = impulseMagnitude * manifold.Normal;
+
+        // Apply impulse to velocities
+        if (bodyA.Type == BodyType.Dynamic)
+        {
+            velocityA.Linear -= inverseMassA * impulse;
+            world.AddComponent(manifold.EntityA, velocityA);
+        }
+
+        if (bodyB.Type == BodyType.Dynamic)
+        {
+            velocityB.Linear += inverseMassB * impulse;
+            world.AddComponent(manifold.EntityB, velocityB);
+        }
+
+        // --- Friction impulse ---
+        ApplyFriction(
+            manifold,
+            bodyA,
+            bodyB,
+            velocityA,
+            velocityB,
+            materialA,
+            materialB,
+            inverseMassA,
+            inverseMassB,
+            inverseMassSum,
+            impulseMagnitude
+        );
+
+        // --- Positional correction ---
+        ApplyPositionalCorrection(
+            manifold,
+            bodyA,
+            bodyB,
+            inverseMassA,
+            inverseMassB,
+            inverseMassSum
+        );
+    }
+
+    private void ApplyFriction(
+        CollisionManifold manifold,
+        RigidBody2D bodyA,
+        RigidBody2D bodyB,
+        Velocity2D velocityA,
+        Velocity2D velocityB,
+        PhysicsMaterial materialA,
+        PhysicsMaterial materialB,
+        float inverseMassA,
+        float inverseMassB,
+        float inverseMassSum,
+        float normalImpulseMagnitude
+    )
+    {
+        // Re-read velocities (they may have been updated by the impulse step)
+        if (bodyA.Type == BodyType.Dynamic)
+            world.TryGetComponent<Velocity2D>(manifold.EntityA, out velocityA);
+        if (bodyB.Type == BodyType.Dynamic)
+            world.TryGetComponent<Velocity2D>(manifold.EntityB, out velocityB);
+
+        var relativeVelocity = velocityB.Linear - velocityA.Linear;
+
+        // Calculate tangent vector (perpendicular to normal, in the direction of relative velocity)
+        var tangent =
+            relativeVelocity - Vector2.Dot(relativeVelocity, manifold.Normal) * manifold.Normal;
+        if (tangent.LengthSquared() < 1e-10f)
+            return;
+
+        tangent = Vector2.Normalize(tangent);
+
+        // Calculate friction impulse magnitude
+        var frictionMagnitude = -Vector2.Dot(relativeVelocity, tangent) / inverseMassSum;
+
+        // Use average friction
+        var staticFriction = (materialA.Friction + materialB.Friction) / 2.0f;
+
+        // Coulomb's law: clamp friction impulse to static friction cone
+        Vector2 frictionImpulse;
+        if (MathF.Abs(frictionMagnitude) < normalImpulseMagnitude * staticFriction)
+        {
+            // Static friction
+            frictionImpulse = frictionMagnitude * tangent;
+        }
+        else
+        {
+            // Dynamic friction (use a slightly lower coefficient)
+            var dynamicFriction = staticFriction * 0.7f;
+            frictionImpulse = -normalImpulseMagnitude * dynamicFriction * tangent;
+        }
+
+        // Apply friction impulse
+        if (bodyA.Type == BodyType.Dynamic)
+        {
+            velocityA.Linear -= inverseMassA * frictionImpulse;
+            world.AddComponent(manifold.EntityA, velocityA);
+        }
+
+        if (bodyB.Type == BodyType.Dynamic)
+        {
+            velocityB.Linear += inverseMassB * frictionImpulse;
+            world.AddComponent(manifold.EntityB, velocityB);
+        }
+    }
+
+    private void ApplyPositionalCorrection(
+        CollisionManifold manifold,
+        RigidBody2D bodyA,
+        RigidBody2D bodyB,
+        float inverseMassA,
+        float inverseMassB,
+        float inverseMassSum
+    )
+    {
+        var correctionMagnitude =
+            MathF.Max(manifold.PenetrationDepth - CorrectionSlop, 0.0f)
+            / inverseMassSum
+            * CorrectionPercent;
+
+        var correction = correctionMagnitude * manifold.Normal;
+
+        if (
+            bodyA.Type == BodyType.Dynamic
+            && world.TryGetComponent<Transform2D>(manifold.EntityA, out var transformA)
+        )
+        {
+            transformA.Position -= inverseMassA * correction;
+            world.AddComponent(manifold.EntityA, transformA);
+        }
+
+        if (
+            bodyB.Type == BodyType.Dynamic
+            && world.TryGetComponent<Transform2D>(manifold.EntityB, out var transformB)
+        )
+        {
+            transformB.Position += inverseMassB * correction;
+            world.AddComponent(manifold.EntityB, transformB);
+        }
+    }
+}

--- a/src/Engine/Yaeger/Physics/Systems/CollisionResolutionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionResolutionSystem.cs
@@ -58,9 +58,11 @@ public class CollisionResolutionSystem(World world)
         world.TryGetComponent<Velocity2D>(manifold.EntityA, out var velocityA);
         world.TryGetComponent<Velocity2D>(manifold.EntityB, out var velocityB);
 
-        // Get physics materials for restitution and friction
-        world.TryGetComponent<PhysicsMaterial>(manifold.EntityA, out var materialA);
-        world.TryGetComponent<PhysicsMaterial>(manifold.EntityB, out var materialB);
+        // Get physics materials for restitution and friction (fall back to default if missing)
+        if (!world.TryGetComponent<PhysicsMaterial>(manifold.EntityA, out var materialA))
+            materialA = PhysicsMaterial.Default;
+        if (!world.TryGetComponent<PhysicsMaterial>(manifold.EntityB, out var materialB))
+            materialB = PhysicsMaterial.Default;
 
         // Use minimum restitution (more conservative bounce)
         var restitution = MathF.Min(materialA.Restitution, materialB.Restitution);

--- a/src/Engine/Yaeger/Physics/Systems/GravitySystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/GravitySystem.cs
@@ -20,10 +20,13 @@ public class GravitySystem(World world, Vector2 gravity) : IUpdateSystem
 
     public void Update(float deltaTime)
     {
-        // Snapshot query results to avoid modifying component stores during iteration
-        var entities = world.Query<RigidBody2D, Velocity2D>().ToList();
-
-        foreach ((Entity entity, RigidBody2D body, Velocity2D velocity) in entities)
+        // Query enumerates RigidBody2D store; we only write back Velocity2D, so no snapshot needed.
+        foreach (
+            (Entity entity, RigidBody2D body, Velocity2D velocity) in world.Query<
+                RigidBody2D,
+                Velocity2D
+            >()
+        )
         {
             if (body.Type != BodyType.Dynamic)
                 continue;

--- a/src/Engine/Yaeger/Physics/Systems/GravitySystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/GravitySystem.cs
@@ -20,12 +20,10 @@ public class GravitySystem(World world, Vector2 gravity) : IUpdateSystem
 
     public void Update(float deltaTime)
     {
-        foreach (
-            (Entity entity, RigidBody2D body, Velocity2D velocity) in world.Query<
-                RigidBody2D,
-                Velocity2D
-            >()
-        )
+        // Snapshot query results to avoid modifying component stores during iteration
+        var entities = world.Query<RigidBody2D, Velocity2D>().ToList();
+
+        foreach ((Entity entity, RigidBody2D body, Velocity2D velocity) in entities)
         {
             if (body.Type != BodyType.Dynamic)
                 continue;

--- a/src/Engine/Yaeger/Physics/Systems/GravitySystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/GravitySystem.cs
@@ -1,0 +1,38 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Physics.Components;
+using Yaeger.Systems;
+
+namespace Yaeger.Physics.Systems;
+
+/// <summary>
+/// Applies gravitational acceleration to all dynamic rigid bodies.
+/// </summary>
+public class GravitySystem(World world, Vector2 gravity) : IUpdateSystem
+{
+    /// <summary>
+    /// The global gravity vector. Default is (0, -9.81).
+    /// </summary>
+    public Vector2 Gravity { get; set; } = gravity;
+
+    public GravitySystem(World world)
+        : this(world, new Vector2(0, -9.81f)) { }
+
+    public void Update(float deltaTime)
+    {
+        foreach (
+            (Entity entity, RigidBody2D body, Velocity2D velocity) in world.Query<
+                RigidBody2D,
+                Velocity2D
+            >()
+        )
+        {
+            if (body.Type != BodyType.Dynamic)
+                continue;
+
+            var newVelocity = velocity;
+            newVelocity.Linear += Gravity * body.GravityScale * deltaTime;
+            world.AddComponent(entity, newVelocity);
+        }
+    }
+}

--- a/src/Engine/Yaeger/Physics/Systems/MovementSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/MovementSystem.cs
@@ -13,13 +13,16 @@ public class MovementSystem(World world) : IUpdateSystem
 {
     public void Update(float deltaTime)
     {
+        // Snapshot query results to avoid modifying component stores during iteration
+        var entities = world.Query<Transform2D, Velocity2D, RigidBody2D>().ToList();
+
         foreach (
             (
                 Entity entity,
                 Transform2D transform,
                 Velocity2D velocity,
                 RigidBody2D body
-            ) in world.Query<Transform2D, Velocity2D, RigidBody2D>()
+            ) in entities
         )
         {
             if (body.Type == BodyType.Static)

--- a/src/Engine/Yaeger/Physics/Systems/MovementSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/MovementSystem.cs
@@ -13,16 +13,15 @@ public class MovementSystem(World world) : IUpdateSystem
 {
     public void Update(float deltaTime)
     {
-        // Snapshot query results to avoid modifying component stores during iteration
-        var entities = world.Query<Transform2D, Velocity2D, RigidBody2D>().ToList();
-
+        // Query enumerates RigidBody2D store; we only write back Transform2D and Velocity2D,
+        // so no snapshot needed — iterating a different store than we're mutating.
         foreach (
             (
                 Entity entity,
+                RigidBody2D body,
                 Transform2D transform,
-                Velocity2D velocity,
-                RigidBody2D body
-            ) in entities
+                Velocity2D velocity
+            ) in world.Query<RigidBody2D, Transform2D, Velocity2D>()
         )
         {
             if (body.Type == BodyType.Static)

--- a/src/Engine/Yaeger/Physics/Systems/MovementSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/MovementSystem.cs
@@ -1,0 +1,45 @@
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics.Components;
+using Yaeger.Systems;
+
+namespace Yaeger.Physics.Systems;
+
+/// <summary>
+/// Integrates velocity into position and rotation using semi-implicit Euler integration.
+/// Also applies linear drag.
+/// </summary>
+public class MovementSystem(World world) : IUpdateSystem
+{
+    public void Update(float deltaTime)
+    {
+        foreach (
+            (
+                Entity entity,
+                Transform2D transform,
+                Velocity2D velocity,
+                RigidBody2D body
+            ) in world.Query<Transform2D, Velocity2D, RigidBody2D>()
+        )
+        {
+            if (body.Type == BodyType.Static)
+                continue;
+
+            var newVelocity = velocity;
+
+            // Apply linear drag to dynamic bodies
+            if (body.Type == BodyType.Dynamic && body.LinearDrag > 0)
+            {
+                newVelocity.Linear *= 1.0f - body.LinearDrag * deltaTime;
+            }
+
+            // Integrate position and rotation
+            var newTransform = transform;
+            newTransform.Position += newVelocity.Linear * deltaTime;
+            newTransform.Rotation += newVelocity.Angular * deltaTime;
+
+            world.AddComponent(entity, newTransform);
+            world.AddComponent(entity, newVelocity);
+        }
+    }
+}

--- a/src/Engine/Yaeger/Physics/Systems/MovementSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/MovementSystem.cs
@@ -30,7 +30,12 @@ public class MovementSystem(World world) : IUpdateSystem
             // Apply linear drag to dynamic bodies
             if (body.Type == BodyType.Dynamic && body.LinearDrag > 0)
             {
-                newVelocity.Linear *= 1.0f - body.LinearDrag * deltaTime;
+                var dragFactor = 1.0f - body.LinearDrag * deltaTime;
+                if (dragFactor < 0.0f)
+                {
+                    dragFactor = 0.0f;
+                }
+                newVelocity.Linear *= dragFactor;
             }
 
             // Integrate position and rotation

--- a/src/Engine/Yaeger/Systems/IUpdateSystem.cs
+++ b/src/Engine/Yaeger/Systems/IUpdateSystem.cs
@@ -1,0 +1,13 @@
+namespace Yaeger.Systems;
+
+/// <summary>
+/// Interface for systems that update game state each frame.
+/// </summary>
+public interface IUpdateSystem
+{
+    /// <summary>
+    /// Updates the system state.
+    /// </summary>
+    /// <param name="deltaTime">The time elapsed since the last update, in seconds.</param>
+    void Update(float deltaTime);
+}

--- a/src/Engine/Yaeger/Yaeger.csproj
+++ b/src/Engine/Yaeger/Yaeger.csproj
@@ -9,7 +9,7 @@
   <Target
     Name="husky"
     BeforeTargets="Restore;CollectPackageReferences"
-    Condition="'$(HUSKY)' != '0'"
+    Condition="'$(HUSKY)' != '0' and Exists('$(MSBuildThisFileDirectory)..\..\..\.git')"
   >
     <Exec
       Command="dotnet tool restore"

--- a/src/Engine/Yaeger/Yaeger.csproj
+++ b/src/Engine/Yaeger/Yaeger.csproj
@@ -6,9 +6,22 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <Target Name="husky" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(HUSKY)' != '0'">
-    <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
-    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="../../../" />
+  <Target
+    Name="husky"
+    BeforeTargets="Restore;CollectPackageReferences"
+    Condition="'$(HUSKY)' != '0'"
+  >
+    <Exec
+      Command="dotnet tool restore"
+      StandardOutputImportance="Low"
+      StandardErrorImportance="High"
+    />
+    <Exec
+      Command="dotnet husky install"
+      StandardOutputImportance="Low"
+      StandardErrorImportance="High"
+      WorkingDirectory="../../../"
+    />
   </Target>
 
   <ItemGroup>

--- a/src/Engine/Yaeger/Yaeger.csproj
+++ b/src/Engine/Yaeger/Yaeger.csproj
@@ -6,6 +6,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <Target Name="husky" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(HUSKY)' != '0'">
+    <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
+    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="../../../" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="HarfBuzzSharp" Version="8.3.1.2" />
     <PackageReference Include="Silk.NET" Version="2.22.0" />

--- a/tests/Yaeger.Tests/Physics/Components/BoxCollider2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/BoxCollider2DTests.cs
@@ -1,0 +1,42 @@
+using System.Numerics;
+using Yaeger.Physics.Components;
+
+namespace Yaeger.Tests.Physics.Components;
+
+public class BoxCollider2DTests
+{
+    [Fact]
+    public void Constructor_WithSize_ShouldSetSizeAndDefaultOffset()
+    {
+        var collider = new BoxCollider2D(new Vector2(2, 3));
+
+        Assert.Equal(new Vector2(2, 3), collider.Size);
+        Assert.Equal(Vector2.Zero, collider.Offset);
+    }
+
+    [Fact]
+    public void Constructor_WithSizeAndOffset_ShouldSetBoth()
+    {
+        var collider = new BoxCollider2D(new Vector2(2, 3), new Vector2(1, -1));
+
+        Assert.Equal(new Vector2(2, 3), collider.Size);
+        Assert.Equal(new Vector2(1, -1), collider.Offset);
+    }
+
+    [Fact]
+    public void Constructor_WithWidthAndHeight_ShouldSetSize()
+    {
+        var collider = new BoxCollider2D(4, 5);
+
+        Assert.Equal(new Vector2(4, 5), collider.Size);
+        Assert.Equal(Vector2.Zero, collider.Offset);
+    }
+
+    [Fact]
+    public void HalfSize_ShouldReturnHalfOfSize()
+    {
+        var collider = new BoxCollider2D(new Vector2(4, 6));
+
+        Assert.Equal(new Vector2(2, 3), collider.HalfSize);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Components/BoxCollider2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/BoxCollider2DTests.cs
@@ -39,4 +39,28 @@ public class BoxCollider2DTests
 
         Assert.Equal(new Vector2(2, 3), collider.HalfSize);
     }
+
+    [Fact]
+    public void Constructor_WithZeroWidth_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BoxCollider2D(0, 5));
+    }
+
+    [Fact]
+    public void Constructor_WithZeroHeight_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BoxCollider2D(5, 0));
+    }
+
+    [Fact]
+    public void Constructor_WithNegativeSize_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BoxCollider2D(new Vector2(-1, 2)));
+    }
+
+    [Fact]
+    public void Constructor_WithNegativeHeight_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BoxCollider2D(new Vector2(2, -1)));
+    }
 }

--- a/tests/Yaeger.Tests/Physics/Components/CircleCollider2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/CircleCollider2DTests.cs
@@ -1,0 +1,25 @@
+using System.Numerics;
+using Yaeger.Physics.Components;
+
+namespace Yaeger.Tests.Physics.Components;
+
+public class CircleCollider2DTests
+{
+    [Fact]
+    public void Constructor_WithRadius_ShouldSetRadiusAndDefaultOffset()
+    {
+        var collider = new CircleCollider2D(5.0f);
+
+        Assert.Equal(5.0f, collider.Radius);
+        Assert.Equal(Vector2.Zero, collider.Offset);
+    }
+
+    [Fact]
+    public void Constructor_WithRadiusAndOffset_ShouldSetBoth()
+    {
+        var collider = new CircleCollider2D(3.0f, new Vector2(1, 2));
+
+        Assert.Equal(3.0f, collider.Radius);
+        Assert.Equal(new Vector2(1, 2), collider.Offset);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Components/CircleCollider2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/CircleCollider2DTests.cs
@@ -22,4 +22,16 @@ public class CircleCollider2DTests
         Assert.Equal(3.0f, collider.Radius);
         Assert.Equal(new Vector2(1, 2), collider.Offset);
     }
+
+    [Fact]
+    public void Constructor_WithZeroRadius_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CircleCollider2D(0.0f));
+    }
+
+    [Fact]
+    public void Constructor_WithNegativeRadius_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CircleCollider2D(-1.0f));
+    }
 }

--- a/tests/Yaeger.Tests/Physics/Components/PhysicsMaterialTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/PhysicsMaterialTests.cs
@@ -1,0 +1,42 @@
+using Yaeger.Physics.Components;
+
+namespace Yaeger.Tests.Physics.Components;
+
+public class PhysicsMaterialTests
+{
+    [Fact]
+    public void Constructor_ShouldSetProperties()
+    {
+        var material = new PhysicsMaterial(0.5f, 0.3f);
+
+        Assert.Equal(0.5f, material.Restitution);
+        Assert.Equal(0.3f, material.Friction);
+    }
+
+    [Fact]
+    public void Default_ShouldHaveModerateValues()
+    {
+        var material = PhysicsMaterial.Default;
+
+        Assert.Equal(0.3f, material.Restitution);
+        Assert.Equal(0.4f, material.Friction);
+    }
+
+    [Fact]
+    public void Bouncy_ShouldHaveFullRestitutionNoFriction()
+    {
+        var material = PhysicsMaterial.Bouncy;
+
+        Assert.Equal(1.0f, material.Restitution);
+        Assert.Equal(0.0f, material.Friction);
+    }
+
+    [Fact]
+    public void Sticky_ShouldHaveNoRestitutionHighFriction()
+    {
+        var material = PhysicsMaterial.Sticky;
+
+        Assert.Equal(0.0f, material.Restitution);
+        Assert.Equal(1.0f, material.Friction);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Components/PhysicsMaterialTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/PhysicsMaterialTests.cs
@@ -39,4 +39,22 @@ public class PhysicsMaterialTests
         Assert.Equal(0.0f, material.Restitution);
         Assert.Equal(1.0f, material.Friction);
     }
+
+    [Fact]
+    public void Constructor_WithNegativeRestitution_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PhysicsMaterial(-0.1f, 0.5f));
+    }
+
+    [Fact]
+    public void Constructor_WithRestitutionAboveOne_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PhysicsMaterial(1.1f, 0.5f));
+    }
+
+    [Fact]
+    public void Constructor_WithNegativeFriction_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PhysicsMaterial(0.5f, -0.1f));
+    }
 }

--- a/tests/Yaeger.Tests/Physics/Components/RigidBody2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/RigidBody2DTests.cs
@@ -1,0 +1,85 @@
+using System.Numerics;
+using Yaeger.Physics.Components;
+
+namespace Yaeger.Tests.Physics.Components;
+
+public class RigidBody2DTests
+{
+    [Fact]
+    public void CreateDynamic_ShouldSetMassAndInverseMass()
+    {
+        var body = RigidBody2D.CreateDynamic(2.0f);
+
+        Assert.Equal(2.0f, body.Mass);
+        Assert.Equal(0.5f, body.InverseMass);
+        Assert.Equal(BodyType.Dynamic, body.Type);
+    }
+
+    [Fact]
+    public void CreateDynamic_ShouldDefaultGravityScaleToOne()
+    {
+        var body = RigidBody2D.CreateDynamic(1.0f);
+
+        Assert.Equal(1.0f, body.GravityScale);
+    }
+
+    [Fact]
+    public void CreateDynamic_ShouldAllowCustomGravityScale()
+    {
+        var body = RigidBody2D.CreateDynamic(1.0f, gravityScale: 0.5f);
+
+        Assert.Equal(0.5f, body.GravityScale);
+    }
+
+    [Fact]
+    public void CreateDynamic_ShouldAllowCustomLinearDrag()
+    {
+        var body = RigidBody2D.CreateDynamic(1.0f, linearDrag: 0.1f);
+
+        Assert.Equal(0.1f, body.LinearDrag);
+    }
+
+    [Fact]
+    public void CreateDynamic_WithZeroMass_ShouldHaveZeroInverseMass()
+    {
+        var body = RigidBody2D.CreateDynamic(0.0f);
+
+        Assert.Equal(0.0f, body.InverseMass);
+    }
+
+    [Fact]
+    public void CreateStatic_ShouldHaveZeroMassAndInverseMass()
+    {
+        var body = RigidBody2D.CreateStatic();
+
+        Assert.Equal(0.0f, body.Mass);
+        Assert.Equal(0.0f, body.InverseMass);
+        Assert.Equal(BodyType.Static, body.Type);
+    }
+
+    [Fact]
+    public void CreateStatic_ShouldHaveZeroGravityScale()
+    {
+        var body = RigidBody2D.CreateStatic();
+
+        Assert.Equal(0.0f, body.GravityScale);
+    }
+
+    [Fact]
+    public void CreateKinematic_ShouldHaveZeroMassAndInverseMass()
+    {
+        var body = RigidBody2D.CreateKinematic();
+
+        Assert.Equal(0.0f, body.Mass);
+        Assert.Equal(0.0f, body.InverseMass);
+        Assert.Equal(BodyType.Kinematic, body.Type);
+    }
+
+    [Fact]
+    public void CreateKinematic_ShouldHaveZeroGravityScale()
+    {
+        var body = RigidBody2D.CreateKinematic();
+
+        Assert.Equal(0.0f, body.GravityScale);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Components/RigidBody2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/RigidBody2DTests.cs
@@ -40,11 +40,15 @@ public class RigidBody2DTests
     }
 
     [Fact]
-    public void CreateDynamic_WithZeroMass_ShouldHaveZeroInverseMass()
+    public void CreateDynamic_WithZeroMass_ShouldThrowArgumentOutOfRangeException()
     {
-        var body = RigidBody2D.CreateDynamic(0.0f);
+        Assert.Throws<ArgumentOutOfRangeException>(() => RigidBody2D.CreateDynamic(0.0f));
+    }
 
-        Assert.Equal(0.0f, body.InverseMass);
+    [Fact]
+    public void CreateDynamic_WithNegativeMass_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => RigidBody2D.CreateDynamic(-1.0f));
     }
 
     [Fact]

--- a/tests/Yaeger.Tests/Physics/Components/RigidBody2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/RigidBody2DTests.cs
@@ -52,6 +52,14 @@ public class RigidBody2DTests
     }
 
     [Fact]
+    public void CreateDynamic_WithNegativeLinearDrag_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            RigidBody2D.CreateDynamic(1.0f, linearDrag: -0.5f)
+        );
+    }
+
+    [Fact]
     public void CreateStatic_ShouldHaveZeroMassAndInverseMass()
     {
         var body = RigidBody2D.CreateStatic();

--- a/tests/Yaeger.Tests/Physics/Components/Velocity2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Components/Velocity2DTests.cs
@@ -1,0 +1,55 @@
+using System.Numerics;
+using Yaeger.Physics.Components;
+
+namespace Yaeger.Tests.Physics.Components;
+
+public class Velocity2DTests
+{
+    [Fact]
+    public void Constructor_WithVector2_ShouldSetLinearVelocity()
+    {
+        var velocity = new Velocity2D(new Vector2(3, 4));
+
+        Assert.Equal(3, velocity.Linear.X);
+        Assert.Equal(4, velocity.Linear.Y);
+        Assert.Equal(0, velocity.Angular);
+    }
+
+    [Fact]
+    public void Constructor_WithXY_ShouldSetLinearVelocity()
+    {
+        var velocity = new Velocity2D(5, -2);
+
+        Assert.Equal(5, velocity.Linear.X);
+        Assert.Equal(-2, velocity.Linear.Y);
+        Assert.Equal(0, velocity.Angular);
+    }
+
+    [Fact]
+    public void Constructor_WithAngular_ShouldSetAngularVelocity()
+    {
+        var velocity = new Velocity2D(new Vector2(1, 2), 3.14f);
+
+        Assert.Equal(3.14f, velocity.Angular);
+    }
+
+    [Fact]
+    public void Zero_ShouldReturnZeroVelocity()
+    {
+        var velocity = Velocity2D.Zero;
+
+        Assert.Equal(Vector2.Zero, velocity.Linear);
+        Assert.Equal(0, velocity.Angular);
+    }
+
+    [Fact]
+    public void Velocity2D_ShouldBeValueType()
+    {
+        var v1 = new Velocity2D(1, 2);
+        var v2 = v1;
+        v2.Linear = new Vector2(10, 20);
+
+        Assert.Equal(1, v1.Linear.X);
+        Assert.Equal(10, v2.Linear.X);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -294,6 +294,36 @@ public class CollisionDetectionSystemTests
         Assert.Single(system.Manifolds);
     }
 
+    [Fact]
+    public void Detect_BoxCircle_CircleInsideBox_ContactPointShouldBeOnBoxSurface()
+    {
+        // Arrange — circle centered inside box, slightly offset on X
+        var world = new World();
+
+        var box = world.CreateEntity();
+        world.AddComponent(box, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(box, new BoxCollider2D(10, 10)); // half size = 5
+
+        var circle = world.CreateEntity();
+        world.AddComponent(circle, new Transform2D(new Vector2(2, 0)));
+        world.AddComponent(circle, new CircleCollider2D(0.5f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — contact point should be on the box face, not at circle center
+        Assert.Single(system.Manifolds);
+        var manifold = system.Manifolds[0];
+
+        // Circle is at (2,0), closest point on box is (2,0) (inside), distance=0
+        // Shortest push-out axis is X (dx=3 < dy=5), normal = (1,0)
+        // Contact point should be on the right face of the box: (5, 0)
+        Assert.Equal(5.0f, manifold.ContactPoint.X, 0.001f);
+        Assert.Equal(0.0f, manifold.ContactPoint.Y, 0.001f);
+    }
+
     #endregion
 
     [Fact]

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -33,8 +33,10 @@ public class CollisionDetectionSystemTests
         // Assert
         Assert.Single(system.Manifolds);
         var manifold = system.Manifolds[0];
-        Assert.Equal(a, manifold.EntityA);
-        Assert.Equal(b, manifold.EntityB);
+        var entities = new[] { manifold.EntityA, manifold.EntityB };
+        Assert.Contains(a, entities);
+        Assert.Contains(b, entities);
+        Assert.NotEqual(manifold.EntityA, manifold.EntityB);
         Assert.True(manifold.PenetrationDepth > 0);
     }
 
@@ -243,8 +245,10 @@ public class CollisionDetectionSystemTests
         // Assert
         Assert.Single(system.Manifolds);
         var manifold = system.Manifolds[0];
-        Assert.Equal(box, manifold.EntityA);
-        Assert.Equal(circle, manifold.EntityB);
+        var entities = new[] { manifold.EntityA, manifold.EntityB };
+        Assert.Contains(box, entities);
+        Assert.Contains(circle, entities);
+        Assert.NotEqual(manifold.EntityA, manifold.EntityB);
         Assert.True(manifold.PenetrationDepth > 0);
     }
 

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -1,0 +1,354 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics;
+using Yaeger.Physics.Components;
+using Yaeger.Physics.Systems;
+
+namespace Yaeger.Tests.Physics.Systems;
+
+public class CollisionDetectionSystemTests
+{
+    #region Box vs Box
+
+    [Fact]
+    public void Detect_BoxBox_ShouldDetectOverlap()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new BoxCollider2D(2, 2));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1, 0)));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert
+        Assert.Single(system.Manifolds);
+        var manifold = system.Manifolds[0];
+        Assert.Equal(a, manifold.EntityA);
+        Assert.Equal(b, manifold.EntityB);
+        Assert.True(manifold.PenetrationDepth > 0);
+    }
+
+    [Fact]
+    public void Detect_BoxBox_ShouldNotDetectNonOverlapping()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new BoxCollider2D(2, 2));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(5, 0)));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert
+        Assert.Empty(system.Manifolds);
+    }
+
+    [Fact]
+    public void Detect_BoxBox_ShouldCalculateCorrectNormal_XAxis()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new BoxCollider2D(2, 2));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1.5f, 0)));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — overlap is less on X axis, so normal should be along X
+        Assert.Single(system.Manifolds);
+        var manifold = system.Manifolds[0];
+        Assert.Equal(1.0f, manifold.Normal.X);
+        Assert.Equal(0.0f, manifold.Normal.Y);
+        Assert.Equal(0.5f, manifold.PenetrationDepth, 0.001f);
+    }
+
+    [Fact]
+    public void Detect_BoxBox_ShouldCalculateCorrectNormal_YAxis()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new BoxCollider2D(2, 2));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(0, 1.5f)));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — overlap is less on Y axis, so normal should be along Y
+        Assert.Single(system.Manifolds);
+        var manifold = system.Manifolds[0];
+        Assert.Equal(0.0f, manifold.Normal.X);
+        Assert.Equal(1.0f, manifold.Normal.Y);
+        Assert.Equal(0.5f, manifold.PenetrationDepth, 0.001f);
+    }
+
+    [Fact]
+    public void Detect_BoxBox_ShouldRespectColliderOffset()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new BoxCollider2D(new Vector2(2, 2), new Vector2(5, 0)));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(6, 0)));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — A is at (0,0) but offset by (5,0), so effective center is (5,0)
+        // B is at (6,0) — they should overlap
+        Assert.Single(system.Manifolds);
+    }
+
+    #endregion
+
+    #region Circle vs Circle
+
+    [Fact]
+    public void Detect_CircleCircle_ShouldDetectOverlap()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new CircleCollider2D(1.0f));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1.5f, 0)));
+        world.AddComponent(b, new CircleCollider2D(1.0f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert
+        Assert.Single(system.Manifolds);
+        var manifold = system.Manifolds[0];
+        Assert.Equal(0.5f, manifold.PenetrationDepth, 0.001f);
+    }
+
+    [Fact]
+    public void Detect_CircleCircle_ShouldNotDetectNonOverlapping()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new CircleCollider2D(1.0f));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(5, 0)));
+        world.AddComponent(b, new CircleCollider2D(1.0f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert
+        Assert.Empty(system.Manifolds);
+    }
+
+    [Fact]
+    public void Detect_CircleCircle_ShouldCalculateCorrectNormal()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new CircleCollider2D(1.0f));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1.0f, 0)));
+        world.AddComponent(b, new CircleCollider2D(1.0f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — normal should point from A to B (along positive X)
+        Assert.Single(system.Manifolds);
+        var manifold = system.Manifolds[0];
+        Assert.Equal(1.0f, manifold.Normal.X, 0.001f);
+        Assert.Equal(0.0f, manifold.Normal.Y, 0.001f);
+    }
+
+    #endregion
+
+    #region Box vs Circle
+
+    [Fact]
+    public void Detect_BoxCircle_ShouldDetectOverlap()
+    {
+        // Arrange
+        var world = new World();
+
+        var box = world.CreateEntity();
+        world.AddComponent(box, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(box, new BoxCollider2D(2, 2));
+
+        var circle = world.CreateEntity();
+        world.AddComponent(circle, new Transform2D(new Vector2(1.5f, 0)));
+        world.AddComponent(circle, new CircleCollider2D(1.0f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert
+        Assert.Single(system.Manifolds);
+        var manifold = system.Manifolds[0];
+        Assert.Equal(box, manifold.EntityA);
+        Assert.Equal(circle, manifold.EntityB);
+        Assert.True(manifold.PenetrationDepth > 0);
+    }
+
+    [Fact]
+    public void Detect_BoxCircle_ShouldNotDetectNonOverlapping()
+    {
+        // Arrange
+        var world = new World();
+
+        var box = world.CreateEntity();
+        world.AddComponent(box, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(box, new BoxCollider2D(2, 2));
+
+        var circle = world.CreateEntity();
+        world.AddComponent(circle, new Transform2D(new Vector2(5, 0)));
+        world.AddComponent(circle, new CircleCollider2D(1.0f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert
+        Assert.Empty(system.Manifolds);
+    }
+
+    [Fact]
+    public void Detect_BoxCircle_CircleInsideBox_ShouldDetect()
+    {
+        // Arrange
+        var world = new World();
+
+        var box = world.CreateEntity();
+        world.AddComponent(box, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(box, new BoxCollider2D(10, 10));
+
+        var circle = world.CreateEntity();
+        world.AddComponent(circle, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(circle, new CircleCollider2D(0.5f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert
+        Assert.Single(system.Manifolds);
+    }
+
+    #endregion
+
+    [Fact]
+    public void Detect_ShouldClearManifoldsBetweenCalls()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new BoxCollider2D(2, 2));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1, 0)));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+        Assert.Single(system.Manifolds);
+
+        // Move B far away
+        world.AddComponent(b, new Transform2D(new Vector2(100, 0)));
+        system.Detect();
+
+        // Assert — should be empty now
+        Assert.Empty(system.Manifolds);
+    }
+
+    [Fact]
+    public void Detect_MultipleCollisions_ShouldReportAll()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new BoxCollider2D(2, 2));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1, 0)));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+
+        var c = world.CreateEntity();
+        world.AddComponent(c, new Transform2D(new Vector2(-1, 0)));
+        world.AddComponent(c, new BoxCollider2D(2, 2));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — A overlaps B (overlap 1), A overlaps C (overlap 1)
+        // B and C are exactly touching (overlap = 0), so no collision
+        Assert.Equal(2, system.Manifolds.Count);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -351,4 +351,24 @@ public class CollisionDetectionSystemTests
         // B and C are exactly touching (overlap = 0), so no collision
         Assert.Equal(2, system.Manifolds.Count);
     }
+
+    [Fact]
+    public void Detect_BoxCircle_SameEntity_ShouldNotSelfCollide()
+    {
+        // Arrange — entity has both BoxCollider2D and CircleCollider2D
+        var world = new World();
+
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(entity, new BoxCollider2D(2, 2));
+        world.AddComponent(entity, new CircleCollider2D(1.0f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — should not generate a self-collision manifold
+        Assert.Empty(system.Manifolds);
+    }
 }

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionResolutionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionResolutionSystemTests.cs
@@ -251,4 +251,41 @@ public class CollisionResolutionSystemTests
         Assert.True(transformA.Position.X < 0);
         Assert.True(transformB.Position.X > 1);
     }
+
+    [Fact]
+    public void Resolve_WithoutPhysicsMaterial_ShouldUseDefaultMaterial()
+    {
+        // Arrange — entities without PhysicsMaterial should use PhysicsMaterial.Default
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new Velocity2D(10, 0));
+        world.AddComponent(a, RigidBody2D.CreateDynamic(1.0f));
+        // No PhysicsMaterial added — should fall back to Default (Restitution=0.3, Friction=0.4)
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1, 0)));
+        world.AddComponent(b, Velocity2D.Zero);
+        world.AddComponent(b, RigidBody2D.CreateStatic());
+        // No PhysicsMaterial added
+
+        var manifold = new CollisionManifold
+        {
+            EntityA = a,
+            EntityB = b,
+            Normal = new Vector2(1, 0),
+            PenetrationDepth = 0.1f,
+            ContactPoint = new Vector2(0.5f, 0),
+        };
+
+        var system = new CollisionResolutionSystem(world);
+
+        // Act
+        system.Resolve([manifold]);
+
+        // Assert — with Default restitution of 0.3, the body should bounce back somewhat
+        var velA = world.GetComponent<Velocity2D>(a);
+        Assert.True(velA.Linear.X < 0); // Should have reversed due to restitution
+    }
 }

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionResolutionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionResolutionSystemTests.cs
@@ -1,0 +1,254 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics;
+using Yaeger.Physics.Components;
+using Yaeger.Physics.Systems;
+
+namespace Yaeger.Tests.Physics.Systems;
+
+public class CollisionResolutionSystemTests
+{
+    [Fact]
+    public void Resolve_ShouldSeparateOverlappingDynamicBodies()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new Velocity2D(5, 0));
+        world.AddComponent(a, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(a, PhysicsMaterial.Default);
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1.5f, 0)));
+        world.AddComponent(b, new Velocity2D(-5, 0));
+        world.AddComponent(b, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(b, PhysicsMaterial.Default);
+
+        var manifold = new CollisionManifold
+        {
+            EntityA = a,
+            EntityB = b,
+            Normal = new Vector2(1, 0),
+            PenetrationDepth = 0.5f,
+            ContactPoint = new Vector2(0.75f, 0),
+        };
+
+        var system = new CollisionResolutionSystem(world);
+
+        // Act
+        system.Resolve([manifold]);
+
+        // Assert — velocities should have changed (A should now move left, B should now move right)
+        var velA = world.GetComponent<Velocity2D>(a);
+        var velB = world.GetComponent<Velocity2D>(b);
+
+        Assert.True(velA.Linear.X < 5); // A should have slowed down or reversed
+        Assert.True(velB.Linear.X > -5); // B should have slowed down or reversed
+    }
+
+    [Fact]
+    public void Resolve_ShouldNotMoveStaticBodies()
+    {
+        // Arrange
+        var world = new World();
+
+        var wall = world.CreateEntity();
+        world.AddComponent(wall, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(wall, Velocity2D.Zero);
+        world.AddComponent(wall, RigidBody2D.CreateStatic());
+        world.AddComponent(wall, PhysicsMaterial.Default);
+
+        var ball = world.CreateEntity();
+        world.AddComponent(ball, new Transform2D(new Vector2(0.8f, 0)));
+        world.AddComponent(ball, new Velocity2D(-10, 0));
+        world.AddComponent(ball, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(ball, PhysicsMaterial.Default);
+
+        var manifold = new CollisionManifold
+        {
+            EntityA = wall,
+            EntityB = ball,
+            Normal = new Vector2(1, 0),
+            PenetrationDepth = 0.2f,
+            ContactPoint = new Vector2(0.5f, 0),
+        };
+
+        var system = new CollisionResolutionSystem(world);
+
+        // Act
+        system.Resolve([manifold]);
+
+        // Assert — wall should not have moved
+        var wallTransform = world.GetComponent<Transform2D>(wall);
+        Assert.Equal(0, wallTransform.Position.X);
+        Assert.Equal(0, wallTransform.Position.Y);
+
+        // Ball velocity should have changed
+        var ballVel = world.GetComponent<Velocity2D>(ball);
+        Assert.True(ballVel.Linear.X > -10);
+    }
+
+    [Fact]
+    public void Resolve_BothStatic_ShouldDoNothing()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, Velocity2D.Zero);
+        world.AddComponent(a, RigidBody2D.CreateStatic());
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(0.5f, 0)));
+        world.AddComponent(b, Velocity2D.Zero);
+        world.AddComponent(b, RigidBody2D.CreateStatic());
+
+        var manifold = new CollisionManifold
+        {
+            EntityA = a,
+            EntityB = b,
+            Normal = new Vector2(1, 0),
+            PenetrationDepth = 0.5f,
+            ContactPoint = new Vector2(0.25f, 0),
+        };
+
+        var system = new CollisionResolutionSystem(world);
+
+        // Act
+        system.Resolve([manifold]);
+
+        // Assert — nothing should change
+        var transformA = world.GetComponent<Transform2D>(a);
+        var transformB = world.GetComponent<Transform2D>(b);
+        Assert.Equal(0, transformA.Position.X);
+        Assert.Equal(0.5f, transformB.Position.X);
+    }
+
+    [Fact]
+    public void Resolve_WithBouncyMaterial_ShouldBounce()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new Velocity2D(10, 0));
+        world.AddComponent(a, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(a, PhysicsMaterial.Bouncy);
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1, 0)));
+        world.AddComponent(b, Velocity2D.Zero);
+        world.AddComponent(b, RigidBody2D.CreateStatic());
+        world.AddComponent(b, PhysicsMaterial.Bouncy);
+
+        var manifold = new CollisionManifold
+        {
+            EntityA = a,
+            EntityB = b,
+            Normal = new Vector2(1, 0),
+            PenetrationDepth = 0.1f,
+            ContactPoint = new Vector2(0.5f, 0),
+        };
+
+        var system = new CollisionResolutionSystem(world);
+
+        // Act
+        system.Resolve([manifold]);
+
+        // Assert — with restitution 1.0, ball should bounce back
+        var velA = world.GetComponent<Velocity2D>(a);
+        Assert.True(velA.Linear.X < 0); // Should have reversed direction
+    }
+
+    [Fact]
+    public void Resolve_ShouldApplyPositionalCorrection()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new Velocity2D(5, 0));
+        world.AddComponent(a, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(a, PhysicsMaterial.Default);
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1.5f, 0)));
+        world.AddComponent(b, new Velocity2D(-5, 0));
+        world.AddComponent(b, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(b, PhysicsMaterial.Default);
+
+        var manifold = new CollisionManifold
+        {
+            EntityA = a,
+            EntityB = b,
+            Normal = new Vector2(1, 0),
+            PenetrationDepth = 0.5f,
+            ContactPoint = new Vector2(0.75f, 0),
+        };
+
+        var system = new CollisionResolutionSystem(world);
+
+        // Act
+        system.Resolve([manifold]);
+
+        // Assert — positions should have been corrected (pushed apart)
+        var transformA = world.GetComponent<Transform2D>(a);
+        var transformB = world.GetComponent<Transform2D>(b);
+
+        // A should have moved left (negative correction)
+        Assert.True(transformA.Position.X < 0);
+        // B should have moved right (positive correction)
+        Assert.True(transformB.Position.X > 1.5f);
+    }
+
+    [Fact]
+    public void Resolve_SeparatingBodies_ShouldStillApplyPositionalCorrection()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new Velocity2D(-5, 0)); // Moving away
+        world.AddComponent(a, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(a, PhysicsMaterial.Default);
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1, 0)));
+        world.AddComponent(b, new Velocity2D(5, 0)); // Moving away
+        world.AddComponent(b, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(b, PhysicsMaterial.Default);
+
+        var manifold = new CollisionManifold
+        {
+            EntityA = a,
+            EntityB = b,
+            Normal = new Vector2(1, 0),
+            PenetrationDepth = 0.5f,
+            ContactPoint = new Vector2(0.5f, 0),
+        };
+
+        var system = new CollisionResolutionSystem(world);
+
+        // Act
+        system.Resolve([manifold]);
+
+        // Assert — velocities should not change (already separating), but positions should be corrected
+        var velA = world.GetComponent<Velocity2D>(a);
+        var velB = world.GetComponent<Velocity2D>(b);
+        Assert.Equal(-5, velA.Linear.X);
+        Assert.Equal(5, velB.Linear.X);
+
+        // But positions should have been corrected
+        var transformA = world.GetComponent<Transform2D>(a);
+        var transformB = world.GetComponent<Transform2D>(b);
+        Assert.True(transformA.Position.X < 0);
+        Assert.True(transformB.Position.X > 1);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Systems/GravitySystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/GravitySystemTests.cs
@@ -1,0 +1,128 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics.Components;
+using Yaeger.Physics.Systems;
+
+namespace Yaeger.Tests.Physics.Systems;
+
+public class GravitySystemTests
+{
+    [Fact]
+    public void Update_ShouldApplyGravityToDynamicBodies()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(entity, Velocity2D.Zero);
+
+        var gravity = new Vector2(0, -10.0f);
+        var system = new GravitySystem(world, gravity);
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.Equal(0, velocity.Linear.X);
+        Assert.Equal(-10.0f, velocity.Linear.Y);
+    }
+
+    [Fact]
+    public void Update_ShouldRespectGravityScale()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f, gravityScale: 0.5f));
+        world.AddComponent(entity, Velocity2D.Zero);
+
+        var gravity = new Vector2(0, -10.0f);
+        var system = new GravitySystem(world, gravity);
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.Equal(-5.0f, velocity.Linear.Y);
+    }
+
+    [Fact]
+    public void Update_ShouldNotAffectStaticBodies()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, RigidBody2D.CreateStatic());
+        world.AddComponent(entity, Velocity2D.Zero);
+
+        var system = new GravitySystem(world, new Vector2(0, -10.0f));
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.Equal(Vector2.Zero, velocity.Linear);
+    }
+
+    [Fact]
+    public void Update_ShouldNotAffectKinematicBodies()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, RigidBody2D.CreateKinematic());
+        world.AddComponent(entity, Velocity2D.Zero);
+
+        var system = new GravitySystem(world, new Vector2(0, -10.0f));
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.Equal(Vector2.Zero, velocity.Linear);
+    }
+
+    [Fact]
+    public void Update_ShouldAccumulateGravityOverMultipleSteps()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(entity, Velocity2D.Zero);
+
+        var system = new GravitySystem(world, new Vector2(0, -10.0f));
+
+        // Act
+        system.Update(0.5f);
+        system.Update(0.5f);
+
+        // Assert
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.Equal(-10.0f, velocity.Linear.Y);
+    }
+
+    [Fact]
+    public void Update_ShouldScaleByDeltaTime()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(entity, Velocity2D.Zero);
+
+        var system = new GravitySystem(world, new Vector2(0, -10.0f));
+
+        // Act
+        system.Update(0.016f); // ~60fps
+
+        // Assert
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.Equal(-0.16f, velocity.Linear.Y, 0.001f);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Systems/MovementSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/MovementSystemTests.cs
@@ -1,0 +1,156 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics.Components;
+using Yaeger.Physics.Systems;
+
+namespace Yaeger.Tests.Physics.Systems;
+
+public class MovementSystemTests
+{
+    [Fact]
+    public void Update_ShouldIntegrateLinearVelocityIntoPosition()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Velocity2D(10, 5));
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f));
+
+        var system = new MovementSystem(world);
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var transform = world.GetComponent<Transform2D>(entity);
+        Assert.Equal(10, transform.Position.X);
+        Assert.Equal(5, transform.Position.Y);
+    }
+
+    [Fact]
+    public void Update_ShouldIntegrateAngularVelocityIntoRotation()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Velocity2D(Vector2.Zero, MathF.PI));
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f));
+
+        var system = new MovementSystem(world);
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var transform = world.GetComponent<Transform2D>(entity);
+        Assert.Equal(MathF.PI, transform.Rotation, 0.001f);
+    }
+
+    [Fact]
+    public void Update_ShouldScaleByDeltaTime()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Velocity2D(100, 200));
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f));
+
+        var system = new MovementSystem(world);
+
+        // Act
+        system.Update(0.5f);
+
+        // Assert
+        var transform = world.GetComponent<Transform2D>(entity);
+        Assert.Equal(50, transform.Position.X);
+        Assert.Equal(100, transform.Position.Y);
+    }
+
+    [Fact]
+    public void Update_ShouldNotMoveStaticBodies()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(new Vector2(5, 5)));
+        world.AddComponent(entity, new Velocity2D(10, 10));
+        world.AddComponent(entity, RigidBody2D.CreateStatic());
+
+        var system = new MovementSystem(world);
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var transform = world.GetComponent<Transform2D>(entity);
+        Assert.Equal(5, transform.Position.X);
+        Assert.Equal(5, transform.Position.Y);
+    }
+
+    [Fact]
+    public void Update_ShouldMoveKinematicBodies()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Velocity2D(5, 0));
+        world.AddComponent(entity, RigidBody2D.CreateKinematic());
+
+        var system = new MovementSystem(world);
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var transform = world.GetComponent<Transform2D>(entity);
+        Assert.Equal(5, transform.Position.X);
+    }
+
+    [Fact]
+    public void Update_ShouldApplyLinearDrag()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Velocity2D(100, 0));
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f, linearDrag: 0.5f));
+
+        var system = new MovementSystem(world);
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert — velocity should be reduced by drag before integration
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.True(velocity.Linear.X < 100);
+        Assert.True(velocity.Linear.X > 0);
+    }
+
+    [Fact]
+    public void Update_ShouldNotApplyDragToKinematicBodies()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Velocity2D(100, 0));
+        var body = RigidBody2D.CreateKinematic();
+        body.LinearDrag = 0.5f; // Set drag, but it shouldn't apply to kinematic
+        world.AddComponent(entity, body);
+
+        var system = new MovementSystem(world);
+
+        // Act
+        system.Update(1.0f);
+
+        // Assert
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.Equal(100, velocity.Linear.X);
+    }
+}

--- a/tests/Yaeger.Tests/Physics/Systems/MovementSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/MovementSystemTests.cs
@@ -153,4 +153,25 @@ public class MovementSystemTests
         var velocity = world.GetComponent<Velocity2D>(entity);
         Assert.Equal(100, velocity.Linear.X);
     }
+
+    [Fact]
+    public void Update_WithHighDragAndLargeDeltaTime_ShouldClampDragFactorToZero()
+    {
+        // Arrange — drag * deltaTime > 1 should not invert velocity
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Velocity2D(100, 50));
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f, linearDrag: 2.0f));
+
+        var system = new MovementSystem(world);
+
+        // Act — large deltaTime causes drag factor to go negative without clamping
+        system.Update(1.0f); // dragFactor = 1 - 2*1 = -1, should be clamped to 0
+
+        // Assert — velocity should be zeroed, not inverted
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.Equal(0.0f, velocity.Linear.X);
+        Assert.Equal(0.0f, velocity.Linear.Y);
+    }
 }

--- a/tests/Yaeger.Tests/Physics/Systems/PhysicsWorld2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/PhysicsWorld2DTests.cs
@@ -89,8 +89,10 @@ public class PhysicsWorld2DTests
 
         // Assert
         Assert.Single(firedEvents);
-        Assert.Equal(a, firedEvents[0].EntityA);
-        Assert.Equal(b, firedEvents[0].EntityB);
+        var entities = new[] { firedEvents[0].EntityA, firedEvents[0].EntityB };
+        Assert.Contains(a, entities);
+        Assert.Contains(b, entities);
+        Assert.NotEqual(firedEvents[0].EntityA, firedEvents[0].EntityB);
     }
 
     [Fact]

--- a/tests/Yaeger.Tests/Physics/Systems/PhysicsWorld2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/PhysicsWorld2DTests.cs
@@ -1,0 +1,154 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics;
+using Yaeger.Physics.Components;
+
+namespace Yaeger.Tests.Physics.Systems;
+
+public class PhysicsWorld2DTests
+{
+    [Fact]
+    public void Update_ShouldApplyGravityAndMoveEntities()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(new Vector2(0, 10)));
+        world.AddComponent(entity, Velocity2D.Zero);
+        world.AddComponent(entity, RigidBody2D.CreateDynamic(1.0f));
+
+        var physics = new PhysicsWorld2D(world, new Vector2(0, -10));
+
+        // Act
+        physics.Update(1.0f);
+
+        // Assert — entity should have fallen
+        var transform = world.GetComponent<Transform2D>(entity);
+        Assert.True(transform.Position.Y < 10);
+
+        var velocity = world.GetComponent<Velocity2D>(entity);
+        Assert.True(velocity.Linear.Y < 0);
+    }
+
+    [Fact]
+    public void Update_ShouldDetectAndResolveCollisions()
+    {
+        // Arrange
+        var world = new World();
+
+        // Two boxes overlapping, moving towards each other
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, new Velocity2D(10, 0));
+        world.AddComponent(a, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(a, new BoxCollider2D(2, 2));
+        world.AddComponent(a, PhysicsMaterial.Default);
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1.5f, 0)));
+        world.AddComponent(b, new Velocity2D(-10, 0));
+        world.AddComponent(b, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+        world.AddComponent(b, PhysicsMaterial.Default);
+
+        var physics = new PhysicsWorld2D(world, Vector2.Zero);
+
+        // Act
+        physics.Update(0.0f); // zero dt to avoid movement, just detect existing overlap
+
+        // Assert — collision should have been detected
+        Assert.NotEmpty(physics.Manifolds);
+    }
+
+    [Fact]
+    public void Update_ShouldFireCollisionEvents()
+    {
+        // Arrange
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(a, Velocity2D.Zero);
+        world.AddComponent(a, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(a, new BoxCollider2D(2, 2));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(1, 0)));
+        world.AddComponent(b, Velocity2D.Zero);
+        world.AddComponent(b, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(b, new BoxCollider2D(2, 2));
+
+        var physics = new PhysicsWorld2D(world, Vector2.Zero);
+
+        var firedEvents = new List<CollisionManifold>();
+        physics.OnCollision += manifold => firedEvents.Add(manifold);
+
+        // Act
+        physics.Update(0.0f);
+
+        // Assert
+        Assert.Single(firedEvents);
+        Assert.Equal(a, firedEvents[0].EntityA);
+        Assert.Equal(b, firedEvents[0].EntityB);
+    }
+
+    [Fact]
+    public void Gravity_ShouldBeConfigurable()
+    {
+        // Arrange
+        var world = new World();
+        var physics = new PhysicsWorld2D(world);
+
+        // Act
+        physics.Gravity = new Vector2(0, -20);
+
+        // Assert
+        Assert.Equal(new Vector2(0, -20), physics.Gravity);
+    }
+
+    [Fact]
+    public void Constructor_ShouldDefaultToEarthGravity()
+    {
+        // Arrange & Act
+        var world = new World();
+        var physics = new PhysicsWorld2D(world);
+
+        // Assert
+        Assert.Equal(new Vector2(0, -9.81f), physics.Gravity);
+    }
+
+    [Fact]
+    public void Update_StaticFloor_DynamicBall_ShouldBounce()
+    {
+        // Arrange
+        var world = new World();
+
+        // Floor (static, wide box at y = 0, height 2, so top edge at y = 1)
+        var floor = world.CreateEntity();
+        world.AddComponent(floor, new Transform2D(new Vector2(0, 0)));
+        world.AddComponent(floor, Velocity2D.Zero);
+        world.AddComponent(floor, RigidBody2D.CreateStatic());
+        world.AddComponent(floor, new BoxCollider2D(100, 2));
+        world.AddComponent(floor, PhysicsMaterial.Bouncy);
+
+        // Ball (dynamic, overlapping with floor — center at y=1.3, radius 0.5, bottom at y=0.8)
+        // Floor top edge at y=1, so overlap = 1.0 - 0.8 = 0.2
+        var ball = world.CreateEntity();
+        world.AddComponent(ball, new Transform2D(new Vector2(0, 1.3f)));
+        world.AddComponent(ball, new Velocity2D(0, -10));
+        world.AddComponent(ball, RigidBody2D.CreateDynamic(1.0f));
+        world.AddComponent(ball, new CircleCollider2D(0.5f));
+        world.AddComponent(ball, PhysicsMaterial.Bouncy);
+
+        var physics = new PhysicsWorld2D(world, Vector2.Zero); // No gravity for simplicity
+
+        // Act
+        physics.Update(0.001f); // Very small step to minimize movement before collision
+
+        // Assert — ball should have bounced (velocity Y should be positive or less negative)
+        var ballVel = world.GetComponent<Velocity2D>(ball);
+        // The ball was going down at -10, after bouncing off a bouncy floor it should reverse
+        Assert.True(ballVel.Linear.Y > -10);
+    }
+}


### PR DESCRIPTION
- [x] PhysicsWorld2D event invocation (already fixed with local var pattern)
- [x] MovementSystem ToList() allocation (already fixed, iterates RigidBody2D first)
- [x] CollisionDetectionSystem: reuse boxEntities/circleEntities as fields instead of allocating per frame
- [x] CollisionResolutionSystem: normalize manifold.Normal in ResolveManifold to enforce unit-vector invariant