### PR TITLE
Optimize ECS query iteration and add forced-store overrides

### DIFF
--- a/src/Engine/Yaeger/ECS/ComponentStorage.cs
+++ b/src/Engine/Yaeger/ECS/ComponentStorage.cs
@@ -5,6 +5,8 @@ public class ComponentStorage<T> : IComponentStore
 {
     private readonly Dictionary<Entity, T> _components = new();
 
+    public int Count => _components.Count;
+
     public void Add(Entity entity, T component) => _components[entity] = component;
 
     public bool Remove(Entity entity) => _components.Remove(entity);

--- a/src/Engine/Yaeger/ECS/WorldExtensions.cs
+++ b/src/Engine/Yaeger/ECS/WorldExtensions.cs
@@ -37,6 +37,51 @@ public static class WorldExtensions
     }
 
     /// <summary>
+    /// Queries entities with two components, forcing iteration of a specific component type.
+    /// </summary>
+    /// <param name="forceIndex">The index of the component type to iterate first (0 for T1, 1 for T2).</param>
+    public static IEnumerable<(Entity, T1, T2)> Query<T1, T2>(this World world, int forceIndex)
+        where T1 : struct
+        where T2 : struct
+    {
+        if (forceIndex < 0 || forceIndex > 1)
+            throw new ArgumentOutOfRangeException(nameof(forceIndex), "Must be 0 or 1");
+
+        var store1 = world.GetStore<T1>();
+        var store2 = world.GetStore<T2>();
+
+        return forceIndex == 0 ? QueryFirstStore(store1, store2) : QuerySecondStore(store1, store2);
+
+        static IEnumerable<(Entity, T1, T2)> QueryFirstStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2
+        )
+        {
+            foreach ((Entity entity, T1 c1) in s1.All())
+            {
+                if (s2.TryGet(entity, out var c2))
+                {
+                    yield return (entity, c1, c2);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2)> QuerySecondStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2
+        )
+        {
+            foreach ((Entity entity, T2 c2) in s2.All())
+            {
+                if (s1.TryGet(entity, out var c1))
+                {
+                    yield return (entity, c1, c2);
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Queries entities with three components.
     /// Automatically iterates the smallest component store for better performance.
     /// Use the override method to force iteration of a specific component type.

--- a/src/Engine/Yaeger/ECS/WorldExtensions.cs
+++ b/src/Engine/Yaeger/ECS/WorldExtensions.cs
@@ -2,6 +2,11 @@ namespace Yaeger.ECS;
 
 public static class WorldExtensions
 {
+    /// <summary>
+    /// Queries entities with two components.
+    /// Automatically iterates the smallest component store for better performance.
+    /// Use the override method to force iteration of a specific component type.
+    /// </summary>
     public static IEnumerable<(Entity, T1, T2)> Query<T1, T2>(this World world)
         where T1 : struct
         where T2 : struct
@@ -9,15 +14,33 @@ public static class WorldExtensions
         var store1 = world.GetStore<T1>();
         var store2 = world.GetStore<T2>();
 
-        foreach ((Entity entity, T1 component1) in store1.All())
+        if (store1.Count <= store2.Count)
         {
-            if (store2.TryGet(entity, out var component2))
+            foreach ((Entity entity, T1 component1) in store1.All())
             {
-                yield return (entity, component1, component2);
+                if (store2.TryGet(entity, out var component2))
+                {
+                    yield return (entity, component1, component2);
+                }
+            }
+        }
+        else
+        {
+            foreach ((Entity entity, T2 component2) in store2.All())
+            {
+                if (store1.TryGet(entity, out var component1))
+                {
+                    yield return (entity, component1, component2);
+                }
             }
         }
     }
 
+    /// <summary>
+    /// Queries entities with three components.
+    /// Automatically iterates the smallest component store for better performance.
+    /// Use the override method to force iteration of a specific component type.
+    /// </summary>
     public static IEnumerable<(Entity, T1, T2, T3)> Query<T1, T2, T3>(this World world)
         where T1 : struct
         where T2 : struct
@@ -27,18 +50,138 @@ public static class WorldExtensions
         var store2 = world.GetStore<T2>();
         var store3 = world.GetStore<T3>();
 
-        foreach ((Entity entity, T1 component1) in store1.All())
+        var minStore = MinStoreIndex(store1.Count, store2.Count, store3.Count);
+
+        return minStore switch
         {
-            if (
-                store2.TryGet(entity, out var component2)
-                && store3.TryGet(entity, out var component3)
-            )
+            0 => QueryFirstStore(store1, store2, store3),
+            1 => QuerySecondStore(store1, store2, store3),
+            _ => QueryThirdStore(store1, store2, store3),
+        };
+
+        static IEnumerable<(Entity, T1, T2, T3)> QueryFirstStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T1 c1) in s1.All())
             {
-                yield return (entity, component1, component2, component3);
+                if (s2.TryGet(entity, out var c2) && s3.TryGet(entity, out var c3))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3)> QuerySecondStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T2 c2) in s2.All())
+            {
+                if (s1.TryGet(entity, out var c1) && s3.TryGet(entity, out var c3))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3)> QueryThirdStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T3 c3) in s3.All())
+            {
+                if (s1.TryGet(entity, out var c1) && s2.TryGet(entity, out var c2))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
             }
         }
     }
 
