### PR TITLE
fix(font): support non-power-of-two font sizes

### DIFF
--- a/Samples/TextRenderingExample/Program.cs
+++ b/Samples/TextRenderingExample/Program.cs
@@ -41,15 +41,33 @@ void OnLoad()
 
     var defaultFont = fontManager.Load("Assets/Roboto-Regular.ttf");
 
-    AddTextOverlay(defaultFont, "Hello, Yaeger!", new Vector2(-0.95f, 0), 24, Color.White);
+    // The mix of sizes below is deliberate and doubles as a visual regression test:
+    //   - Multiple sizes of one font coexist — proves the atlas is keyed by (font, size)
+    //     rather than font alone (fix for a bug where the first size rendered became
+    //     permanent for the rest of the session).
+    //   - 22, 18, 14, 10 are NOT multiples of 4 — proves the glyph upload path respects
+    //     GL_UNPACK_ALIGNMENT = 1 (fix for a bug where sub-multiple-of-4 sizes produced
+    //     sheared/striped glyphs). If any of these lines render as stripes rather than
+    //     readable text, the alignment fix has regressed.
+
+    AddTextOverlay(defaultFont, "Hello, Yaeger!", new Vector2(-0.95f, 0.60f), 32, Color.White);
     AddTextOverlay(
         defaultFont,
         "The quick brown fox jumps over the lazy dog",
-        new Vector2(-0.95f, -0.2f),
-        16,
+        new Vector2(-0.95f, 0.35f),
+        22,
         Color.Green
     );
-    AddTextOverlay(defaultFont, "Press ESC to exit", new Vector2(-0.95f, -0.4f), 8, Color.Blue);
+    AddTextOverlay(
+        defaultFont,
+        "fontSize 18 renders cleanly (not a multiple of 4)",
+        new Vector2(-0.95f, 0.15f),
+        18,
+        Color.White
+    );
+    AddTextOverlay(defaultFont, "and 14 too", new Vector2(-0.95f, 0.00f), 14, Color.White);
+    AddTextOverlay(defaultFont, "even 10 pt", new Vector2(-0.95f, -0.12f), 10, Color.White);
+    AddTextOverlay(defaultFont, "Press ESC to exit", new Vector2(-0.95f, -0.30f), 16, Color.Blue);
 }
 
 void OnRender(double deltaTime)

--- a/Samples/TextRenderingExample/README.md
+++ b/Samples/TextRenderingExample/README.md
@@ -28,6 +28,18 @@ dotnet run --project Samples/TextRenderingExample/TextRenderingExample.csproj
 4. **Text Rendering**: Efficient rendering of text using batch rendering
 5. **Text Shaping**: Proper text layout with HarfBuzz
 
+## Visual regression test
+
+The sample's font-size mix is chosen to catch two bugs that previously broke
+text rendering for everything except powers of 2:
+
+- **Multiple sizes in one scene** (32, 22, 18, 14, 10, 16). Each must render at
+  its requested size. If they all render at one size, the glyph-atlas cache
+  has regressed to keying by `Font` alone.
+- **Non-multiple-of-4 sizes** (22, 18, 14, 10). Each must render as readable
+  glyphs. If any appear as sheared stripes, the glyph upload path has
+  regressed on OpenGL pixel-store state (`GL_UNPACK_ALIGNMENT`).
+
 ## Implementation Details
 
 The example demonstrates the complete text rendering pipeline:

--- a/src/Engine/Yaeger/Font/GlyphAtlas.cs
+++ b/src/Engine/Yaeger/Font/GlyphAtlas.cs
@@ -142,8 +142,9 @@ public class GlyphAtlas : IDisposable
         if (pixmap != null)
         {
             var pixelSpan = pixmap.GetPixelSpan();
-            // Upload to texture atlas
-            _texture.SetData(pixelSpan, x, y, _fontSize, _fontSize);
+            // RowBytes (bytes per row) == row length in pixels for Alpha8 (1 byte per pixel).
+            // Pass it through so GL knows the actual stride if SkiaSharp padded rows internally.
+            _texture.SetData(pixelSpan, x, y, _fontSize, _fontSize, pixmap.RowBytes);
         }
 
         // Create atlas glyph with actual metrics

--- a/src/Engine/Yaeger/Rendering/FontTexture.cs
+++ b/src/Engine/Yaeger/Rendering/FontTexture.cs
@@ -67,33 +67,29 @@ public class FontTexture : IDisposable
         _gl.BindTexture(TextureTarget.Texture2D, 0);
     }
 
-    public void SetData<T>(ReadOnlySpan<T> data, int xOffset, int yOffset, int width, int height)
+    public void SetData<T>(
+        ReadOnlySpan<T> data,
+        int xOffset,
+        int yOffset,
+        int width,
+        int height,
+        int sourceRowLengthInPixels = 0
+    )
         where T : unmanaged
     {
         Bind();
-        unsafe
-        {
-            fixed (void* d = data)
-            {
-                _gl.TexSubImage2D(
-                    TextureTarget.Texture2D,
-                    0,
-                    xOffset,
-                    yOffset,
-                    (uint)width,
-                    (uint)height,
-                    PixelFormat.Red,
-                    PixelType.UnsignedByte,
-                    d
-                );
-            }
-        }
-        Unbind();
-    }
 
