### PR TITLE
docs: fix inaccuracies and reduce staleness in CLAUDE.md and copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,10 +6,10 @@ Yaeger is a modular, experimental 2D game engine written in C# using Entity-Comp
 
 **Key Technologies:**
 - **Language**: C# with .NET 10.0 target framework
-- **Graphics**: Silk.NET (version 2.22.0) for OpenGL rendering
+- **Graphics**: Silk.NET for OpenGL rendering
 - **Audio**: Silk.NET.OpenAL for audio playback
 - **Text**: SkiaSharp + HarfBuzzSharp for glyph rasterisation
-- **Image Processing**: StbImageSharp (version 2.30.15)
+- **Image Processing**: StbImageSharp
 - **Architecture**: Entity-Component-System (ECS) pattern
 - **Platform**: Cross-platform (Windows, macOS, Linux)
 
@@ -54,15 +54,16 @@ dotnet test
 dotnet test --filter "FullyQualifiedName~WorldTests.CreateEntity"
 ```
 
-The test suite uses xUnit and covers ECS, physics, and graphics primitives (~45 tests). Rendering, windowing, input, and audio require a live platform context and are not unit-tested.
+The test suite uses xUnit and covers ECS, physics, and graphics primitives. Rendering, windowing, input, and audio require a live platform context and are not unit-tested.
 
 ## Architecture
 
 ### ECS (`src/Engine/Yaeger/ECS/`)
 - **`World`** — central container; holds all entities and one `ComponentStorage<T>` per component type (created lazily).
 - **`Entity`** — value-type (`struct`) ID wrapper. Optionally registered under a string tag.
-- **`WorldExtensions`** — `Query<T1,T2>()` / `Query<T1,T2,T3>()` / `Query<T1,T2,T3,T4>()` extension methods that join stores.
-- **`ComponentRegistry` / `PrefabLoader` / `Prefab`** — JSON prefab pipeline. Files use `{"components": [{"type": "...", ...}]}`. Call `registry.RegisterEngineComponents()` then `world.Instantiate(prefab)`.
+- **`WorldExtensions`** — `Query<T1,T2>()` / `Query<T1,T2,T3>()` / `Query<T1,T2,T3,T4>()` extension methods. Iterates `T1`'s store and probes the rest — put the rarest type first.
+- **`ComponentStorage<T>`** — internal store per component type. Access only through `World` APIs, never directly.
+- **`ComponentRegistry` / `PrefabLoader` / `Prefab`** — JSON prefab pipeline. Files use `{"components": [{"type": "...", ...}]}`. Call `registry.RegisterEngineComponents()` then `world.Instantiate(prefab, optionalTag)`.
 
 **All components must be `struct`, never `class`.**
 
@@ -93,7 +94,7 @@ Event-based: `OnLoad`, `OnUpdate`, `OnRender`, `OnResize`, `OnClosing`. Always `
 
 - `src/Engine/Yaeger/` — core engine library
 - `tests/Yaeger.Tests/` — xUnit test suite
-- `Samples/` — runnable example games and demos (Pong, BouncingBalls, Animation2D, BatchRenderingExample, TextRenderingExample)
+- `Samples/` — runnable example games and demos (one subdirectory per sample)
 - `docs/` — documentation (animation, audio, physics, testing guides)
 
 ## Development Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Yaeger is a 2D game engine library (`src/Engine/Yaeger/`) built around ECS. Game
 - **`World`** — the central container. Holds all entities and typed `ComponentStorage<T>` instances (one per component type, created lazily).
 - **`Entity`** — a value-type ID wrapper (`int`). Entities can optionally be named with a string tag.
 - **`ComponentStorage<T>`** — internal dictionary-backed store per component type. Never access it directly; use `World` APIs.
-- **`WorldExtensions`** — provides `Query<T1,T2>()` / `Query<T1,T2,T3>()` / `Query<T1,T2,T3,T4>()` LINQ-style extension methods. These iterate the smallest store and join on the rest.
+- **`WorldExtensions`** — provides `Query<T1,T2>()` / `Query<T1,T2,T3>()` / `Query<T1,T2,T3,T4>()` LINQ-style extension methods. These iterate `T1`'s store and probe the remaining stores with `TryGet` — put the rarest component type first for best performance.
 - **`IComponentSerializer` / `ComponentRegistry` / `PrefabLoader` / `Prefab`** — the prefab pipeline. JSON files with a `"components": [{"type": "...", ...}]` structure are loaded via `PrefabLoader`, which looks up serializers in a `ComponentRegistry`. Call `registry.RegisterEngineComponents()` to register the built-in serializers, then add game-specific ones. Instantiate via `world.Instantiate(prefab, optionalTag)`.
 
 **Critical constraint**: All components must be `struct`, never `class`. `ComponentStorage<T>` has a `where T : struct` constraint.


### PR DESCRIPTION
## Summary

- Fix `WorldExtensions` description in CLAUDE.md: said "iterates the smallest store" — actually iterates `T1`'s store unconditionally. Added the performance tip: put the rarest type first.
- Remove hardcoded test count (`~45`) from copilot instructions — was 4× stale (actual count is 184). Test counts change with every PR.
- Remove package version annotations (`Silk.NET (version 2.22.0)`, `StbImageSharp (version 2.30.15)`) — `.csproj` is authoritative; prose versions drift silently.
- Replace hardcoded sample list with a directory reference — new samples would immediately make the list stale.
- Add `ComponentStorage<T>` access note to copilot instructions (was only in CLAUDE.md).
- Add optional tag parameter to prefab instantiation example in copilot instructions for consistency with CLAUDE.md.

## Test plan

- [ ] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)