+    /// <summary>
+    /// Queries entities with three components, forcing iteration of a specific component type.
+    /// </summary>
+    /// <param name="forceIndex">The index of the component type to iterate first (0 for T1, 1 for T2, 2 for T3).</param>
+    public static IEnumerable<(Entity, T1, T2, T3)> Query<T1, T2, T3>(
+        this World world,
+        int forceIndex
+    )
+        where T1 : struct
+        where T2 : struct
+        where T3 : struct
+    {
+        if (forceIndex < 0 || forceIndex > 2)
+            throw new ArgumentOutOfRangeException(nameof(forceIndex), "Must be 0, 1, or 2");
+
+        var store1 = world.GetStore<T1>();
+        var store2 = world.GetStore<T2>();
+        var store3 = world.GetStore<T3>();
+
+        return forceIndex switch
+        {
+            0 => QueryFirstStore(store1, store2, store3),
+            1 => QuerySecondStore(store1, store2, store3),
+            _ => QueryThirdStore(store1, store2, store3),
+        };
+
+        static IEnumerable<(Entity, T1, T2, T3)> QueryFirstStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T1 c1) in s1.All())
+            {
+                if (s2.TryGet(entity, out var c2) && s3.TryGet(entity, out var c3))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3)> QuerySecondStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T2 c2) in s2.All())
+            {
+                if (s1.TryGet(entity, out var c1) && s3.TryGet(entity, out var c3))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3)> QueryThirdStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T3 c3) in s3.All())
+            {
+                if (s1.TryGet(entity, out var c1) && s2.TryGet(entity, out var c2))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Queries entities with four components.
+    /// Automatically iterates the smallest component store for better performance.
+    /// Use the override method to force iteration of a specific component type.
+    /// </summary>
     public static IEnumerable<(Entity, T1, T2, T3, T4)> Query<T1, T2, T3, T4>(this World world)
         where T1 : struct
         where T2 : struct
@@ -50,16 +193,229 @@ public static class WorldExtensions
         var store3 = world.GetStore<T3>();
         var store4 = world.GetStore<T4>();
 
-        foreach ((Entity entity, T1 component1) in store1.All())
+        var minStore = MinStoreIndex(store1.Count, store2.Count, store3.Count, store4.Count);
+
+        return minStore switch
         {
-            if (
-                store2.TryGet(entity, out var component2)
-                && store3.TryGet(entity, out var component3)
-                && store4.TryGet(entity, out var component4)
-            )
+            0 => QueryFirstStore(store1, store2, store3, store4),
+            1 => QuerySecondStore(store1, store2, store3, store4),
+            2 => QueryThirdStore(store1, store2, store3, store4),
+            _ => QueryFourthStore(store1, store2, store3, store4),
+        };
+
+        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryFirstStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T1 c1) in s1.All())
             {
-                yield return (entity, component1, component2, component3, component4);
+                if (
+                    s2.TryGet(entity, out var c2)
+                    && s3.TryGet(entity, out var c3)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
             }
         }
