### PR TITLE
Add deterministic render layers with unified draw ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Yaeger is a modular, experimental 2D game engine written in C#. It aims to provi
 ## Features
 
 - Entity-Component-System (ECS) architecture
-- 2D rendering with Silk.NET (texture-batched sprites, one draw call per texture per frame)
+- 2D rendering with Silk.NET (texture-batched sprites with deterministic ordering)
+- Deterministic layered draw ordering via `RenderLayer` and `UnifiedRenderSystem`
 - Opt-in 2D camera (pan / zoom / rotate; world-space sprites + screen-space text)
 - Input handling (keyboard, mouse)
 - Sample games (see `Samples/Pong`, `Samples/BouncingBalls`, `Samples/Animation2D`, `Samples/CameraDemo`)

--- a/docs/camera.md
+++ b/docs/camera.md
@@ -39,6 +39,6 @@ If you need world-anchored labels (e.g., a name floating above a sprite), positi
 
 ## Known limitations
 
-- No depth sorting — draw order is texture-group order, as before.
+- Deterministic layered ordering is available via `UnifiedRenderSystem` + `RenderLayer`. Legacy `RenderSystem` and `TextRenderSystem` still run as separate passes.
 - No camera shake / follow systems yet — they'd be separate systems that mutate `Camera2D.Position` before `RenderSystem.Render()` runs.
 - No viewport sub-regions (split-screen).

--- a/docs/camera.md
+++ b/docs/camera.md
@@ -39,6 +39,6 @@ If you need world-anchored labels (e.g., a name floating above a sprite), positi
 
 ## Known limitations
 
-- Deterministic layered ordering is available via `UnifiedRenderSystem` + `RenderLayer`. Legacy `RenderSystem` and `TextRenderSystem` still run as separate passes.
+- Legacy `RenderSystem` and `TextRenderSystem` run in separate passes, so they cannot provide deterministic mixed sprite/text ordering. Use `UnifiedRenderSystem` + `RenderLayer` when you need explicit layering.
 - No camera shake / follow systems yet — they'd be separate systems that mutate `Camera2D.Position` before `RenderSystem.Render()` runs.
 - No viewport sub-regions (split-screen).