-    public void SetData(Span<Byte> data, int xOffset, int yOffset, int width, int height)
-    {
-        Bind();
+        // R8 uploads are byte-aligned; the default GL_UNPACK_ALIGNMENT of 4 assumes rows
+        // are padded to 4-byte boundaries, which silently corrupts glyph uploads whenever
+        // `width % 4 != 0`. If the source's row stride differs from `width`, also set
+        // UNPACK_ROW_LENGTH so GL reads rows at the correct offset.
+        _gl.PixelStore(PixelStoreParameter.UnpackAlignment, 1);
+        var needsRowLength = sourceRowLengthInPixels != 0 && sourceRowLengthInPixels != width;
+        if (needsRowLength)
+        {
+            _gl.PixelStore(PixelStoreParameter.UnpackRowLength, sourceRowLengthInPixels);
+        }
+
         unsafe
         {
             fixed (void* d = data)
@@ -111,6 +107,14 @@ public class FontTexture : IDisposable
                 );
             }
         }
+
+        // Restore GL defaults so non-font texture uploads elsewhere aren't affected.
+        if (needsRowLength)
+        {
+            _gl.PixelStore(PixelStoreParameter.UnpackRowLength, 0);
+        }
+        _gl.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
+
         Unbind();
     }
 

--- a/src/Engine/Yaeger/Rendering/TextRenderer.cs
+++ b/src/Engine/Yaeger/Rendering/TextRenderer.cs
@@ -14,7 +14,10 @@ public class TextRenderer : IDisposable
 {
     private readonly GL _gl;
     private readonly Shader _textShader;
-    private readonly Dictionary<Font.Font, GlyphAtlas> _glyphAtlases = new();
+
+    // Keyed by (font, fontSize) so the same font rendered at different sizes gets its own
+    // atlas. Previously keyed by Font alone, which silently reused the first size forever.
+    private readonly Dictionary<(Font.Font Font, int FontSize), GlyphAtlas> _glyphAtlases = new();
     private readonly FontVertexArray _vao;
     private readonly Buffer<float> _vbo;
     private readonly Buffer<uint> _ebo;
@@ -95,13 +98,14 @@ public class TextRenderer : IDisposable
     /// </summary>
     private GlyphAtlas GetOrCreateAtlas(Font.Font font, int fontSize = 48)
     {
-        if (_glyphAtlases.TryGetValue(font, out var atlas))
+        var key = (font, fontSize);
+        if (_glyphAtlases.TryGetValue(key, out var atlas))
         {
             return atlas;
         }
 
         atlas = new GlyphAtlas(_gl, font, fontSize);
-        _glyphAtlases[font] = atlas;
+        _glyphAtlases[key] = atlas;
         return atlas;
     }
 


### PR DESCRIPTION
## Summary

Fixes the "fontSize must be a power of 2" symptom. Two independent bugs stacked together — neither is actually a power-of-2 constraint, but their combination made only a specific subset of sizes work:

1. **`TextRenderer._glyphAtlases` was keyed by `Font` alone.** The first `fontSize` rendered for a font became permanent; every subsequent `Text` with a different size silently reused the original atlas. The `FontSize` field on `Text` was effectively vestigial after the first render.
2. **`FontTexture.SetData` didn't configure OpenGL pixel-store state.** With `GL_UNPACK_ALIGNMENT` at its default of 4, uploading a `fontSize × fontSize` R8 sub-image at non-multiple-of-4 sizes made GL read each row starting in the middle of the previous row. Glyphs came out sheared into stripes.

User confirmed both cases via smoke test — the sheared output at `fontSize=14` and the persisted first-size on fontSize changes.

## Why "powers of 2" seemed special

The subset `{8, 16, 32, 64}` was coincidentally the set of sizes the user tested. All are multiples of 4 (passes the alignment gate) AND divisors of the 512px atlas (fills the grid cleanly). Multiples of 4 that aren't powers of 2 (12, 20, 24, 28, 48) were just untested — they hit the same good path.

## Commits

- **`3848783`** — Key atlas cache by `(Font, FontSize)` so sizes don't collide.
- **`433fc50`** — Set `GL_UNPACK_ALIGNMENT=1` and `GL_UNPACK_ROW_LENGTH=pixmap.RowBytes` for glyph uploads; restore defaults after so state doesn't leak to sprite texture uploads. Dropped the unused `SetData(Span<byte>, ...)` overload.

Each fix is independently useful — split into two commits so `git bisect` can isolate.

## API changes

Internal only:
- `FontTexture.SetData<T>(..., int sourceRowLengthInPixels = 0)` — new optional parameter. `0` (default) = use `width` as stride, matching the old behaviour for callers that don't care.
- `FontTexture.SetData(Span<byte>, ...)` overload removed (was unused).

## Tests

- Existing 192 unit tests pass.
- Rendering isn't unit-tested per repo convention (`CLAUDE.md`: "Rendering, windowing, input, and audio are not unit-tested").
- **Visual verification required on merge**: `TextRenderingExample` with `fontSize` values `14`, `18`, `22`, `26` should render clean glyphs instead of sheared stripes; multi-size text in the same frame (e.g., the existing 24 / 16 / 8 in `TextRenderingExample.Program.cs`) should now render at the correct sizes instead of all three using whichever was rendered first.

## Non-goals for this PR

- Atlas doesn't auto-grow when the glyph grid fills up. For `fontSize > 512 / ⌈√ expected_glyphs⌉` you still lose glyphs. Separate concern — document as a known limitation or add dynamic atlas resizing later.
- Glyph cells are still `fontSize × fontSize` squares regardless of actual glyph width, wasting atlas space on thin characters like `i` and `|`. Packer-based allocation is a larger rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)