+
+        static IEnumerable<(Entity, T1, T2, T3, T4)> QuerySecondStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T2 c2) in s2.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s3.TryGet(entity, out var c3)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryThirdStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T3 c3) in s3.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s2.TryGet(entity, out var c2)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryFourthStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T4 c4) in s4.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s2.TryGet(entity, out var c2)
+                    && s3.TryGet(entity, out var c3)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Queries entities with four components, forcing iteration of a specific component type.
+    /// </summary>
+    /// <param name="forceIndex">The index of the component type to iterate first (0 for T1, 1 for T2, 2 for T3, 3 for T4).</param>
+    public static IEnumerable<(Entity, T1, T2, T3, T4)> Query<T1, T2, T3, T4>(
+        this World world,
+        int forceIndex
+    )
+        where T1 : struct
+        where T2 : struct
+        where T3 : struct
+        where T4 : struct
+    {
+        if (forceIndex < 0 || forceIndex > 3)
+            throw new ArgumentOutOfRangeException(nameof(forceIndex), "Must be 0, 1, 2, or 3");
+
+        var store1 = world.GetStore<T1>();
+        var store2 = world.GetStore<T2>();
+        var store3 = world.GetStore<T3>();
+        var store4 = world.GetStore<T4>();
+
+        return forceIndex switch
+        {
+            0 => QueryFirstStore(store1, store2, store3, store4),
+            1 => QuerySecondStore(store1, store2, store3, store4),
+            2 => QueryThirdStore(store1, store2, store3, store4),
+            _ => QueryFourthStore(store1, store2, store3, store4),
+        };
+
+        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryFirstStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T1 c1) in s1.All())
+            {
+                if (
+                    s2.TryGet(entity, out var c2)
+                    && s3.TryGet(entity, out var c3)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3, T4)> QuerySecondStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T2 c2) in s2.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s3.TryGet(entity, out var c3)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryThirdStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T3 c3) in s3.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s2.TryGet(entity, out var c2)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+
+        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryFourthStore(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T4 c4) in s4.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s2.TryGet(entity, out var c2)
+                    && s3.TryGet(entity, out var c3)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+    }
+
+    private static int MinStoreIndex(int count1, int count2)
+    {
+        return count1 <= count2 ? 0 : 1;
+    }
+
+    private static int MinStoreIndex(int count1, int count2, int count3)
+    {
+        if (count1 <= count2 && count1 <= count3)
+            return 0;
+        if (count2 <= count1 && count2 <= count3)
+            return 1;
+        return 2;
+    }
+
+    private static int MinStoreIndex(int count1, int count2, int count3, int count4)
+    {
+        if (count1 <= count2 && count1 <= count3 && count1 <= count4)
+            return 0;
+        if (count2 <= count1 && count2 <= count3 && count2 <= count4)
+            return 1;
+        if (count3 <= count1 && count3 <= count2 && count3 <= count4)
+            return 2;
+        return 3;
     }
 }

--- a/src/Engine/Yaeger/ECS/WorldExtensions.cs
+++ b/src/Engine/Yaeger/ECS/WorldExtensions.cs
@@ -13,27 +13,8 @@ public static class WorldExtensions
     {
         var store1 = world.GetStore<T1>();
         var store2 = world.GetStore<T2>();
-
-        if (store1.Count <= store2.Count)
-        {
-            foreach ((Entity entity, T1 component1) in store1.All())
-            {
-                if (store2.TryGet(entity, out var component2))
-                {
-                    yield return (entity, component1, component2);
-                }
-            }
-        }
-        else
-        {
-            foreach ((Entity entity, T2 component2) in store2.All())
-            {
-                if (store1.TryGet(entity, out var component1))
-                {
-                    yield return (entity, component1, component2);
-                }
-            }
-        }
+        var minStoreIdx = store1.Count <= store2.Count ? 0 : 1;
+        return Query2Helper<T1, T2>.Execute(minStoreIdx, store1, store2);
     }
 
     /// <summary>
@@ -49,36 +30,7 @@ public static class WorldExtensions
 
         var store1 = world.GetStore<T1>();
         var store2 = world.GetStore<T2>();