--- a/docs/scenes.md
+++ b/docs/scenes.md
@@ -59,7 +59,7 @@ var saver = new SceneSaver(registry);
 saver.Save(world, "Scenes/level1.json");   // writes an indented JSON scene file
 ```
 
-`SceneSaver` iterates every entity in `world.Entities` (in ascending `Entity.Id` order) and, for each entity, asks every registered `IComponentSerializer` to serialize its component via `TrySerialize(world, entity)`. Serializers that return `null` (e.g. when the entity does not carry that component type) are silently skipped. Paths passed to `Save` are resolved via `AssetPath.Resolve` (against `AppContext.BaseDirectory`), matching the `SceneLoader.Load` convention so a relative path like `"Scenes/level1.json"` targets the same file in both directions.
+`SceneSaver` enumerates `world.Entities`, sorts them by ascending `Entity.Id`, and, for each entity, asks every registered `IComponentSerializer` to serialize its component via `TrySerialize(world, entity)`. Serializers that return `null` (e.g. when the entity does not carry that component type) are silently skipped. Paths passed to `Save` are resolved via `AssetPath.Resolve` (against `AppContext.BaseDirectory`), matching the `SceneLoader.Load` convention so a relative path like `"Scenes/level1.json"` targets the same file in both directions.
 
 All six engine-provided serializers support the write direction. Custom serializers opt in by overriding the default `TrySerialize` method on `IComponentSerializer`; they must return a `JsonObject` that includes a non-empty `"type"` field — `SceneSaver` throws `SceneSaveException` if that contract is violated.
 

--- a/docs/scenes.md
+++ b/docs/scenes.md
@@ -13,7 +13,8 @@ Scenes extend the existing prefab pipeline — they reuse `ComponentRegistry` an
       "tag": "player",
       "components": [
         { "type": "Sprite", "texturePath": "Assets/player.png" },
-        { "type": "Transform2D", "position": [0.0, 0.0], "scale": [0.1, 0.1] }
+        { "type": "Transform2D", "position": [0.0, 0.0], "scale": [0.1, 0.1] },
+        { "type": "RenderLayer", "value": 5 }
       ]
     },
     {
@@ -60,7 +61,7 @@ saver.Save(world, "Scenes/level1.json");   // writes an indented JSON scene file
 
 `SceneSaver` iterates every entity in `world.Entities` (in ascending `Entity.Id` order) and, for each entity, asks every registered `IComponentSerializer` to serialize its component via `TrySerialize(world, entity)`. Serializers that return `null` (e.g. when the entity does not carry that component type) are silently skipped. Paths passed to `Save` are resolved via `AssetPath.Resolve` (against `AppContext.BaseDirectory`), matching the `SceneLoader.Load` convention so a relative path like `"Scenes/level1.json"` targets the same file in both directions.
 
-All five engine-provided serializers support the write direction. Custom serializers opt in by overriding the default `TrySerialize` method on `IComponentSerializer`; they must return a `JsonObject` that includes a non-empty `"type"` field — `SceneSaver` throws `SceneSaveException` if that contract is violated.
+All six engine-provided serializers support the write direction. Custom serializers opt in by overriding the default `TrySerialize` method on `IComponentSerializer`; they must return a `JsonObject` that includes a non-empty `"type"` field — `SceneSaver` throws `SceneSaveException` if that contract is violated.
 
 ### Round-trip
 

--- a/src/Engine/Yaeger/ECS/Serializers/EngineComponentRegistryExtensions.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/EngineComponentRegistryExtensions.cs
@@ -14,6 +14,7 @@ public static class EngineComponentRegistryExtensions
     ///   <item><see cref="Yaeger.Graphics.SpriteSheet"/> – type id <c>"SpriteSheet"</c></item>
     ///   <item><see cref="Yaeger.Graphics.Animation"/> – type id <c>"Animation"</c></item>
     ///   <item><see cref="Yaeger.Graphics.AnimationState"/> – type id <c>"AnimationState"</c></item>
+    ///   <item><see cref="Yaeger.Graphics.RenderLayer"/> – type id <c>"RenderLayer"</c></item>
     /// </list>
     /// </summary>
     /// <returns>The same <paramref name="registry"/> for method chaining.</returns>
@@ -24,6 +25,7 @@ public static class EngineComponentRegistryExtensions
         registry.Register(new SpriteSheetSerializer());
         registry.Register(new AnimationSerializer());
         registry.Register(new AnimationStateSerializer());
+        registry.Register(new RenderLayerSerializer());
         return registry;
     }
 }

--- a/src/Engine/Yaeger/ECS/Serializers/RenderLayerSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/RenderLayerSerializer.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Yaeger.Graphics;
+
+namespace Yaeger.ECS.Serializers;
+
+/// <summary>
+/// Serializer for the <see cref="RenderLayer"/> component.
+/// </summary>
+/// <remarks>
+/// JSON format:
+/// <code>
+/// { "type": "RenderLayer", "value": 10 }
+/// </code>
+/// The value defaults to 0 when omitted.
+/// </remarks>
+public sealed class RenderLayerSerializer : IComponentSerializer
+{
+    /// <inheritdoc/>
+    public string TypeId => "RenderLayer";
+
+    /// <inheritdoc/>
+    public Action<World, Entity> Deserialize(JsonElement element)
+    {
+        var value = 0;
+        if (element.TryGetProperty("value", out var valueEl) && !valueEl.TryGetInt32(out value))
+        {
+            throw new PrefabLoadException("RenderLayer 'value' must be an integer.");
+        }
+
+        var component = new RenderLayer(value);
+        return (world, entity) => world.AddComponent(entity, component);
+    }
+
+    /// <inheritdoc/>
+    public JsonNode? TrySerialize(World world, Entity entity)
+    {
+        if (!world.TryGetComponent<RenderLayer>(entity, out var renderLayer))
+            return null;
+
+        return new JsonObject { ["type"] = TypeId, ["value"] = renderLayer.Value };
+    }
+}

--- a/src/Engine/Yaeger/Graphics/RenderLayer.cs
+++ b/src/Engine/Yaeger/Graphics/RenderLayer.cs
@@ -1,0 +1,7 @@
+namespace Yaeger.Graphics;
+
+/// <summary>
+/// Component that controls deterministic draw order for renderable entities.
+/// Lower values render first; higher values render on top.
+/// </summary>
+public readonly record struct RenderLayer(int Value = 0);

--- a/src/Engine/Yaeger/Rendering/Renderer.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer.cs
@@ -1,13 +1,13 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Silk.NET.OpenGL;
 using Yaeger.Windowing;
 
 namespace Yaeger.Rendering;
 
 /// <summary>
-/// Renders quads in batches grouped by texture to minimise OpenGL state changes.
+/// Renders quads in deterministic submission order, batching contiguous quads that
+/// share a texture to minimise OpenGL state changes.
 /// Submit quads with <see cref="SubmitQuad(Matrix4x4, string)"/> or its UV-aware overload;
 /// draw calls are issued during <see cref="EndFrame"/>.
 /// </summary>
@@ -62,7 +62,7 @@ public class Renderer : IDisposable
         MaxQuadsPerBatch * VerticesPerQuad * FloatsPerVertex
     ];
 
-    private readonly Dictionary<string, List<QuadSubmission>> _batchQueue = new();
+    private readonly List<QuadSubmission> _submissionQueue = [];
 
     private Matrix4x4 _viewProjection = Matrix4x4.Identity;
 
@@ -101,10 +101,7 @@ public class Renderer : IDisposable
         _gl.ClearColor(0f, 0f, 0f, 1f);
         _gl.Clear((uint)ClearBufferMask.ColorBufferBit);
 
-        foreach (var submissions in _batchQueue.Values)
-        {
-            submissions.Clear();
-        }
+        _submissionQueue.Clear();
 
         CheckGlError();
     }
@@ -148,29 +145,48 @@ public class Renderer : IDisposable
         Vector4 color
     )
     {
-        ref var submissions = ref CollectionsMarshal.GetValueRefOrAddDefault(
-            _batchQueue,
-            texturePath,
-            out _
-        );
-        submissions ??= [];
-        submissions.Add(new QuadSubmission(model, uvMin, uvMax, color));
+        _submissionQueue.Add(new QuadSubmission(texturePath, model, uvMin, uvMax, color));
     }
 
-    /// <summary>Flushes all queued quads. One draw call per texture (split into batches of 1000).</summary>
+    /// <summary>
+    /// Flushes all queued quads, preserving submission order and batching contiguous
+    /// quads that share a texture (up to 1000 quads per draw call).
+    /// </summary>
     public void EndFrame()
     {
-        foreach (var (texturePath, submissions) in _batchQueue)
-        {
-            if (submissions.Count == 0)
-            {
-                continue;
-            }
-            RenderBatch(texturePath, submissions);
-        }
+        FlushQueuedQuads();
     }
 
-    private void RenderBatch(string texturePath, List<QuadSubmission> submissions)
+    /// <summary>
+    /// Flushes queued quads immediately while preserving submission order.
+    /// </summary>
+    public void FlushQueuedQuads()
+    {
+        if (_submissionQueue.Count == 0)
+            return;
+
+        var startIndex = 0;
+        while (startIndex < _submissionQueue.Count)
+        {
+            var texturePath = _submissionQueue[startIndex].TexturePath;
+            var batchSize = 1;
+            while (
+                startIndex + batchSize < _submissionQueue.Count
+                && batchSize < MaxQuadsPerBatch
+                && _submissionQueue[startIndex + batchSize].TexturePath == texturePath
+            )
+            {
+                batchSize++;
+            }
+
+            RenderBatch(texturePath, startIndex, batchSize);
+            startIndex += batchSize;
+        }
+
+        _submissionQueue.Clear();
+    }
+
+    private void RenderBatch(string texturePath, int startIndex, int batchSize)
     {
         var texture = _textureManager.Get(texturePath);
         _textureShader.Bind();
@@ -179,19 +195,15 @@ public class Renderer : IDisposable
         _vao.Bind();
         _vbo.Bind();
 
-        for (var i = 0; i < submissions.Count; i += MaxQuadsPerBatch)
-        {
-            var batchSize = Math.Min(MaxQuadsPerBatch, submissions.Count - i);
-            FillVertexBuffer(submissions, i, batchSize);
-            DrawBatch(batchSize);
-        }
+        FillVertexBuffer(startIndex, batchSize);
+        DrawBatch(batchSize);
 
         _vao.Unbind();
         texture.Unbind();
         _textureShader.Unbind();
     }
 
-    private void FillVertexBuffer(List<QuadSubmission> submissions, int startIndex, int count)
+    private void FillVertexBuffer(int startIndex, int count)
     {
         // Corner order must match the quad winding baked into QuadIndexing: TR, BR, BL, TL.
         ReadOnlySpan<Vector3> basePositions =
@@ -204,7 +216,7 @@ public class Renderer : IDisposable
 
         for (var q = 0; q < count; q++)
         {
-            var submission = submissions[startIndex + q];
+            var submission = _submissionQueue[startIndex + q];
             var transform = submission.Transform;
             var uvMin = submission.UvMin;
             var uvMax = submission.UvMax;
@@ -293,6 +305,7 @@ public class Renderer : IDisposable
     }
 
     private readonly record struct QuadSubmission(
+        string TexturePath,
         Matrix4x4 Transform,
         Vector2 UvMin,
         Vector2 UvMax,

--- a/src/Engine/Yaeger/Rendering/Renderer.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer.cs
@@ -9,7 +9,8 @@ namespace Yaeger.Rendering;
 /// Renders quads in deterministic submission order, batching contiguous quads that
 /// share a texture to minimise OpenGL state changes.
 /// Submit quads with <see cref="SubmitQuad(Matrix4x4, string)"/> or its UV-aware overload;
-/// draw calls are issued during <see cref="EndFrame"/>.
+/// draw calls are issued when queued quads are flushed via
+/// <see cref="FlushQueuedQuads"/> or <see cref="EndFrame"/>.
 /// </summary>
 public class Renderer : IDisposable
 {
@@ -150,7 +151,8 @@ public class Renderer : IDisposable
 
     /// <summary>
     /// Flushes all queued quads, preserving submission order and batching contiguous
-    /// quads that share a texture (up to 1000 quads per draw call).
+    /// quads that share a texture (up to 1000 quads per draw call), by delegating to
+    /// <see cref="FlushQueuedQuads"/>.
     /// </summary>
     public void EndFrame()
     {

--- a/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
@@ -8,7 +8,7 @@ namespace Yaeger.Systems;
 
 /// <summary>
 /// Renders sprites, sprite sheets, and text in a shared deterministic order using
-/// <see cref="RenderLayer"/> and <see cref="Entity.Id"/> as sort keys.
+/// <see cref="RenderLayer"/>, <see cref="Entity.Id"/>, and command kind as sort keys.
 /// </summary>
 public class UnifiedRenderSystem(
     Renderer renderer,

--- a/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
@@ -1,0 +1,249 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Rendering;
+using Yaeger.Windowing;
+
+namespace Yaeger.Systems;
+
+/// <summary>
+/// Renders sprites, sprite sheets, and text in a shared deterministic order using
+/// <see cref="RenderLayer"/> and <see cref="Entity.Id"/> as sort keys.
+/// </summary>
+public class UnifiedRenderSystem(
+    Renderer renderer,
+    TextRenderer textRenderer,
+    World world,
+    Window? window = null
+)
+{
+    private readonly List<RenderCommand> _commands = [];
+
+    public void Render()
+    {
+        UpdateCamera();
+        BuildCommandQueue();
+
+        renderer.BeginFrame();
+
+        foreach (var command in _commands)
+        {
+            switch (command.Kind)
+            {
+                case RenderCommandKind.Sprite:
+                    renderer.SubmitQuad(command.Transform, command.TexturePath!, command.Color);
+                    break;
+                case RenderCommandKind.SpriteSheet:
+                    renderer.SubmitQuad(
+                        command.Transform,
+                        command.TexturePath!,
+                        command.UvMin,
+                        command.UvMax,
+                        command.Color
+                    );
+                    break;
+                case RenderCommandKind.Text:
+                    renderer.FlushQueuedQuads();
+                    textRenderer.DrawText(
+                        command.TextComponent.Content,
+                        command.Transform,
+                        command.TextComponent.Font,
+                        command.TextComponent.FontSize,
+                        command.TextComponent.Color
+                    );
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unknown render command kind: {command.Kind}"
+                    );
+            }
+        }
+
+        renderer.EndFrame();
+    }
+
+    private void BuildCommandQueue()
+    {
+        _commands.Clear();
+
+        var renderLayerStore = world.GetStore<RenderLayer>();
+        var spriteSheetStore = world.GetStore<SpriteSheet>();
+        var animationStateStore = world.GetStore<AnimationState>();
+
+        foreach (
+            (Entity entity, Sprite sprite, Transform2D transform) in world.Query<
+                Sprite,
+                Transform2D
+            >()
+        )
+        {
+            if (spriteSheetStore.TryGet(entity, out _) && animationStateStore.TryGet(entity, out _))
+                continue;
+
+            _commands.Add(
+                RenderCommand.ForSprite(
+                    entity,
+                    GetRenderLayerValue(renderLayerStore, entity),
+                    transform.TransformMatrix,
+                    sprite
+                )
+            );
+        }
+
+        foreach (
+            (
+                Entity entity,
+                SpriteSheet sheet,
+                AnimationState state,
+                Transform2D transform
+            ) in world.Query<SpriteSheet, AnimationState, Transform2D>()
+        )
+        {
+            if (sheet.FrameCount <= 0)
+                continue;
+
+            var frameIndex = Math.Clamp(state.CurrentFrameIndex, 0, sheet.FrameCount - 1);
+            var (uvMin, uvMax) = sheet.GetFrameUv(frameIndex);
+
+            _commands.Add(
+                RenderCommand.ForSpriteSheet(
+                    entity,
+                    GetRenderLayerValue(renderLayerStore, entity),
+                    transform.TransformMatrix,
+                    sheet.TexturePath,
+                    uvMin,
+                    uvMax,
+                    sheet.Tint.ToVector4()
+                )
+            );
+        }
+
+        foreach (
+            (Entity entity, Text text, Transform2D transform) in world.Query<Text, Transform2D>()
+        )
+        {
+            _commands.Add(
+                RenderCommand.ForText(
+                    entity,
+                    GetRenderLayerValue(renderLayerStore, entity),
+                    transform.TransformMatrix,
+                    text
+                )
+            );
+        }
+
+        _commands.Sort(
+            static (a, b) =>
+            {
+                var layerComparison = a.Layer.CompareTo(b.Layer);
+                if (layerComparison != 0)
+                    return layerComparison;
+
+                var entityComparison = a.Entity.Id.CompareTo(b.Entity.Id);
+                if (entityComparison != 0)
+                    return entityComparison;
+
+                return a.Kind.CompareTo(b.Kind);
+            }
+        );
+    }
+
+    private static int GetRenderLayerValue(
+        ComponentStorage<RenderLayer> renderLayerStore,
+        Entity entity
+    ) => renderLayerStore.TryGet(entity, out var renderLayer) ? renderLayer.Value : 0;
+
+    private void UpdateCamera()
+    {
+        // Without a Window we can't derive aspect ratio; leave the renderer's view-projection alone.
+        if (window is null)
+            return;
+
+        foreach (var (_, camera) in world.GetStore<Camera2D>().All())
+        {
+            var size = window.Size;
+            var aspectRatio = size.Y > 0 ? size.X / size.Y : 1f;
+            renderer.SetCamera(camera.ViewProjection(aspectRatio));
+            return;
+        }
+
+        renderer.SetCamera(Matrix4x4.Identity);
+    }
+
+    private enum RenderCommandKind
+    {
+        Sprite = 0,
+        SpriteSheet = 1,
+        Text = 2,
+    }
+
+    private readonly record struct RenderCommand(
+        Entity Entity,
+        int Layer,
+        RenderCommandKind Kind,
+        Matrix4x4 Transform,
+        string? TexturePath,
+        Vector2 UvMin,
+        Vector2 UvMax,
+        Vector4 Color,
+        Text TextComponent
+    )
+    {
+        public static RenderCommand ForSprite(
+            Entity entity,
+            int layer,
+            Matrix4x4 transform,
+            Sprite sprite
+        ) =>
+            new(
+                entity,
+                layer,
+                RenderCommandKind.Sprite,
+                transform,
+                sprite.TexturePath,
+                Vector2.Zero,
+                Vector2.One,
+                sprite.Tint.ToVector4(),
+                default
+            );
+
+        public static RenderCommand ForSpriteSheet(
+            Entity entity,
+            int layer,
+            Matrix4x4 transform,
+            string texturePath,
+            Vector2 uvMin,
+            Vector2 uvMax,
+            Vector4 color
+        ) =>
+            new(
+                entity,
+                layer,
+                RenderCommandKind.SpriteSheet,
+                transform,
+                texturePath,
+                uvMin,
+                uvMax,
+                color,
+                default
+            );
+
+        public static RenderCommand ForText(
+            Entity entity,
+            int layer,
+            Matrix4x4 transform,
+            Text text
+        ) =>
+            new(
+                entity,
+                layer,
+                RenderCommandKind.Text,
+                transform,
+                null,
+                Vector2.Zero,
+                Vector2.One,
+                Vector4.Zero,
+                text
+            );
+    }
+}

--- a/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
@@ -787,7 +787,7 @@ public class PrefabLoaderTests
     // ── RegisterEngineComponents convenience extension ────────────────────────
 
     [Fact]
-    public void RegisterEngineComponents_RegistersAllFiveBuiltInTypes()
+    public void RegisterEngineComponents_RegistersAllSixBuiltInTypes()
     {
         var registry = new ComponentRegistry().RegisterEngineComponents();
 
@@ -796,6 +796,7 @@ public class PrefabLoaderTests
         Assert.Contains("SpriteSheet", registry.RegisteredTypeIds);
         Assert.Contains("Animation", registry.RegisteredTypeIds);
         Assert.Contains("AnimationState", registry.RegisteredTypeIds);
+        Assert.Contains("RenderLayer", registry.RegisteredTypeIds);
     }
 
     // ── PrefabLoader.Load – file-not-found ────────────────────────────────────

--- a/tests/Yaeger.Tests/ECS/RenderLayerSerializerTests.cs
+++ b/tests/Yaeger.Tests/ECS/RenderLayerSerializerTests.cs
@@ -1,0 +1,69 @@
+using Yaeger.ECS;
+using Yaeger.ECS.Serializers;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.ECS;
+
+public class RenderLayerSerializerTests
+{
+    [Fact]
+    public void RenderLayerSerializer_RoundTrip_ThroughPrefabLoader()
+    {
+        var registry = new ComponentRegistry().RegisterEngineComponents();
+        var loader = new PrefabLoader(registry);
+        var prefab = loader.Parse(
+            """{ "components": [ { "type": "RenderLayer", "value": 7 } ] }"""
+        );
+
+        var world = new World();
+        var entity = world.Instantiate(prefab);
+
+        Assert.True(world.TryGetComponent<RenderLayer>(entity, out var renderLayer));
+        Assert.Equal(7, renderLayer.Value);
+    }
+
+    [Fact]
+    public void RenderLayerSerializer_MissingValue_DefaultsToZero()
+    {
+        var registry = new ComponentRegistry().RegisterEngineComponents();
+        var loader = new PrefabLoader(registry);
+        var prefab = loader.Parse("""{ "components": [ { "type": "RenderLayer" } ] }""");
+
+        var world = new World();
+        var entity = world.Instantiate(prefab);
+
+        Assert.True(world.TryGetComponent<RenderLayer>(entity, out var renderLayer));
+        Assert.Equal(0, renderLayer.Value);
+    }
+
+    [Fact]
+    public void RenderLayerSerializer_NonIntegerValue_ThrowsPrefabLoadException()
+    {
+        var registry = new ComponentRegistry().RegisterEngineComponents();
+        var loader = new PrefabLoader(registry);
+
+        var ex = Assert.Throws<PrefabLoadException>(() =>
+            loader.Parse("""{ "components": [ { "type": "RenderLayer", "value": 1.5 } ] }""")
+        );
+
+        Assert.Contains("RenderLayer", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SceneSaver_RenderLayerComponent_ShouldRoundTrip()
+    {
+        var registry = new ComponentRegistry().RegisterEngineComponents();
+        var world = new World();
+        var entity = world.CreateEntity("hud");
+        world.AddComponent(entity, new RenderLayer(11));
+
+        var json = new SceneSaver(registry).Serialize(world);
+
+        var reloaded = new World();
+        reloaded.Instantiate(new SceneLoader(registry).Parse(json));
+
+        Assert.True(reloaded.TryGetEntity("hud", out var reloadedEntity));
+        Assert.True(reloaded.TryGetComponent<RenderLayer>(reloadedEntity, out var renderLayer));
+        Assert.Equal(11, renderLayer.Value);
+    }
+}

--- a/tests/Yaeger.Tests/ECS/RenderLayerSerializerTests.cs
+++ b/tests/Yaeger.Tests/ECS/RenderLayerSerializerTests.cs
@@ -7,7 +7,7 @@ namespace Yaeger.Tests.ECS;
 public class RenderLayerSerializerTests
 {
     [Fact]
-    public void RenderLayerSerializer_RoundTrip_ThroughPrefabLoader()
+    public void RenderLayerSerializer_Deserializes_ThroughPrefabLoader()
     {
         var registry = new ComponentRegistry().RegisterEngineComponents();
         var loader = new PrefabLoader(registry);


### PR DESCRIPTION
## Why
Sprite draw order was tied to texture batching and text rendered in a separate pass, so overlap could be incorrect or inconsistent. This adds deterministic ordering controls that work across sprites, sprite sheets, and text.

## What changed
- Added `RenderLayer` component (`int`, default `0`) for explicit ordering.
- Added `RenderLayerSerializer` and registered it in `RegisterEngineComponents()` so scenes/prefabs can load and save layer data.
- Added `UnifiedRenderSystem` that gathers sprite, sprite-sheet, and text draw commands, sorts by `(RenderLayer, Entity.Id, kind)`, and renders in that order.
- Updated `Renderer` to preserve submission order while still batching contiguous quads that share a texture, and added `FlushQueuedQuads()` to support sprite/text interleaving.
- Updated docs and README to reflect deterministic layered rendering.
- Added tests for `RenderLayer` serializer behavior and registry coverage.

## Notes for reviewers
- `RenderSystem` and `TextRenderSystem` remain available unchanged for backward compatibility.
- Text remains screen-space. `UnifiedRenderSystem` flushes queued sprite quads before each text draw to preserve the shared ordering contract.

## Validation
- `dotnet test --filter "FullyQualifiedName~RenderLayerSerializerTests"`
- `dotnet test --filter "FullyQualifiedName~RegisterEngineComponents_RegistersAllSixBuiltInTypes"`