### PR TITLE
refactor: reduce SpriteSerializer tint parsing complexity

### DIFF
--- a/src/Engine/Yaeger/ECS/Serializers/SpriteSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/SpriteSerializer.cs
@@ -22,58 +22,8 @@ public sealed class SpriteSerializer : IComponentSerializer
     /// <inheritdoc/>
     public Action<World, Entity> Deserialize(JsonElement element)
     {
-        if (!element.TryGetProperty("texturePath", out var texturePathEl))
-            throw new PrefabLoadException(
-                "Sprite component is missing required 'texturePath' property."
-            );
-
-        if (texturePathEl.ValueKind != JsonValueKind.String)
-            throw new PrefabLoadException("Sprite 'texturePath' must be a string.");
-
-        var texturePath = texturePathEl.GetString();
-        if (string.IsNullOrWhiteSpace(texturePath))
-            throw new PrefabLoadException("Sprite 'texturePath' must be a non-empty string.");
-
-        // Parse optional tint property
-        Color? tint = null;
-        if (element.TryGetProperty("tint", out var tintEl))
-        {
-            if (tintEl.ValueKind != JsonValueKind.Array)
-                throw new PrefabLoadException("Sprite 'tint' must be an array of 3 or 4 numbers.");
-
-            var channels = new int[4];
-            var channelCount = 0;
-            foreach (var channelEl in tintEl.EnumerateArray())
-            {
-                if (channelCount == channels.Length)
-                {
-                    throw new PrefabLoadException(
-                        "Sprite 'tint' array must contain 3 (RGB) or 4 (RGBA) elements."
-                    );
-                }
-
-                if (
-                    !channelEl.TryGetInt32(out var channelValue)
-                    || channelValue < 0
-                    || channelValue > 255
-                )
-                {
-                    throw new PrefabLoadException(
-                        "Sprite 'tint' array elements must be integers between 0 and 255."
-                    );
-                }
-
-                channels[channelCount++] = channelValue;
-            }
-
-            if (channelCount < 3)
-                throw new PrefabLoadException(
-                    "Sprite 'tint' array must contain 3 (RGB) or 4 (RGBA) elements."
-                );
-
-            var alpha = channelCount == 4 ? channels[3] : 255;
-            tint = new Color((byte)channels[0], (byte)channels[1], (byte)channels[2], (byte)alpha);
-        }
+        var texturePath = GetRequiredTexturePath(element);
+        var tint = ParseOptionalTint(element);
 
         var component = new Sprite(texturePath, tint);
         return (world, entity) => world.AddComponent(entity, component);
@@ -87,22 +37,91 @@ public sealed class SpriteSerializer : IComponentSerializer
 
         var json = new JsonObject { ["type"] = TypeId, ["texturePath"] = sprite.TexturePath };
 
-        // Only serialize tint if it's not white (the default)
-        if (
-            sprite.Tint.R != 255
-            || sprite.Tint.G != 255
-            || sprite.Tint.B != 255
-            || sprite.Tint.A != 255
-        )
-        {
-            json["tint"] = new JsonArray(
-                sprite.Tint.R,
-                sprite.Tint.G,
-                sprite.Tint.B,
-                sprite.Tint.A
-            );
-        }
+        WriteTintIfNonDefault(json, sprite.Tint);
 
         return json;
+    }
+
+    private static string GetRequiredTexturePath(JsonElement element)
+    {
+        if (!element.TryGetProperty("texturePath", out var texturePathEl))
+            throw new PrefabLoadException(
+                "Sprite component is missing required 'texturePath' property."
+            );
+
+        if (texturePathEl.ValueKind != JsonValueKind.String)
+            throw new PrefabLoadException("Sprite 'texturePath' must be a string.");
+
+        return
+            texturePathEl.GetString() is { } texturePath && !string.IsNullOrWhiteSpace(texturePath)
+            ? texturePath
+            : throw new PrefabLoadException("Sprite 'texturePath' must be a non-empty string.");
+    }
+
+    private static Color? ParseOptionalTint(JsonElement element)
+    {
+        if (!element.TryGetProperty("tint", out var tintEl))
+            return null;
+
+        if (tintEl.ValueKind != JsonValueKind.Array)
+            throw new PrefabLoadException("Sprite 'tint' must be an array of 3 or 4 numbers.");
+
+        var channels = ReadTintChannels(tintEl);
+        var alpha = channels[3];
+        return new Color((byte)channels[0], (byte)channels[1], (byte)channels[2], (byte)alpha);
+    }
+
+    private static int[] ReadTintChannels(JsonElement tintEl)
+    {
+        var channels = new int[4];
+        var channelCount = 0;
+        foreach (var channelEl in tintEl.EnumerateArray())
+        {
+            EnsureTintChannelCapacity(channelCount, channels.Length);
+            channels[channelCount++] = ParseTintChannel(channelEl);
+        }
+
+        EnsureMinimumTintChannelCount(channelCount);
+        if (channelCount == 3)
+            channels[3] = 255;
+        return channels;
+    }
+
+    private static void EnsureTintChannelCapacity(int channelCount, int maxChannels)
+    {
+        if (channelCount != maxChannels)
+            return;
+
+        throw new PrefabLoadException(
+            "Sprite 'tint' array must contain 3 (RGB) or 4 (RGBA) elements."
+        );
+    }
+
+    private static int ParseTintChannel(JsonElement channelEl)
+    {
+        if (!channelEl.TryGetInt32(out var channelValue) || channelValue < 0 || channelValue > 255)
+            throw new PrefabLoadException(
+                "Sprite 'tint' array elements must be integers between 0 and 255."
+            );
+
+        return channelValue;
+    }
+
+    private static void EnsureMinimumTintChannelCount(int channelCount)
+    {
+        if (channelCount >= 3)
+            return;
+
+        throw new PrefabLoadException(
+            "Sprite 'tint' array must contain 3 (RGB) or 4 (RGBA) elements."
+        );
+    }
+
+    private static void WriteTintIfNonDefault(JsonObject json, Color tint)
+    {
+        if (tint.R == 255 && tint.G == 255 && tint.B == 255 && tint.A == 255)
+            return;
+
+        json["tint"] = new JsonArray(tint.R, tint.G, tint.B, tint.A);
     }
 }


### PR DESCRIPTION
## Summary
- refactor `SpriteSerializer` to reduce method-level branching in tint parsing
- extract focused helper methods for tint channel parsing/validation
- preserve existing serializer behavior and error message text

## Why
- `ParseOptionalTint` was flagged as a hotspot due to complexity + churn
- this change keeps logic easier to read and safer to modify without changing behavior