-
-        return forceIndex == 0 ? QueryFirstStore(store1, store2) : QuerySecondStore(store1, store2);
-
-        static IEnumerable<(Entity, T1, T2)> QueryFirstStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2
-        )
-        {
-            foreach ((Entity entity, T1 c1) in s1.All())
-            {
-                if (s2.TryGet(entity, out var c2))
-                {
-                    yield return (entity, c1, c2);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2)> QuerySecondStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2
-        )
-        {
-            foreach ((Entity entity, T2 c2) in s2.All())
-            {
-                if (s1.TryGet(entity, out var c1))
-                {
-                    yield return (entity, c1, c2);
-                }
-            }
-        }
+        return Query2Helper<T1, T2>.Execute(forceIndex, store1, store2);
     }
 
     /// <summary>
@@ -94,60 +46,8 @@ public static class WorldExtensions
         var store1 = world.GetStore<T1>();
         var store2 = world.GetStore<T2>();
         var store3 = world.GetStore<T3>();
-
-        var minStore = MinStoreIndex(store1.Count, store2.Count, store3.Count);
-
-        return minStore switch
-        {
-            0 => QueryFirstStore(store1, store2, store3),
-            1 => QuerySecondStore(store1, store2, store3),
-            _ => QueryThirdStore(store1, store2, store3),
-        };
-
-        static IEnumerable<(Entity, T1, T2, T3)> QueryFirstStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3
-        )
-        {
-            foreach ((Entity entity, T1 c1) in s1.All())
-            {
-                if (s2.TryGet(entity, out var c2) && s3.TryGet(entity, out var c3))
-                {
-                    yield return (entity, c1, c2, c3);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3)> QuerySecondStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3
-        )
-        {
-            foreach ((Entity entity, T2 c2) in s2.All())
-            {
-                if (s1.TryGet(entity, out var c1) && s3.TryGet(entity, out var c3))
-                {
-                    yield return (entity, c1, c2, c3);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3)> QueryThirdStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3
-        )
-        {
-            foreach ((Entity entity, T3 c3) in s3.All())
-            {
-                if (s1.TryGet(entity, out var c1) && s2.TryGet(entity, out var c2))
-                {
-                    yield return (entity, c1, c2, c3);
-                }
-            }
-        }
+        var minStoreIdx = MinStoreIndex(store1.Count, store2.Count, store3.Count);
+        return Query3Helper<T1, T2, T3>.Execute(minStoreIdx, store1, store2, store3);
     }
 
     /// <summary>
@@ -168,58 +68,7 @@ public static class WorldExtensions
         var store1 = world.GetStore<T1>();
         var store2 = world.GetStore<T2>();
         var store3 = world.GetStore<T3>();
-
-        return forceIndex switch
-        {
-            0 => QueryFirstStore(store1, store2, store3),
-            1 => QuerySecondStore(store1, store2, store3),
-            _ => QueryThirdStore(store1, store2, store3),
-        };
-
-        static IEnumerable<(Entity, T1, T2, T3)> QueryFirstStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3
-        )
-        {
-            foreach ((Entity entity, T1 c1) in s1.All())
-            {
-                if (s2.TryGet(entity, out var c2) && s3.TryGet(entity, out var c3))
-                {
-                    yield return (entity, c1, c2, c3);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3)> QuerySecondStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3
-        )
-        {
-            foreach ((Entity entity, T2 c2) in s2.All())
-            {
-                if (s1.TryGet(entity, out var c1) && s3.TryGet(entity, out var c3))
-                {
-                    yield return (entity, c1, c2, c3);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3)> QueryThirdStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3
-        )
-        {
-            foreach ((Entity entity, T3 c3) in s3.All())
-            {
-                if (s1.TryGet(entity, out var c1) && s2.TryGet(entity, out var c2))
-                {
-                    yield return (entity, c1, c2, c3);
-                }
-            }
-        }
+        return Query3Helper<T1, T2, T3>.Execute(forceIndex, store1, store2, store3);
     }
 
     /// <summary>
@@ -237,96 +86,8 @@ public static class WorldExtensions
         var store2 = world.GetStore<T2>();
         var store3 = world.GetStore<T3>();
         var store4 = world.GetStore<T4>();
-
-        var minStore = MinStoreIndex(store1.Count, store2.Count, store3.Count, store4.Count);
-
-        return minStore switch
-        {
-            0 => QueryFirstStore(store1, store2, store3, store4),
-            1 => QuerySecondStore(store1, store2, store3, store4),
-            2 => QueryThirdStore(store1, store2, store3, store4),
-            _ => QueryFourthStore(store1, store2, store3, store4),
-        };
-
-        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryFirstStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3,
-            ComponentStorage<T4> s4
-        )
-        {
-            foreach ((Entity entity, T1 c1) in s1.All())
-            {
-                if (
-                    s2.TryGet(entity, out var c2)
-                    && s3.TryGet(entity, out var c3)
-                    && s4.TryGet(entity, out var c4)
-                )
-                {
-                    yield return (entity, c1, c2, c3, c4);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3, T4)> QuerySecondStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3,
-            ComponentStorage<T4> s4
-        )
-        {
-            foreach ((Entity entity, T2 c2) in s2.All())
-            {
-                if (
-                    s1.TryGet(entity, out var c1)
-                    && s3.TryGet(entity, out var c3)
-                    && s4.TryGet(entity, out var c4)
-                )
-                {
-                    yield return (entity, c1, c2, c3, c4);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryThirdStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3,
-            ComponentStorage<T4> s4
-        )
-        {
-            foreach ((Entity entity, T3 c3) in s3.All())
-            {
-                if (
-                    s1.TryGet(entity, out var c1)
-                    && s2.TryGet(entity, out var c2)
-                    && s4.TryGet(entity, out var c4)
-                )
-                {
-                    yield return (entity, c1, c2, c3, c4);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryFourthStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3,
-            ComponentStorage<T4> s4
-        )
-        {
-            foreach ((Entity entity, T4 c4) in s4.All())
-            {
-                if (
-                    s1.TryGet(entity, out var c1)
-                    && s2.TryGet(entity, out var c2)
-                    && s3.TryGet(entity, out var c3)
-                )
-                {
-                    yield return (entity, c1, c2, c3, c4);
-                }
-            }
-        }
+        var minStoreIdx = MinStoreIndex(store1.Count, store2.Count, store3.Count, store4.Count);
+        return Query4Helper<T1, T2, T3, T4>.Execute(minStoreIdx, store1, store2, store3, store4);
     }
 
     /// <summary>
@@ -349,99 +110,7 @@ public static class WorldExtensions
         var store2 = world.GetStore<T2>();
         var store3 = world.GetStore<T3>();
         var store4 = world.GetStore<T4>();
-
-        return forceIndex switch
-        {
-            0 => QueryFirstStore(store1, store2, store3, store4),
-            1 => QuerySecondStore(store1, store2, store3, store4),
-            2 => QueryThirdStore(store1, store2, store3, store4),
-            _ => QueryFourthStore(store1, store2, store3, store4),
-        };
-
-        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryFirstStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3,
-            ComponentStorage<T4> s4
-        )
-        {
-            foreach ((Entity entity, T1 c1) in s1.All())
-            {
-                if (
-                    s2.TryGet(entity, out var c2)
-                    && s3.TryGet(entity, out var c3)
-                    && s4.TryGet(entity, out var c4)
-                )
-                {
-                    yield return (entity, c1, c2, c3, c4);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3, T4)> QuerySecondStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3,
-            ComponentStorage<T4> s4
-        )
-        {
-            foreach ((Entity entity, T2 c2) in s2.All())
-            {
-                if (
-                    s1.TryGet(entity, out var c1)
-                    && s3.TryGet(entity, out var c3)
-                    && s4.TryGet(entity, out var c4)
-                )
-                {
-                    yield return (entity, c1, c2, c3, c4);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryThirdStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3,
-            ComponentStorage<T4> s4
-        )
-        {
-            foreach ((Entity entity, T3 c3) in s3.All())
-            {
-                if (
-                    s1.TryGet(entity, out var c1)
-                    && s2.TryGet(entity, out var c2)
-                    && s4.TryGet(entity, out var c4)
-                )
-                {
-                    yield return (entity, c1, c2, c3, c4);
-                }
-            }
-        }
-
-        static IEnumerable<(Entity, T1, T2, T3, T4)> QueryFourthStore(
-            ComponentStorage<T1> s1,
-            ComponentStorage<T2> s2,
-            ComponentStorage<T3> s3,
-            ComponentStorage<T4> s4
-        )
-        {
-            foreach ((Entity entity, T4 c4) in s4.All())
-            {
-                if (
-                    s1.TryGet(entity, out var c1)
-                    && s2.TryGet(entity, out var c2)
-                    && s3.TryGet(entity, out var c3)
-                )
-                {
-                    yield return (entity, c1, c2, c3, c4);
-                }
-            }
-        }
-    }
-
-    private static int MinStoreIndex(int count1, int count2)
-    {
-        return count1 <= count2 ? 0 : 1;
+        return Query4Helper<T1, T2, T3, T4>.Execute(forceIndex, store1, store2, store3, store4);
     }
 
     private static int MinStoreIndex(int count1, int count2, int count3)
@@ -462,5 +131,217 @@ public static class WorldExtensions
         if (count3 <= count1 && count3 <= count2 && count3 <= count4)
             return 2;
         return 3;
+    }
+
+    private static class Query2Helper<T1, T2>
+        where T1 : struct
+        where T2 : struct
+    {
+        internal static IEnumerable<(Entity, T1, T2)> Execute(
+            int storeIndex,
+            ComponentStorage<T1> store1,
+            ComponentStorage<T2> store2
+        )
+        {
+            return storeIndex == 0 ? IterateFirst(store1, store2) : IterateSecond(store1, store2);
+        }
+
+        private static IEnumerable<(Entity, T1, T2)> IterateFirst(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2
+        )
+        {
+            foreach ((Entity entity, T1 c1) in s1.All())
+            {
+                if (s2.TryGet(entity, out var c2))
+                {
+                    yield return (entity, c1, c2);
+                }
+            }
+        }
+
+        private static IEnumerable<(Entity, T1, T2)> IterateSecond(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2
+        )
+        {
+            foreach ((Entity entity, T2 c2) in s2.All())
+            {
+                if (s1.TryGet(entity, out var c1))
+                {
+                    yield return (entity, c1, c2);
+                }
+            }
+        }
+    }
+
+    private static class Query3Helper<T1, T2, T3>
+        where T1 : struct
+        where T2 : struct
+        where T3 : struct
+    {
+        internal static IEnumerable<(Entity, T1, T2, T3)> Execute(
+            int storeIndex,
+            ComponentStorage<T1> store1,
+            ComponentStorage<T2> store2,
+            ComponentStorage<T3> store3
+        )
+        {
+            return storeIndex switch
+            {
+                0 => IterateFirst(store1, store2, store3),
+                1 => IterateSecond(store1, store2, store3),
+                _ => IterateThird(store1, store2, store3),
+            };
+        }
+
+        private static IEnumerable<(Entity, T1, T2, T3)> IterateFirst(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T1 c1) in s1.All())
+            {
+                if (s2.TryGet(entity, out var c2) && s3.TryGet(entity, out var c3))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
+            }
+        }
+
+        private static IEnumerable<(Entity, T1, T2, T3)> IterateSecond(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T2 c2) in s2.All())
+            {
+                if (s1.TryGet(entity, out var c1) && s3.TryGet(entity, out var c3))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
+            }
+        }
+
+        private static IEnumerable<(Entity, T1, T2, T3)> IterateThird(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3
+        )
+        {
+            foreach ((Entity entity, T3 c3) in s3.All())
+            {
+                if (s1.TryGet(entity, out var c1) && s2.TryGet(entity, out var c2))
+                {
+                    yield return (entity, c1, c2, c3);
+                }
+            }
+        }
+    }
+
+    private static class Query4Helper<T1, T2, T3, T4>
+        where T1 : struct
+        where T2 : struct
+        where T3 : struct
+        where T4 : struct
+    {
+        internal static IEnumerable<(Entity, T1, T2, T3, T4)> Execute(
+            int storeIndex,
+            ComponentStorage<T1> store1,
+            ComponentStorage<T2> store2,
+            ComponentStorage<T3> store3,
+            ComponentStorage<T4> store4
+        )
+        {
+            return storeIndex switch
+            {
+                0 => IterateFirst(store1, store2, store3, store4),
+                1 => IterateSecond(store1, store2, store3, store4),
+                2 => IterateThird(store1, store2, store3, store4),
+                _ => IterateFourth(store1, store2, store3, store4),
+            };
+        }
+
+        private static IEnumerable<(Entity, T1, T2, T3, T4)> IterateFirst(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T1 c1) in s1.All())
+            {
+                if (
+                    s2.TryGet(entity, out var c2)
+                    && s3.TryGet(entity, out var c3)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+
+        private static IEnumerable<(Entity, T1, T2, T3, T4)> IterateSecond(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T2 c2) in s2.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s3.TryGet(entity, out var c3)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+
+        private static IEnumerable<(Entity, T1, T2, T3, T4)> IterateThird(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T3 c3) in s3.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s2.TryGet(entity, out var c2)
+                    && s4.TryGet(entity, out var c4)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
+
+        private static IEnumerable<(Entity, T1, T2, T3, T4)> IterateFourth(
+            ComponentStorage<T1> s1,
+            ComponentStorage<T2> s2,
+            ComponentStorage<T3> s3,
+            ComponentStorage<T4> s4
+        )
+        {
+            foreach ((Entity entity, T4 c4) in s4.All())
+            {
+                if (
+                    s1.TryGet(entity, out var c1)
+                    && s2.TryGet(entity, out var c2)
+                    && s3.TryGet(entity, out var c3)
+                )
+                {
+                    yield return (entity, c1, c2, c3, c4);
+                }
+            }
+        }
     }
 }

