### PR TITLE
Fix: Update yaeger-browser.js import path to root-relative

### DIFF
--- a/Samples/BrowserDemo/Game.razor
+++ b/Samples/BrowserDemo/Game.razor
@@ -13,7 +13,7 @@
             return;
 
         // Load the Yaeger interop ES module so all [JSImport] functions become available.
-        await JSHost.ImportAsync("yaeger-browser", "./yaeger-browser.js");
+        await JSHost.ImportAsync("yaeger-browser", "/yaeger-browser.js");
 
         _renderSurface = new BrowserRenderSurface("yaeger-canvas");
         _renderSurface.Initialize();


### PR DESCRIPTION
Changed the JSHost.ImportAsync path from relative './yaeger-browser.js' to absolute '/yaeger-browser.js' to fix module resolution in browser environment.