### PR TITLE
feat: add physics debug renderer for collider wireframe visualization

### DIFF
--- a/Samples/BouncingBalls/Program.cs
+++ b/Samples/BouncingBalls/Program.cs
@@ -17,7 +17,7 @@ var renderSystem = new RenderSystem(renderer, world);
 var physics = new PhysicsWorld2D(world, new Vector2(0, -2.0f));
 
 // Debug renderer for collider wireframes (toggle with Space)
-var debugRenderer = new PhysicsDebugRenderer(window, world);
+using var debugRenderer = new PhysicsDebugRenderer(window, world);
 var showDebug = false;
 
 // --- Walls (static boxes forming a container) ---

--- a/Samples/BouncingBalls/Program.cs
+++ b/Samples/BouncingBalls/Program.cs
@@ -16,6 +16,10 @@ var renderSystem = new RenderSystem(renderer, world);
 // Physics world with downward gravity (positive Y is up in NDC)
 var physics = new PhysicsWorld2D(world, new Vector2(0, -2.0f));
 
+// Debug renderer for collider wireframes (toggle with Space)
+var debugRenderer = new PhysicsDebugRenderer(window, world);
+var showDebug = false;
+
 // --- Walls (static boxes forming a container) ---
 var wallThickness = 0.05f;
 
@@ -120,9 +124,13 @@ window.OnUpdate += delta =>
 window.OnRender += _ =>
 {
     renderSystem.Render();
+
+    if (showDebug)
+        debugRenderer.Render();
 };
 
 Keyboard.AddKeyDown(Keys.Escape, () => window.Close());
+Keyboard.AddKeyDown(Keys.Space, () => showDebug = !showDebug);
 
 window.Run();
 

--- a/src/Engine/Yaeger/Physics/PhysicsDebugRenderer.cs
+++ b/src/Engine/Yaeger/Physics/PhysicsDebugRenderer.cs
@@ -9,14 +9,13 @@ using Yaeger.Windowing;
 namespace Yaeger.Physics;
 
 /// <summary>