--- a/tests/Yaeger.Tests/ECS/WorldExtensionsTests.cs
+++ b/tests/Yaeger.Tests/ECS/WorldExtensionsTests.cs
@@ -167,6 +167,114 @@ public class WorldExtensionsTests
         Assert.Equal(5, results.Count);
     }
 
+    [Fact]
+    public void Query_WithThreeComponents_UsingOverride_ShouldReturnCorrectResults()
+    {
+        // Arrange
+        var world = new World();
+        var entity1 = world.CreateEntity();
+        var entity2 = world.CreateEntity();
+
+        world.AddComponent(entity1, new ComponentA { Value = 1 });
+        world.AddComponent(entity1, new ComponentB { Name = "A" });
+        world.AddComponent(entity1, new ComponentC { Flag = true });
+
+        world.AddComponent(entity2, new ComponentA { Value = 2 });
+        world.AddComponent(entity2, new ComponentB { Name = "B" });
+
+        // Act - Force iteration to start with ComponentB (index 1)
+        var results = world.Query<ComponentA, ComponentB, ComponentC>(forceIndex: 1).ToList();
+
+        // Assert
+        Assert.Single(results);
+        Assert.Contains(
+            results,
+            r =>
+                r.Item1.Equals(entity1) && r.Item2.Value == 1 && r.Item3.Name == "A" && r.Item4.Flag
+        );
+    }
+
+    [Fact]
+    public void Query_WithThreeComponents_UsingOverrideForThirdComponent_ShouldReturnCorrectResults()
+    {
+        // Arrange
+        var world = new World();
+        var entity = world.CreateEntity();
+
+        world.AddComponent(entity, new ComponentA { Value = 1 });
+        world.AddComponent(entity, new ComponentB { Name = "A" });
+        world.AddComponent(entity, new ComponentC { Flag = true });
+
+        // Act - Force iteration to start with ComponentC (index 2)
+        var results = world.Query<ComponentA, ComponentB, ComponentC>(forceIndex: 2).ToList();
+
+        // Assert
+        Assert.Single(results);
+        Assert.Contains(
+            results,
+            r => r.Item1.Equals(entity) && r.Item2.Value == 1 && r.Item3.Name == "A" && r.Item4.Flag
+        );
+    }
+
+    [Fact]
+    public void Query_WithFourComponents_UsingOverride_ShouldReturnCorrectResults()
+    {
+        // Arrange
+        var world = new World();
+        var entity1 = world.CreateEntity();
+        var entity2 = world.CreateEntity();
+
+        world.AddComponent(entity1, new ComponentA { Value = 1 });
+        world.AddComponent(entity1, new ComponentB { Name = "A" });
+        world.AddComponent(entity1, new ComponentC { Flag = true });
+        world.AddComponent(entity1, new ComponentD { Score = 100 });
+
+        world.AddComponent(entity2, new ComponentA { Value = 2 });
+        world.AddComponent(entity2, new ComponentB { Name = "B" });
+        world.AddComponent(entity2, new ComponentC { Flag = false });
+
+        // Act - Force iteration to start with ComponentD (index 3)
+        var results = world
+            .Query<ComponentA, ComponentB, ComponentC, ComponentD>(forceIndex: 3)
+            .ToList();
+
+        // Assert
+        Assert.Single(results);
+        Assert.Contains(
+            results,
+            r =>
+                r.Item1.Equals(entity1)
+                && r.Item2.Value == 1
+                && r.Item3.Name == "A"
+                && r.Item4.Flag
+                && r.Item5.Score == 100
+        );
+    }
+
+    [Fact]
+    public void Query_WithThreeComponents_OverrideInvalidIndex_ShouldThrow()
+    {
+        // Arrange
+        var world = new World();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            world.Query<ComponentA, ComponentB, ComponentC>(forceIndex: 3).ToList()
+        );
+    }
+
+    [Fact]
+    public void Query_WithFourComponents_OverrideInvalidIndex_ShouldThrow()
+    {
+        // Arrange
+        var world = new World();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            world.Query<ComponentA, ComponentB, ComponentC, ComponentD>(forceIndex: 4).ToList()
+        );
+    }
+
     // Helper test components
     private struct ComponentA
     {

--- a/tests/Yaeger.Tests/ECS/WorldExtensionsTests.cs
+++ b/tests/Yaeger.Tests/ECS/WorldExtensionsTests.cs
@@ -190,6 +190,10 @@ public class WorldExtensionsTests
             results,
             r => r.Item1.Equals(entity1) && r.Item2.Value == 1 && r.Item3.Name == "A"
         );
