### PR TITLE
refactor: simplify and clean up Samples code

### DIFF
--- a/Samples/Animation2D/Program.cs
+++ b/Samples/Animation2D/Program.cs
@@ -107,19 +107,17 @@ void ApplyCombatSequence()
 }
 
 // ------------------------------------------------------------------
-// Key bindings: switch animations at runtime.
-// ------------------------------------------------------------------
 Keyboard.AddKeyDown(Keys.W, () => ApplyAnimation("Walk"));
-Keyboard.AddKeyDown(Keys.R, () => ApplyAnimation("Run", frameDuration: 0.05f)); // Faster frame rate for running
-Keyboard.AddKeyDown(Keys.J, () => ApplyAnimation("Jump", loop: false)); // Don't loop the jump animation
+Keyboard.AddKeyDown(Keys.R, () => ApplyAnimation("Run", frameDuration: 0.05f));
+Keyboard.AddKeyDown(Keys.J, () => ApplyAnimation("Jump", loop: false));
 Keyboard.AddKeyDown(Keys.I, () => ApplyAnimation("Idle"));
-Keyboard.AddKeyDown(Keys.Num1, () => ApplyAnimation("Attack_1", loop: false)); // Don't loop attack animations
+Keyboard.AddKeyDown(Keys.Num1, () => ApplyAnimation("Attack_1", loop: false));
 Keyboard.AddKeyDown(Keys.Num2, () => ApplyAnimation("Attack_2", loop: false));
 Keyboard.AddKeyDown(Keys.Num3, () => ApplyAnimation("Attack_3", loop: false));
-Keyboard.AddKeyDown(Keys.C, ApplyCombatSequence); // Trigger the full combat sequence (for demonstration)
-Keyboard.AddKeyDown(Keys.H, () => ApplyAnimation("Hurt", frameDuration: 0.2f, loop: false)); // Slower frame rate for hurt animation
-Keyboard.AddKeyDown(Keys.S, () => ApplyAnimation("Shield", frameDuration: 0.2f)); // Slower frame rate for shield animation
-Keyboard.AddKeyDown(Keys.D, () => ApplyAnimation("Dead", loop: false)); // Don't loop the dead animation
+Keyboard.AddKeyDown(Keys.C, ApplyCombatSequence);
+Keyboard.AddKeyDown(Keys.H, () => ApplyAnimation("Hurt", frameDuration: 0.2f, loop: false));
+Keyboard.AddKeyDown(Keys.S, () => ApplyAnimation("Shield", frameDuration: 0.2f));
+Keyboard.AddKeyDown(Keys.D, () => ApplyAnimation("Dead", loop: false));
 
 var currentAnimationLabel = world.CreateEntity();
 world.AddComponent(
@@ -131,14 +129,17 @@ world.AddComponent(
     new Transform2D(new Vector2(-0.95f, -0.9f), 0f, new Vector2(0.003f, 0.003f))
 );
 
-window.OnUpdate += deltaTime => animationSystem.Update((float)deltaTime);
-window.OnUpdate += _ =>
-{
-    // Advance through the combat sequence automatically when each attack finishes
-    if (combatPhase < 0)
-        return;
+var lastLabelSheetName = currentSheetName;
 
-    if (world.TryGetComponent<AnimationState>(samurai, out var state) && state.IsFinished)
+window.OnUpdate += deltaTime =>
+{
+    animationSystem.Update((float)deltaTime);
+
+    if (
+        combatPhase >= 0
+        && world.TryGetComponent<AnimationState>(samurai, out var state)
+        && state.IsFinished
+    )
     {
         combatPhase++;
         if (combatPhase < combatSequence.Length)
@@ -149,13 +150,14 @@ window.OnUpdate += _ =>
             ApplyAnimation("Idle");
         }
     }
-};
-window.OnUpdate += _ =>
-{
-    // Update the current animation label text to reflect the active animation
-    var textComp = world.GetComponent<Text>(currentAnimationLabel);
-    textComp.Content = $"Current Animation: {currentSheetName}";
-    world.AddComponent(currentAnimationLabel, textComp); // Re-add to trigger the text system to update the rendering
+
+    if (currentSheetName != lastLabelSheetName)
+    {
+        lastLabelSheetName = currentSheetName;
+        var textComp = world.GetComponent<Text>(currentAnimationLabel);
+        textComp.Content = $"Current Animation: {currentSheetName}";
+        world.AddComponent(currentAnimationLabel, textComp); // Re-add to trigger the text system to update the rendering
+    }
 };
 window.OnRender += _ => renderSystem.Render();
 window.OnRender += _ => textRenderSystem.Render();

--- a/Samples/BatchRenderingExample/Program.cs
+++ b/Samples/BatchRenderingExample/Program.cs
@@ -76,13 +76,7 @@ Keyboard.AddKeyDown(
     }
 );
 
