### PR TITLE
Optimize collision detection query ordering

### DIFF
--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -37,9 +37,9 @@ public class CollisionDetectionSystem(World world)
 
         // Collect all collidable entities with their world positions
         foreach (
-            (Entity entity, Transform2D transform, BoxCollider2D collider) in world.Query<
-                Transform2D,
-                BoxCollider2D
+            (Entity entity, BoxCollider2D collider, Transform2D transform) in world.Query<
+                BoxCollider2D,
+                Transform2D
             >()
         )
         {
@@ -48,9 +48,9 @@ public class CollisionDetectionSystem(World world)
         }
 
         foreach (
-            (Entity entity, Transform2D transform, CircleCollider2D collider) in world.Query<
-                Transform2D,
-                CircleCollider2D
+            (Entity entity, CircleCollider2D collider, Transform2D transform) in world.Query<
+                CircleCollider2D,
+                Transform2D
             >()
         )
         {


### PR DESCRIPTION
## Summary
- switch `CollisionDetectionSystem.Detect()` component query order to iterate `BoxCollider2D`/`CircleCollider2D` stores first, then probe `Transform2D`
- preserve behavior while reducing per-frame iterations and dictionary lookups when many entities have `Transform2D` but fewer have colliders

## Why this change
`World.Query<T1, T2>()` iterates `T1`'s store and probes `T2`. In hot physics scenes, `Transform2D` is usually far more common than colliders, so querying `Transform2D` first wastes work every frame.

## Validation
- `dotnet build yaeger.sln`
- `dotnet test`
- `dotnet csharpier check .`