+        Assert.Contains(
+            results,
+            r => r.Item1.Equals(entity2) && r.Item2.Value == 2 && r.Item3.Name == "B"
+        );
     }
 
     [Fact]

--- a/tests/Yaeger.Tests/ECS/WorldExtensionsTests.cs
+++ b/tests/Yaeger.Tests/ECS/WorldExtensionsTests.cs
@@ -168,6 +168,43 @@ public class WorldExtensionsTests
     }
 
     [Fact]
+    public void Query_WithTwoComponents_UsingOverride_ShouldReturnCorrectResults()
+    {
+        // Arrange
+        var world = new World();
+        var entity1 = world.CreateEntity();
+        var entity2 = world.CreateEntity();
+
+        world.AddComponent(entity1, new ComponentA { Value = 1 });
+        world.AddComponent(entity1, new ComponentB { Name = "A" });
+
+        world.AddComponent(entity2, new ComponentA { Value = 2 });
+        world.AddComponent(entity2, new ComponentB { Name = "B" });
+
+        // Act - Force iteration to start with ComponentB (index 1)
+        var results = world.Query<ComponentA, ComponentB>(forceIndex: 1).ToList();
+
+        // Assert
+        Assert.Equal(2, results.Count);
+        Assert.Contains(
+            results,
+            r => r.Item1.Equals(entity1) && r.Item2.Value == 1 && r.Item3.Name == "A"
+        );
+    }
+
+    [Fact]
+    public void Query_WithTwoComponents_OverrideInvalidIndex_ShouldThrow()
+    {
+        // Arrange
+        var world = new World();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            world.Query<ComponentA, ComponentB>(forceIndex: 2).ToList()
+        );
+    }
+
+    [Fact]
     public void Query_WithThreeComponents_UsingOverride_ShouldReturnCorrectResults()
     {
         // Arrange


### PR DESCRIPTION
## Why
Default ECS queries always iterated the first component store. When component distributions are skewed, that can iterate many entities that do not match the full query.

This change optimizes default iteration while still allowing callers to explicitly control which store is iterated first when needed.

## What changed
- Added `ComponentStorage<T>.Count` for O(1) store size comparisons.
- Updated `WorldExtensions.Query` for 2/3/4 component queries to iterate the smallest store by default.
- Added `forceIndex` overloads for:
  - `Query<T1, T2>(int forceIndex)`
  - `Query<T1, T2, T3>(int forceIndex)`
  - `Query<T1, T2, T3, T4>(int forceIndex)`
- Added range validation for `forceIndex` with `ArgumentOutOfRangeException`.
- Refactored `WorldExtensions` internals to shared helper classes (`Query2Helper`, `Query3Helper`, `Query4Helper`) to reduce duplicated iteration logic.
- Expanded unit tests to cover override behavior and invalid override indices.

## Notes
- Existing query API behavior remains backward compatible.
- Callers now get better default iteration performance while retaining manual override control when determinism is preferred.