-Keyboard.AddKeyDown(
-    Keys.Escape,
-    () =>
-    {
-        window.Close();
-    }
-);
+Keyboard.AddKeyDown(Keys.Escape, window.Close);
 
 window.OnUpdate += Update;
 window.OnRender += Render;

--- a/Samples/BatchRenderingExample/Systems/PhysicsSystem.cs
+++ b/Samples/BatchRenderingExample/Systems/PhysicsSystem.cs
@@ -8,7 +8,6 @@ public class PhysicsSystem(World world)
 {
     public void Update(float deltaTime)
     {
-        // Update sprite positions and rotations
         foreach (
             (
                 Entity entity,
@@ -22,7 +21,6 @@ public class PhysicsSystem(World world)
             var rotation = transform2D.Rotation + rotationSpeed.Value * deltaTime;
             var newVelocity = velocity;
 
-            // Bounce off edges
             if (position.X is < -1f or > 1f)
             {
                 newVelocity = new Velocity(velocity.Value with { X = -velocity.Value.X });
@@ -42,7 +40,8 @@ public class PhysicsSystem(World world)
                     Rotation = rotation,
                 }
             );
-            world.AddComponent(entity, newVelocity);
+            if (newVelocity.Value != velocity.Value)
+                world.AddComponent(entity, newVelocity);
         }
     }
 }

--- a/Samples/Pong/EntityFactory.cs
+++ b/Samples/Pong/EntityFactory.cs
@@ -85,6 +85,7 @@ public class EntityFactory
     public void SpawnScoreBoard()
     {
         const int scoreFontSize = 48;
+        var scoreScale = new Vector2(0.005f, 0.005f);
         var fontManager = new FontManager();
         var defaultFont = fontManager.Load("Assets/Roboto-Regular.ttf");
 
@@ -92,22 +93,14 @@ public class EntityFactory
         _world.AddComponent(leftScore, new Text("0", defaultFont, scoreFontSize, Color.White));
         _world.AddComponent(
             leftScore,
-            new Transform2D
-            {
-                Position = new Vector2(-0.15f, 0.8f),
-                Scale = new Vector2(0.005f, 0.005f), // Scale down for screen-space rendering
-            }
+            new Transform2D { Position = new Vector2(-0.15f, 0.8f), Scale = scoreScale }
         );
 
         var rightScore = _world.CreateEntity(EntityTags.RightScore);
         _world.AddComponent(rightScore, new Text("0", defaultFont, scoreFontSize, Color.White));
         _world.AddComponent(
             rightScore,
-            new Transform2D
-            {
-                Position = new Vector2(0.075f, 0.8f),
-                Scale = new Vector2(0.005f, 0.005f), // Scale down for screen-space rendering
-            }
+            new Transform2D { Position = new Vector2(0.075f, 0.8f), Scale = scoreScale }
         );
     }
 }

--- a/Samples/Pong/Program.cs
+++ b/Samples/Pong/Program.cs
@@ -15,24 +15,6 @@ var renderSystem = new RenderSystem(renderer, world);
 var textRenderer = new TextRenderer(window);
 var textRenderSystem = new TextRenderSystem(textRenderer, world);
 