-/// Renders wireframe outlines for physics colliders using GL_LINES.
-/// Draws green outlines for box colliders and green outlines for circle colliders.
+/// Renders configurable wireframe outlines for physics colliders using GL_LINES.
 /// </summary>
 public class PhysicsDebugRenderer : IDisposable
 {
     private readonly GL _gl;
     private readonly World _world;
-    private readonly Rendering.Shader _shader;
+    private readonly Yaeger.Rendering.Shader _shader;
     private readonly DebugVertexArray _vao;
     private readonly Buffer<float> _vbo;
 
@@ -59,7 +58,7 @@ public class PhysicsDebugRenderer : IDisposable
         _gl = window.Gl;
         _world = world;
 
-        _shader = new Rendering.Shader(_gl, VertexShaderSource, FragmentShaderSource);
+        _shader = new Yaeger.Rendering.Shader(_gl, VertexShaderSource, FragmentShaderSource);
 
         _vertexBuffer = new float[MaxLineSegments * VerticesPerLine * FloatsPerVertex];
 
@@ -150,7 +149,10 @@ public class PhysicsDebugRenderer : IDisposable
     private void AddLine(Vector2 from, Vector2 to)
     {
         if (_vertexCount + 2 > MaxLineSegments * VerticesPerLine)
-            return;
+        {
+            Flush();
+            _vertexCount = 0;
+        }
 
         var offset = _vertexCount * FloatsPerVertex;
 

--- a/src/Engine/Yaeger/Physics/PhysicsDebugRenderer.cs
+++ b/src/Engine/Yaeger/Physics/PhysicsDebugRenderer.cs
@@ -1,0 +1,195 @@
+using System.Numerics;
+using Silk.NET.OpenGL;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Physics.Components;
+using Yaeger.Rendering;
+using Yaeger.Windowing;
+
+namespace Yaeger.Physics;
+
+/// <summary>
+/// Renders wireframe outlines for physics colliders using GL_LINES.
+/// Draws green outlines for box colliders and green outlines for circle colliders.
+/// </summary>
+public class PhysicsDebugRenderer : IDisposable
+{
+    private readonly GL _gl;
+    private readonly World _world;
+    private readonly Rendering.Shader _shader;
+    private readonly DebugVertexArray _vao;
+    private readonly Buffer<float> _vbo;
+
+    private const int MaxLineSegments = 4096;
+    private const int FloatsPerVertex = 3;
+    private const int VerticesPerLine = 2;
+    private const int CircleSegments = 32;
+
+    private readonly float[] _vertexBuffer;
+    private int _vertexCount;
+
+    /// <summary>
+    /// The color used for collider wireframes. Default is green.
+    /// </summary>
+    public Vector4 ColliderColor { get; set; } = new(0.0f, 1.0f, 0.0f, 1.0f);
+
+    private const string VertexShaderSource = """
+        #version 330 core
+        layout(location = 0) in vec3 aPosition;
+
+        void main()
+        {
+            gl_Position = vec4(aPosition, 1.0);
+        }
+        """;
+
+    private const string FragmentShaderSource = """
+        #version 330 core
+        uniform vec4 uColor;
+        out vec4 FragColor;
+
+        void main()
+        {
+            FragColor = uColor;
+        }
+        """;
+
+    public PhysicsDebugRenderer(Window window, World world)
+    {
+        _gl = window.Gl;
+        _world = world;
+
+        _shader = new Rendering.Shader(_gl, VertexShaderSource, FragmentShaderSource);
+
+        _vertexBuffer = new float[MaxLineSegments * VerticesPerLine * FloatsPerVertex];
+
+        _vbo = new Buffer<float>(
+            _gl,
+            _vertexBuffer,
+            BufferTargetARB.ArrayBuffer,
+            BufferUsageARB.DynamicDraw
+        );
+
+        _vao = new DebugVertexArray(_gl, _vbo);
+        _vao.Unbind();
+    }
+
+    /// <summary>
+    /// Renders wireframe outlines for all entities that have collider components.
+    /// Call this after your main render pass so the debug lines draw on top.
+    /// </summary>
+    public void Render()
+    {
+        _vertexCount = 0;
+
+        // Collect box collider outlines
+        foreach (
+            (Entity _, Transform2D transform, BoxCollider2D collider) in _world.Query<
+                Transform2D,
+                BoxCollider2D
+            >()
+        )
+        {
+            var center = transform.Position + collider.Offset;
+            AddBox(center, collider.HalfSize);
+        }
+
+        // Collect circle collider outlines
+        foreach (
+            (Entity _, Transform2D transform, CircleCollider2D collider) in _world.Query<
+                Transform2D,
+                CircleCollider2D
+            >()
+        )
+        {
+            var center = transform.Position + collider.Offset;
+            AddCircle(center, collider.Radius);
+        }
+
+        if (_vertexCount == 0)
+            return;
+
+        Flush();
+    }
+
+    private void AddBox(Vector2 center, Vector2 halfSize)
+    {
+        var topLeft = new Vector2(center.X - halfSize.X, center.Y + halfSize.Y);
+        var topRight = new Vector2(center.X + halfSize.X, center.Y + halfSize.Y);
+        var bottomRight = new Vector2(center.X + halfSize.X, center.Y - halfSize.Y);
+        var bottomLeft = new Vector2(center.X - halfSize.X, center.Y - halfSize.Y);
+
+        AddLine(topLeft, topRight);
+        AddLine(topRight, bottomRight);
+        AddLine(bottomRight, bottomLeft);
+        AddLine(bottomLeft, topLeft);
+    }
+
+    private void AddCircle(Vector2 center, float radius)
+    {
+        var angleStep = MathF.PI * 2.0f / CircleSegments;
+
+        for (var i = 0; i < CircleSegments; i++)
+        {
+            var angle1 = i * angleStep;
+            var angle2 = (i + 1) * angleStep;
+
+            var p1 = new Vector2(
+                center.X + MathF.Cos(angle1) * radius,
+                center.Y + MathF.Sin(angle1) * radius
+            );
+            var p2 = new Vector2(
+                center.X + MathF.Cos(angle2) * radius,
+                center.Y + MathF.Sin(angle2) * radius
+            );
+
+            AddLine(p1, p2);
+        }
+    }
+
+    private void AddLine(Vector2 from, Vector2 to)
+    {
+        if (_vertexCount + 2 > MaxLineSegments * VerticesPerLine)
+            return;
+
+        var offset = _vertexCount * FloatsPerVertex;
+
+        _vertexBuffer[offset + 0] = from.X;
+        _vertexBuffer[offset + 1] = from.Y;
+        _vertexBuffer[offset + 2] = 0.0f;
+
+        _vertexBuffer[offset + 3] = to.X;
+        _vertexBuffer[offset + 4] = to.Y;
+        _vertexBuffer[offset + 5] = 0.0f;
+
+        _vertexCount += 2;
+    }
+
+    private unsafe void Flush()
+    {
+        _shader.Bind();
+        _shader.SetUniformVec4("uColor", ColliderColor);
+
+        _vao.Bind();
+        _vbo.Bind();
+
+        var byteCount = (nuint)(_vertexCount * FloatsPerVertex * sizeof(float));
+        fixed (float* ptr = _vertexBuffer)
+        {
+            _gl.BufferSubData(BufferTargetARB.ArrayBuffer, 0, byteCount, ptr);
+        }
+
+        _gl.DrawArrays(PrimitiveType.Lines, 0, (uint)_vertexCount);
+
+        _vao.Unbind();
+        _shader.Unbind();
+    }
+
+    public void Dispose()
+    {
+        _vao.Dispose();
+        _vbo.Dispose();
+        _shader.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Engine/Yaeger/Physics/PhysicsDebugRenderer.cs
+++ b/src/Engine/Yaeger/Physics/PhysicsDebugRenderer.cs
@@ -83,9 +83,9 @@ public class PhysicsDebugRenderer : IDisposable
 
         // Collect box collider outlines
         foreach (
-            (Entity _, Transform2D transform, BoxCollider2D collider) in _world.Query<
-                Transform2D,
-                BoxCollider2D
+            (Entity _, BoxCollider2D collider, Transform2D transform) in _world.Query<
+                BoxCollider2D,
+                Transform2D
             >()
         )
         {
@@ -95,9 +95,9 @@ public class PhysicsDebugRenderer : IDisposable
 
         // Collect circle collider outlines
         foreach (
-            (Entity _, Transform2D transform, CircleCollider2D collider) in _world.Query<
-                Transform2D,
-                CircleCollider2D
+            (Entity _, CircleCollider2D collider, Transform2D transform) in _world.Query<
+                CircleCollider2D,
+                Transform2D
             >()
         )
         {

--- a/src/Engine/Yaeger/Physics/PhysicsDebugRenderer.cs
+++ b/src/Engine/Yaeger/Physics/PhysicsDebugRenderer.cs
@@ -1,10 +1,10 @@
 using System.Numerics;
-using Silk.NET.OpenGL;
 using Yaeger.ECS;
 using Yaeger.Graphics;
 using Yaeger.Physics.Components;
 using Yaeger.Rendering;
 using Yaeger.Windowing;
+using GL = Silk.NET.OpenGL.GL;
 
 namespace Yaeger.Physics;
 
@@ -15,7 +15,7 @@ public class PhysicsDebugRenderer : IDisposable
 {
     private readonly GL _gl;
     private readonly World _world;
-    private readonly Yaeger.Rendering.Shader _shader;
+    private readonly Shader _shader;
     private readonly DebugVertexArray _vao;
     private readonly Buffer<float> _vbo;
 
@@ -58,15 +58,15 @@ public class PhysicsDebugRenderer : IDisposable
         _gl = window.Gl;
         _world = world;
 
-        _shader = new Yaeger.Rendering.Shader(_gl, VertexShaderSource, FragmentShaderSource);
+        _shader = new Shader(_gl, VertexShaderSource, FragmentShaderSource);
 
         _vertexBuffer = new float[MaxLineSegments * VerticesPerLine * FloatsPerVertex];
 
         _vbo = new Buffer<float>(
             _gl,
             _vertexBuffer,
-            BufferTargetARB.ArrayBuffer,
-            BufferUsageARB.DynamicDraw
+            Silk.NET.OpenGL.BufferTargetARB.ArrayBuffer,
+            Silk.NET.OpenGL.BufferUsageARB.DynamicDraw
         );
 
         _vao = new DebugVertexArray(_gl, _vbo);
@@ -178,10 +178,10 @@ public class PhysicsDebugRenderer : IDisposable
         var byteCount = (nuint)(_vertexCount * FloatsPerVertex * sizeof(float));
         fixed (float* ptr = _vertexBuffer)
         {
-            _gl.BufferSubData(BufferTargetARB.ArrayBuffer, 0, byteCount, ptr);
+            _gl.BufferSubData(Silk.NET.OpenGL.BufferTargetARB.ArrayBuffer, 0, byteCount, ptr);
         }
 
-        _gl.DrawArrays(PrimitiveType.Lines, 0, (uint)_vertexCount);
+        _gl.DrawArrays(Silk.NET.OpenGL.PrimitiveType.Lines, 0, (uint)_vertexCount);
 
         _vao.Unbind();
         _shader.Unbind();

--- a/src/Engine/Yaeger/Rendering/DebugVertexArray.cs
+++ b/src/Engine/Yaeger/Rendering/DebugVertexArray.cs
@@ -1,0 +1,49 @@
+using Silk.NET.OpenGL;
+
+namespace Yaeger.Rendering;
+
+/// <summary>
+/// Vertex array for debug line rendering. Position-only layout (3 floats per vertex).
+/// </summary>
+public class DebugVertexArray : IDisposable
+{
+    private readonly GL _gl;
+    private readonly uint _handle;
+
+    private const uint VertexSize = 3; // x, y, z
+    private const int PositionCount = 3;
+
+    public DebugVertexArray(GL gl, Buffer<float> vbo)
+    {
+        _gl = gl;
+        _handle = _gl.GenVertexArray();
+        Bind();
+        vbo.Bind();
+
+        VertexAttributeFloatPointer(0, PositionCount, VertexSize, 0);
+    }
+
+    private unsafe void VertexAttributeFloatPointer(
+        uint index,
+        int count,
+        uint vertexSize,
+        int offset
+    )
+    {
+        _gl.VertexAttribPointer(
+            index,
+            count,
+            VertexAttribPointerType.Float,
+            false,
+            vertexSize * sizeof(float),
+            (void*)(offset * sizeof(float))
+        );
+        _gl.EnableVertexAttribArray(index);
+    }
+
+    public void Bind() => _gl.BindVertexArray(_handle);
+
+    public void Unbind() => _gl.BindVertexArray(0);
+
+    public void Dispose() => _gl.DeleteVertexArray(_handle);
+}

--- a/src/Engine/Yaeger/Rendering/Shader.cs
+++ b/src/Engine/Yaeger/Rendering/Shader.cs
@@ -69,5 +69,11 @@ public class Shader : IDisposable
         _gl.UniformMatrix4(location, 1, false, (float*)&matrix);
     }
 
+    public void SetUniformVec4(string name, Vector4 value)
+    {
+        var location = GetUniformLocation(name);
+        _gl.Uniform4(location, value.X, value.Y, value.Z, value.W);
+    }
+
     public void Dispose() => _gl.DeleteProgram(_program);
 }


### PR DESCRIPTION
## Summary

- Add `PhysicsDebugRenderer` that draws wireframe outlines (`GL_LINES`) for all entities with `BoxCollider2D` or `CircleCollider2D` components
- Boxes render as 4 line segments, circles as 32-segment approximations — all in configurable color (default green)
- Standalone design: decoupled from `PhysicsWorld2D`, queries the ECS directly for collider + transform components
- Add `DebugVertexArray` (position-only, 3 floats/vertex) and `Shader.SetUniformVec4` to support the color-only shader
- BouncingBalls sample: press **Space** to toggle debug wireframes on/off