-// Example: How to use the sound system (requires .wav audio files)
-// Uncomment the following lines to play sounds:
-//
-// var soundBuffer = SoundBuffer.FromFile(window.AudioContext, "Assets/beep.wav");
-// var soundSource = SoundSource.Create(window.AudioContext);
-// soundSource.SetBuffer(soundBuffer);
-// soundSource.Play();
-//
-// To play a sound when the ball hits a paddle:
-// soundSource.Play();
-//
-// To loop background music:
-// var musicBuffer = SoundBuffer.FromFile(window.AudioContext, "Assets/music.wav");
-// var musicSource = SoundSource.Create(window.AudioContext);
-// musicSource.Looping = true;
-// musicSource.SetBuffer(musicBuffer);
-// musicSource.Play();
-
 var updateSystems = new List<IUpdateSystem>
 {
     new InputSystem(world),
@@ -44,7 +26,8 @@ var entityFactory = new EntityFactory(world);
 
 int fps = 0;
 double lastFpsCount = 0;
-Stack<int> fpsCounts = new();
+int fpsSum = 0;
+int fpsSnapshots = 0;
 
 entityFactory.SpawnLeftPaddle();
 entityFactory.SpawnRightPaddle();
@@ -56,15 +39,10 @@ window.OnLoad += OnLoad;
 window.OnResize += size => Console.WriteLine($"Window resized to {size.X}x{size.Y}");
 window.OnUpdate += Update;
 window.OnRender += Render;
-window.OnClosing += () => Console.WriteLine("Average FPS: " + fpsCounts.Average());
+window.OnClosing += () =>
+    Console.WriteLine("Average FPS: " + (fpsSnapshots > 0 ? (double)fpsSum / fpsSnapshots : 0));
 
-Keyboard.AddKeyDown(
-    Keys.Escape,
-    () =>
-    {
-        window.Close();
-    }
-);
+Keyboard.AddKeyDown(Keys.Escape, window.Close);
 
 window.Run();
 
@@ -95,7 +73,8 @@ void Render(double delta)
 
     if (lastFpsCount >= 1.0)
     {
-        fpsCounts.Push(fps);
+        fpsSum += fps;
+        fpsSnapshots++;
         Console.WriteLine($"FPS: {fps}");
         fps = 0;
         lastFpsCount = 0;

--- a/Samples/Pong/Systems/InputSystem.cs
+++ b/Samples/Pong/Systems/InputSystem.cs
@@ -27,32 +27,16 @@ public class InputSystem(World world) : IUpdateSystem
 
     private static Velocity HandlePaddleInput(Transform2D transform, Velocity velocity)
     {
-        var dir = 0f;
-        switch (transform.Position.X)
-        {
-            // Naive paddle detection based on x position
-            // Left paddle
-            case < 0f:
-            {
-                if (Keyboard.IsKeyPressed(Keys.W))
-                    dir += 1f;
-                if (Keyboard.IsKeyPressed(Keys.S))
-                    dir -= 1f;
-                velocity.Value = new Vector2(0, dir * 1.0f);
-                break;
-            }
-            // Right paddle
-            case > 0f:
-            {
-                if (Keyboard.IsKeyPressed(Keys.Up))
-                    dir += 1f;
-                if (Keyboard.IsKeyPressed(Keys.Down))
-                    dir -= 1f;
-                velocity.Value = new Vector2(0, dir * 1.0f);
-                break;
-            }
-        }
+        // Naive paddle detection based on x position
+        var (upKey, downKey) = transform.Position.X < 0f ? (Keys.W, Keys.S) : (Keys.Up, Keys.Down);
 
+        var dir = 0f;
+        if (Keyboard.IsKeyPressed(upKey))
+            dir += 1f;
+        if (Keyboard.IsKeyPressed(downKey))
+            dir -= 1f;
+
+        velocity.Value = new Vector2(0, dir);
         return velocity;
     }
 

--- a/Samples/Pong/Systems/MoveSystem.cs
+++ b/Samples/Pong/Systems/MoveSystem.cs
@@ -9,7 +9,6 @@ public class MoveSystem(World world) : IUpdateSystem
 {
     public void Update(float deltaTime)
     {
-        // Move all entities with Velocity and Transform2D
         foreach (
             (Entity entity, Transform2D transform, Velocity velocity, Bounds bounds) in world.Query<
                 Transform2D,

--- a/Samples/Pong/Systems/PhysicsSystem.cs
+++ b/Samples/Pong/Systems/PhysicsSystem.cs
@@ -7,24 +7,29 @@ using Yaeger.Systems;
 
 namespace Pong.Systems;
 
-public class PhysicsSystem(World world) : IUpdateSystem
+public class PhysicsSystem : IUpdateSystem
 {
-    private long _lastBounce = Stopwatch.GetTimestamp();
-    const float BallVelocityIncrement = 1.1f; // Increment ball speed after each bounce
+    private readonly World _world;
+    private readonly Entity _ballEntity;
+    private long _lastBounce;
+    const float BallVelocityIncrement = 1.1f;
+
+    public PhysicsSystem(World world)
+    {
+        _world = world;
+        _ballEntity = world.GetEntity(EntityTags.Ball);
+        _lastBounce = Stopwatch.GetTimestamp();
+    }
 
     public void Update(float deltaTime)
     {
-        // Find the ball (assume only one ball, with Velocity and Transform2D)
-        (Entity ballEntity, _, Transform2D transform, Velocity velocity, Bounds bounds) = world
-            .Query<Ball, Transform2D, Velocity, Bounds>()
-            .First();
+        var transform = _world.GetComponent<Transform2D>(_ballEntity);
+        var velocity = _world.GetComponent<Velocity>(_ballEntity);
+        var bounds = _world.GetComponent<Bounds>(_ballEntity);
 
-        // Ball bounds
         var ballPos = transform.Position;
         var ballScale = transform.Scale;
         var ballHalf = ballScale / 2f;
-
-        // --- Pong-specific collision detection ---
 
         if (Stopwatch.GetTimestamp() - _lastBounce < Stopwatch.Frequency / 30)
             return;
@@ -32,8 +37,7 @@ public class PhysicsSystem(World world) : IUpdateSystem
         velocity = HandleWallCollisions(ballPos, ballHalf, velocity, bounds);
         velocity = HandlePaddleCollisions(ballPos, ballHalf, velocity);
 
-        // Write back ball velocity
-        world.AddComponent(ballEntity, velocity);
+        _world.AddComponent(_ballEntity, velocity);
     }
 
     private Velocity HandlePaddleCollisions(
@@ -42,8 +46,7 @@ public class PhysicsSystem(World world) : IUpdateSystem
         Velocity ballVelocity
     )
     {
-        // Check collision with paddles
-        foreach ((_, Transform2D paddle, _) in world.Query<Transform2D, PlayerControlled>())
+        foreach ((_, Transform2D paddle, _) in _world.Query<Transform2D, PlayerControlled>())
         {
             var paddlePos = paddle.Position;
             var paddleScale = paddle.Scale;
@@ -53,8 +56,6 @@ public class PhysicsSystem(World world) : IUpdateSystem
             var overlapY = MathF.Abs(ballPos.Y - paddlePos.Y) < ballHalf.Y + paddleHalf.Y;
             if (!overlapX || !overlapY)
                 continue;
-            // Reverse X velocity
-            // Update the ball's velocity
             ballVelocity = new Velocity(
                 ballVelocity.Value with
                 {
@@ -75,7 +76,6 @@ public class PhysicsSystem(World world) : IUpdateSystem
         Bounds bounds
     )
     {
-        // Check collision with top/bottom walls (assuming play area is -1 to 1 in Y)
         if (ballPos.Y + ballHalf.Y > bounds.MaxY)
         {
             ballVelocity = new Velocity(

--- a/Samples/Pong/Systems/PrintScoreSystem.cs
+++ b/Samples/Pong/Systems/PrintScoreSystem.cs
@@ -5,22 +5,39 @@ using Yaeger.Systems;
 
 namespace Pong.Systems;
 
-public class PrintScoreSystem(World world) : IUpdateSystem
+public class PrintScoreSystem : IUpdateSystem
 {
-    public void Update(float deltaTime)
+    private readonly World _world;
+    private readonly Entity _leftPaddle;
+    private readonly Entity _rightPaddle;
+    private readonly Entity _leftScore;
+    private readonly Entity _rightScore;
+    private int _lastLeftScore = -1;
+    private int _lastRightScore = -1;
+
+    public PrintScoreSystem(World world)
     {
-        UpdateScore(EntityTags.LeftPaddle, EntityTags.LeftScore);
-        UpdateScore(EntityTags.RightPaddle, EntityTags.RightScore);
+        _world = world;
+        _leftPaddle = world.GetEntity(EntityTags.LeftPaddle);
+        _rightPaddle = world.GetEntity(EntityTags.RightPaddle);
+        _leftScore = world.GetEntity(EntityTags.LeftScore);
+        _rightScore = world.GetEntity(EntityTags.RightScore);
     }
 
-    private void UpdateScore(string playerTag, string scoreTag)
+    public void Update(float deltaTime)
     {
-        var player = world.GetEntity(playerTag);
-        var playerScore = world.GetComponent<PlayerScore>(player);
+        UpdateScore(_leftPaddle, _leftScore, ref _lastLeftScore);
+        UpdateScore(_rightPaddle, _rightScore, ref _lastRightScore);
+    }
 
-        var scoreEntity = world.GetEntity(scoreTag);
-        var scoreText = world.GetComponent<Text>(scoreEntity);
+    private void UpdateScore(Entity playerEntity, Entity scoreEntity, ref int lastScore)
+    {
+        var score = _world.GetComponent<PlayerScore>(playerEntity).Score;
+        if (score == lastScore)
+            return;
 
-        world.AddComponent(scoreEntity, scoreText with { Content = playerScore.Score.ToString() });
+        lastScore = score;
+        var scoreText = _world.GetComponent<Text>(scoreEntity);
+        _world.AddComponent(scoreEntity, scoreText with { Content = score.ToString() });
     }
 }

--- a/Samples/Pong/Systems/ResetBallSystem.cs
+++ b/Samples/Pong/Systems/ResetBallSystem.cs
@@ -6,23 +6,25 @@ using Yaeger.Systems;
 
 namespace Pong.Systems;
 
-public class ResetBallSystem(World world) : IUpdateSystem
+public class ResetBallSystem : IUpdateSystem
 {
+    private readonly World _world;
+    private readonly Entity _ballEntity;
+
+    public ResetBallSystem(World world)
+    {
+        _world = world;
+        _ballEntity = world.GetEntity(EntityTags.Ball);
+    }
+
     public void Update(float deltaTime)
     {
-        var ballEntity = world.GetEntity(EntityTags.Ball);
-
-        if (!world.TryGetComponent(ballEntity, out Ball ball) || ball.State != BallState.Scored)
-        {
+        if (!_world.TryGetComponent(_ballEntity, out Ball ball) || ball.State != BallState.Scored)
             return;
-        }
 
-        // Reset the ball position and velocity
-        var transform = world.GetComponent<Transform2D>(ballEntity);
-        world.AddComponent(ballEntity, transform with { Position = Vector2.Zero });
-        world.AddComponent(ballEntity, new Velocity(Vector2.Zero));
-
-        // Reset the ball state
-        world.AddComponent(ballEntity, ball with { State = BallState.Waiting });
+        var transform = _world.GetComponent<Transform2D>(_ballEntity);
+        _world.AddComponent(_ballEntity, transform with { Position = Vector2.Zero });
+        _world.AddComponent(_ballEntity, new Velocity(Vector2.Zero));
+        _world.AddComponent(_ballEntity, ball with { State = BallState.Waiting });
     }
 }

--- a/Samples/Pong/Systems/ScoringSystem.cs
+++ b/Samples/Pong/Systems/ScoringSystem.cs
@@ -13,23 +13,15 @@ public class ScoringSystem(World world) : IUpdateSystem
         var transform = world.GetComponent<Transform2D>(ballEntity);
         var bounds = world.GetComponent<Bounds>(ballEntity);
 
-        // Check for score
-        // Ball bounds
         var ballPos = transform.Position;
         var ballScale = transform.Scale;
         var ballHalf = ballScale / 2f;
 
-        // Left player scored
         if (ballPos.X + ballHalf.X > bounds.MaxX)
-        {
             HandleScore(EntityTags.LeftPaddle, Player.Right, ballEntity);
-        }
 
-        // Right player scored
         if (ballPos.X - ballHalf.X < bounds.MinX)
-        {
             HandleScore(EntityTags.RightPaddle, Player.Left, ballEntity);
-        }
     }
 
     private void HandleScore(string playerTag, Player server, Entity ballEntity)

--- a/Samples/TextRenderingExample/Program.cs
+++ b/Samples/TextRenderingExample/Program.cs
@@ -17,7 +17,7 @@ window.OnLoad += OnLoad;
 window.OnRender += OnRender;
 window.OnClosing += OnClosing;
 
-Keyboard.AddKeyDown(Keys.Escape, () => window.Close());
+Keyboard.AddKeyDown(Keys.Escape, window.Close);
 
 window.Run();
 
@@ -25,52 +25,35 @@ Console.WriteLine("Window closed");
 
 return;
 
+void AddTextOverlay(Font font, string content, Vector2 position, int fontSize, Color color)
+{
+    var entity = world.CreateEntity();
+    world.AddComponent(entity, new Text(content, font, fontSize, color));
+    world.AddComponent(
+        entity,
+        new Transform2D { Position = position, Scale = new Vector2(0.003f, 0.003f) }
+    );
+}
+
 void OnLoad()
 {
     Console.WriteLine("Text Rendering Example - Loading...");
 
     var defaultFont = fontManager.Load("Assets/Roboto-Regular.ttf");
 
-    var textEntity = world.CreateEntity();
-    world.AddComponent(textEntity, new Text("Hello, Yaeger!", defaultFont, 24, Color.White));
-    world.AddComponent(
-        textEntity,
-        new Transform2D
-        {
-            Position = new Vector2(-0.95f, 0),
-            Scale = new Vector2(0.003f, 0.003f), // Scale down for screen-space rendering
-        }
+    AddTextOverlay(defaultFont, "Hello, Yaeger!", new Vector2(-0.95f, 0), 24, Color.White);
+    AddTextOverlay(
+        defaultFont,
+        "The quick brown fox jumps over the lazy dog",
+        new Vector2(-0.95f, -0.2f),
+        16,
+        Color.Green
     );
-
-    var textEntity2 = world.CreateEntity();
-    world.AddComponent(
-        textEntity2,
-        new Text("The quick brown fox jumps over the lazy dog", defaultFont, 16, Color.Green)
-    );
-    world.AddComponent(
-        textEntity2,
-        new Transform2D
-        {
-            Position = new Vector2(-0.95f, -0.2f),
-            Scale = new Vector2(0.003f, 0.003f), // Scale down for screen-space rendering
-        }
-    );
-
-    var textEntity3 = world.CreateEntity();
-    world.AddComponent(textEntity3, new Text("Press ESC to exit", defaultFont, 8, Color.Blue));
-    world.AddComponent(
-        textEntity3,
-        new Transform2D
-        {
-            Position = new Vector2(-0.95f, -0.4f),
-            Scale = new Vector2(0.003f, 0.003f), // Scale down for screen-space rendering
-        }
-    );
+    AddTextOverlay(defaultFont, "Press ESC to exit", new Vector2(-0.95f, -0.4f), 8, Color.Blue);
 }
 
 void OnRender(double deltaTime)
 {
-    // Render all text entities
     textRenderSystem.Render();
 }
 


### PR DESCRIPTION
## Summary

- **Pong/PrintScoreSystem**: cache entity handles in constructor, add dirty flag so `AddComponent` only fires on score change (was writing every frame at 60fps)
- **Pong/PhysicsSystem**: replace `.First()` (heap-allocating LINQ per frame) with cached ball entity via `GetEntity`; remove WHAT comments
- **Pong/ResetBallSystem**: cache ball entity in constructor
- **Pong/InputSystem**: unify duplicate left/right switch branches into a single key-pair lookup; remove no-op `* 1.0f` multiplications and WHAT comments
- **Pong/MoveSystem, ScoringSystem**: remove WHAT comments
- **Pong/Program**: delete dead commented-out audio block; replace block-body escape lambda with method group; replace unbounded `Stack<int>` + `.Average()` with O(1) running sum
- **Pong/EntityFactory**: extract shared `scoreScale` constant, remove duplicate inline comments
- **BatchRenderingExample/PhysicsSystem**: guard velocity `AddComponent` behind a value-change check (skips write on non-bouncing frames)
- **BatchRenderingExample/Program**: escape lambda → method group
- **Animation2D/Program**: consolidate three `OnUpdate` subscriptions into one; add dirty flag for label text so glyph atlas is not invalidated every frame; remove WHAT comments
- **TextRenderingExample/Program**: extract `AddTextOverlay` helper to eliminate repeated inline entity creation; escape lambda → method group; remove WHAT comment

## Test plan

- [x] `dotnet build yaeger.sln` — 0 errors, 0 warnings
- [x] `dotnet test` — 184/184 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)