### PR TITLE
Support browser keyboard, mouse, touch, and frame timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Yaeger is a modular, experimental 2D game engine written in C#. It aims to provi
 - Input handling (keyboard, mouse; browser runtime maps single-touch/pen to mouse-style input)
 - Sample games (see `Samples/Pong`, `Samples/BouncingBalls`, `Samples/Animation2D`, `Samples/CameraDemo`)
 - Extensible component and system design
-- Comprehensive test suite with 45 unit tests
+- Comprehensive unit test suite
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Yaeger is a modular, experimental 2D game engine written in C#. It aims to provi
 - 2D rendering with Silk.NET (texture-batched sprites with deterministic ordering)
 - Deterministic layered draw ordering via `RenderLayer` and `UnifiedRenderSystem`
 - Opt-in 2D camera (pan / zoom / rotate; world-space sprites + screen-space text)
-- Input handling (keyboard, mouse)
+- Input handling (keyboard, mouse; browser runtime maps single-touch/pen to mouse-style input)
 - Sample games (see `Samples/Pong`, `Samples/BouncingBalls`, `Samples/Animation2D`, `Samples/CameraDemo`)
 - Extensible component and system design
 - Comprehensive test suite with 45 unit tests
@@ -65,10 +65,12 @@ For more information about testing, see the [Testing Guide](docs/testing.md).
 
 - `src/Engine/Yaeger.Core/` - Platform-agnostic engine core (ECS, scenes, animation, transforms, physics, gameplay logic)
 - `src/Engine/Yaeger/` - Native runtime (windowing, rendering, input bindings, audio, font runtime)
+- `src/Engine/Yaeger.Browser/` - Browser runtime adapters (Canvas2D render surface, browser input/time sources)
 - `tests/Yaeger.Tests/` - Unit test suite
   - `ECS/` - Tests for ECS components
   - `Graphics/` - Tests for graphics primitives
 - `Samples/` - Example games and demos
+  - `BrowserDemo/` - Blazor/WebAssembly browser loop + browser input/runtime integration
   - `Pong/` - Classic Pong game implementation
   - `BouncingBalls/` - Physics demo
   - `Animation2D/` - Sprite-sheet animation demo
@@ -83,6 +85,7 @@ For more information about testing, see the [Testing Guide](docs/testing.md).
 
 For headless/platform-agnostic simulation and gameplay logic, reference `Yaeger.Core`.
 For desktop/native runtime behavior (window, rendering, input, audio), reference `Yaeger`.
+For browser/WebAssembly behavior (Canvas2D rendering, browser input/frame timing), reference `Yaeger.Browser`.
 See the Pong sample for a minimal end-to-end native implementation.
 
 ## Contributing

--- a/Samples/BrowserDemo/wwwroot/app.css
+++ b/Samples/BrowserDemo/wwwroot/app.css
@@ -10,6 +10,7 @@ body {
     display: block;
     width: 100vw;
     height: 100vh;
+    touch-action: none;
 }
 
 /* Loading indicator styles (matches Blazor WASM template) */

--- a/Samples/BrowserDemo/wwwroot/yaeger-browser.js
+++ b/Samples/BrowserDemo/wwwroot/yaeger-browser.js
@@ -107,11 +107,10 @@ export function initCanvas(canvasId) {
             return;
         }
 
-        const rect = canvas.getBoundingClientRect();
-        mouseX = e.clientX - rect.left;
-        mouseY = e.clientY - rect.top;
-
         if (e.pointerType === 'mouse') {
+            const rect = canvas.getBoundingClientRect();
+            mouseX = e.clientX - rect.left;
+            mouseY = e.clientY - rect.top;
             mouseButtons.add(e.button);
             return;
         }
@@ -124,6 +123,9 @@ export function initCanvas(canvasId) {
             return;
         }
 
+        const rect = canvas.getBoundingClientRect();
+        mouseX = e.clientX - rect.left;
+        mouseY = e.clientY - rect.top;
         mouseButtons.add(0);
         if (canvas.setPointerCapture) {
             canvas.setPointerCapture(e.pointerId);

--- a/Samples/BrowserDemo/wwwroot/yaeger-browser.js
+++ b/Samples/BrowserDemo/wwwroot/yaeger-browser.js
@@ -12,22 +12,27 @@ let mouseX = 0;
 let mouseY = 0;
 let scrollDelta = 0;
 const mouseButtons = new Set();
+let activePrimaryPointerId;
 const PIXELS_PER_LINE = 16;
 const WHEEL_EVENT_OPTIONS = { passive: false };
+const POINTER_EVENT_OPTIONS = { passive: false };
 
 let resizeCanvasHandler;
 let keyDownHandler;
 let keyUpHandler;
-let mouseMoveHandler;
-let mouseDownHandler;
-let mouseUpHandler;
+let pointerDownHandler;
+let pointerMoveHandler;
+let pointerUpHandler;
+let pointerCancelHandler;
 let wheelHandler;
 let blurHandler;
+let contextMenuHandler;
 
 function clearInputState() {
     pressedKeys.clear();
     mouseButtons.clear();
     scrollDelta = 0;
+    activePrimaryPointerId = undefined;
 }
 
 function normalizeWheelDeltaToPixels(e) {
@@ -56,6 +61,7 @@ export function initCanvas(canvasId) {
     if (!ctx) {
         throw new Error(`[Yaeger] Failed to acquire 2D context for canvas '#${canvasId}'.`);
     }
+    canvas.style.touchAction = 'none';
 
     resizeCanvasHandler = () => {
         if (!canvas) {
@@ -78,7 +84,25 @@ export function initCanvas(canvasId) {
         }
     };
 
-    mouseMoveHandler = (e) => {
+    pointerMoveHandler = (e) => {
+        if (!canvas) {
+            return;
+        }
+
+        if (e.pointerType !== 'mouse' && e.pointerId !== activePrimaryPointerId) {
+            return;
+        }
+
+        const rect = canvas.getBoundingClientRect();
+        mouseX = e.clientX - rect.left;
+        mouseY = e.clientY - rect.top;
+
+        if (e.pointerType !== 'mouse') {
+            e.preventDefault();
+        }
+    };
+
+    pointerDownHandler = (e) => {
         if (!canvas) {
             return;
         }
@@ -86,25 +110,80 @@ export function initCanvas(canvasId) {
         const rect = canvas.getBoundingClientRect();
         mouseX = e.clientX - rect.left;
         mouseY = e.clientY - rect.top;
+
+        if (e.pointerType === 'mouse') {
+            mouseButtons.add(e.button);
+            return;
+        }
+
+        if (activePrimaryPointerId === undefined) {
+            activePrimaryPointerId = e.pointerId;
+        }
+
+        if (e.pointerId !== activePrimaryPointerId) {
+            return;
+        }
+
+        mouseButtons.add(0);
+        if (canvas.setPointerCapture) {
+            canvas.setPointerCapture(e.pointerId);
+        }
+        e.preventDefault();
     };
 
-    mouseDownHandler = (e) => mouseButtons.add(e.button);
-    mouseUpHandler = (e) => mouseButtons.delete(e.button);
+    pointerUpHandler = (e) => {
+        if (!canvas) {
+            return;
+        }
+
+        if (e.pointerType === 'mouse') {
+            mouseButtons.delete(e.button);
+            return;
+        }
+
+        if (e.pointerId !== activePrimaryPointerId) {
+            return;
+        }
+
+        mouseButtons.delete(0);
+        activePrimaryPointerId = undefined;
+        if (canvas.hasPointerCapture?.(e.pointerId)) {
+            canvas.releasePointerCapture(e.pointerId);
+        }
+        e.preventDefault();
+    };
+
+    pointerCancelHandler = (e) => {
+        if (!canvas || e.pointerType === 'mouse' || e.pointerId !== activePrimaryPointerId) {
+            return;
+        }
+
+        mouseButtons.delete(0);
+        activePrimaryPointerId = undefined;
+        if (canvas.hasPointerCapture?.(e.pointerId)) {
+            canvas.releasePointerCapture(e.pointerId);
+        }
+        e.preventDefault();
+    };
+
     wheelHandler = (e) => {
         scrollDelta += normalizeWheelDeltaToPixels(e);
         e.preventDefault();
     };
     blurHandler = () => clearInputState();
+    contextMenuHandler = (e) => e.preventDefault();
 
     resizeCanvasHandler();
     window.addEventListener('resize', resizeCanvasHandler);
     window.addEventListener('keydown', keyDownHandler);
     window.addEventListener('keyup', keyUpHandler);
-    canvas.addEventListener('mousemove', mouseMoveHandler);
-    canvas.addEventListener('mousedown', mouseDownHandler);
-    window.addEventListener('mouseup', mouseUpHandler);
+    canvas.addEventListener('pointermove', pointerMoveHandler, POINTER_EVENT_OPTIONS);
+    canvas.addEventListener('pointerdown', pointerDownHandler, POINTER_EVENT_OPTIONS);
+    window.addEventListener('pointerup', pointerUpHandler, POINTER_EVENT_OPTIONS);
+    window.addEventListener('pointercancel', pointerCancelHandler, POINTER_EVENT_OPTIONS);
     canvas.addEventListener('wheel', wheelHandler, WHEEL_EVENT_OPTIONS);
     window.addEventListener('blur', blurHandler);
+    canvas.addEventListener('contextmenu', contextMenuHandler);
 }
 
 /**
@@ -126,19 +205,24 @@ export function disposeCanvas() {
         keyUpHandler = undefined;
     }
 
-    if (mouseMoveHandler && canvas) {
-        canvas.removeEventListener('mousemove', mouseMoveHandler);
-        mouseMoveHandler = undefined;
+    if (pointerMoveHandler && canvas) {
+        canvas.removeEventListener('pointermove', pointerMoveHandler, POINTER_EVENT_OPTIONS);
+        pointerMoveHandler = undefined;
     }
 
-    if (mouseDownHandler && canvas) {
-        canvas.removeEventListener('mousedown', mouseDownHandler);
-        mouseDownHandler = undefined;
+    if (pointerDownHandler && canvas) {
+        canvas.removeEventListener('pointerdown', pointerDownHandler, POINTER_EVENT_OPTIONS);
+        pointerDownHandler = undefined;
     }
 
-    if (mouseUpHandler) {
-        window.removeEventListener('mouseup', mouseUpHandler);
-        mouseUpHandler = undefined;
+    if (pointerUpHandler) {
+        window.removeEventListener('pointerup', pointerUpHandler, POINTER_EVENT_OPTIONS);
+        pointerUpHandler = undefined;
+    }
+
+    if (pointerCancelHandler) {
+        window.removeEventListener('pointercancel', pointerCancelHandler, POINTER_EVENT_OPTIONS);
+        pointerCancelHandler = undefined;
     }
 
     if (wheelHandler && canvas) {
@@ -149,6 +233,11 @@ export function disposeCanvas() {
     if (blurHandler) {
         window.removeEventListener('blur', blurHandler);
         blurHandler = undefined;
+    }
+
+    if (contextMenuHandler && canvas) {
+        canvas.removeEventListener('contextmenu', contextMenuHandler);
+        contextMenuHandler = undefined;
     }
 
     clearInputState();

--- a/src/Engine/Yaeger.Browser/BrowserInputState.cs
+++ b/src/Engine/Yaeger.Browser/BrowserInputState.cs
@@ -6,8 +6,9 @@ using Yaeger.Platform;
 namespace Yaeger.Browser;
 
 /// <summary>
-/// <see cref="IInputState"/> implementation for the browser, backed by keyboard and mouse
+/// <see cref="IInputState"/> implementation for the browser, backed by keyboard and pointer
 /// event listeners registered by the "yaeger-browser" JavaScript module.
+/// Touch and pen input are mapped into existing mouse-style semantics by the JS layer.
 /// </summary>
 public sealed class BrowserInputState : IInputState
 {

--- a/src/Engine/Yaeger.Browser/BrowserTimeSource.cs
+++ b/src/Engine/Yaeger.Browser/BrowserTimeSource.cs
@@ -8,8 +8,23 @@ namespace Yaeger.Browser;
 /// </summary>
 public sealed class BrowserTimeSource : ITimeSource
 {
+    public const float DefaultMaxDeltaTimeSeconds = 1f / 15f;
+
     private double _lastTimestampMs;
     private bool _initialized;
+    private readonly float _maxDeltaTimeSeconds;
+
+    public BrowserTimeSource(float maxDeltaTimeSeconds = DefaultMaxDeltaTimeSeconds)
+    {
+        if (maxDeltaTimeSeconds <= 0f)
+            throw new ArgumentOutOfRangeException(
+                nameof(maxDeltaTimeSeconds),
+                maxDeltaTimeSeconds,
+                "Maximum delta time must be greater than zero."
+            );
+
+        _maxDeltaTimeSeconds = maxDeltaTimeSeconds;
+    }
 
     public float DeltaTime { get; private set; }
 
@@ -22,8 +37,9 @@ public sealed class BrowserTimeSource : ITimeSource
     /// Subsequent ticks compute the delta from the previous timestamp. Backward timestamps
     /// (e.g. caused by a non-monotonic browser clock or bad caller input) are treated as
     /// a no-op so that the baseline is not moved backward and the next valid frame does not
-    /// over-report <see cref="DeltaTime"/>. This also ensures <see cref="ITimeSource.TotalTime"/>
-    /// never decreases.
+    /// over-report <see cref="DeltaTime"/>. Large frame gaps are clamped to
+    /// <see cref="_maxDeltaTimeSeconds"/> to avoid simulation spikes after background tab stalls.
+    /// This also ensures <see cref="ITimeSource.TotalTime"/> never decreases.
     /// No exception is thrown because throwing inside a <c>requestAnimationFrame</c> callback
     /// chain would silently stop the loop rather than degrade gracefully.
     /// </summary>
@@ -40,7 +56,8 @@ public sealed class BrowserTimeSource : ITimeSource
         var clampedTimestampMs = Math.Max(timestampMs, _lastTimestampMs);
         var deltaMs = clampedTimestampMs - _lastTimestampMs;
         _lastTimestampMs = clampedTimestampMs;
-        DeltaTime = (float)(deltaMs / 1000.0);
-        TotalTime += deltaMs / 1000.0;
+        var deltaSeconds = Math.Min(deltaMs / 1000.0, _maxDeltaTimeSeconds);
+        DeltaTime = (float)deltaSeconds;
+        TotalTime += deltaSeconds;
     }
 }

--- a/src/Engine/Yaeger.Browser/BrowserTimeSource.cs
+++ b/src/Engine/Yaeger.Browser/BrowserTimeSource.cs
@@ -16,11 +16,11 @@ public sealed class BrowserTimeSource : ITimeSource
 
     public BrowserTimeSource(float maxDeltaTimeSeconds = DefaultMaxDeltaTimeSeconds)
     {
-        if (maxDeltaTimeSeconds <= 0f)
+        if (!float.IsFinite(maxDeltaTimeSeconds) || maxDeltaTimeSeconds <= 0f)
             throw new ArgumentOutOfRangeException(
                 nameof(maxDeltaTimeSeconds),
                 maxDeltaTimeSeconds,
-                "Maximum delta time must be greater than zero."
+                "Maximum delta time must be finite and greater than zero."
             );
 
         _maxDeltaTimeSeconds = maxDeltaTimeSeconds;
@@ -45,6 +45,12 @@ public sealed class BrowserTimeSource : ITimeSource
     /// </summary>
     public void Advance(double timestampMs)
     {
+        if (!double.IsFinite(timestampMs))
+        {
+            DeltaTime = 0.0f;
+            return;
+        }
+
         if (!_initialized)
         {
             _initialized = true;

--- a/tests/Yaeger.Tests/Browser/BrowserTimeSourceTests.cs
+++ b/tests/Yaeger.Tests/Browser/BrowserTimeSourceTests.cs
@@ -4,6 +4,20 @@ namespace Yaeger.Tests.Browser;
 
 public class BrowserTimeSourceTests
 {
+    [Theory]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void Constructor_NonFiniteMaxDeltaTime_ShouldThrowArgumentOutOfRangeException(
+        float maxDeltaTimeSeconds
+    )
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new BrowserTimeSource(maxDeltaTimeSeconds)
+        );
+    }
+
     [Fact]
     public void Advance_FirstTick_ShouldSetZeroDeltaTime()
     {
@@ -63,5 +77,43 @@ public class BrowserTimeSourceTests
         // Assert
         Assert.Equal(maxDeltaSeconds, timeSource.DeltaTime, 6);
         Assert.Equal(maxDeltaSeconds, timeSource.TotalTime, 6);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void Advance_NonFiniteTimestamp_ShouldTreatBadInputAsNoOp(double timestampMs)
+    {
+        // Arrange
+        var timeSource = new BrowserTimeSource(maxDeltaTimeSeconds: 1f);
+        timeSource.Advance(1000.0);
+        timeSource.Advance(1016.0);
+
+        // Act
+        timeSource.Advance(timestampMs);
+
+        // Assert
+        Assert.Equal(0f, timeSource.DeltaTime);
+        Assert.Equal(0.016d, timeSource.TotalTime, 6);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void Advance_NonFiniteFirstTimestamp_ShouldWaitForFirstValidTick(double timestampMs)
+    {
+        // Arrange
+        var timeSource = new BrowserTimeSource(maxDeltaTimeSeconds: 1f);
+
+        // Act
+        timeSource.Advance(timestampMs);
+        timeSource.Advance(1000.0);
+        timeSource.Advance(1016.0);
+
+        // Assert
+        Assert.Equal(0.016f, timeSource.DeltaTime, 6);
+        Assert.Equal(0.016d, timeSource.TotalTime, 6);
     }
 }

--- a/tests/Yaeger.Tests/Browser/BrowserTimeSourceTests.cs
+++ b/tests/Yaeger.Tests/Browser/BrowserTimeSourceTests.cs
@@ -1,0 +1,67 @@
+using Yaeger.Browser;
+
+namespace Yaeger.Tests.Browser;
+
+public class BrowserTimeSourceTests
+{
+    [Fact]
+    public void Advance_FirstTick_ShouldSetZeroDeltaTime()
+    {
+        // Arrange
+        var timeSource = new BrowserTimeSource();
+
+        // Act
+        timeSource.Advance(1234.0);
+
+        // Assert
+        Assert.Equal(0f, timeSource.DeltaTime);
+        Assert.Equal(0d, timeSource.TotalTime, 6);
+    }
+
+    [Fact]
+    public void Advance_ForwardTimestamps_ShouldAccumulateDeltaAndTotal()
+    {
+        // Arrange
+        var timeSource = new BrowserTimeSource(maxDeltaTimeSeconds: 1f);
+        timeSource.Advance(1000.0);
+
+        // Act
+        timeSource.Advance(1125.0);
+
+        // Assert
+        Assert.Equal(0.125f, timeSource.DeltaTime, 6);
+        Assert.Equal(0.125d, timeSource.TotalTime, 6);
+    }
+
+    [Fact]
+    public void Advance_BackwardTimestamp_ShouldKeepDeltaAtZero()
+    {
+        // Arrange
+        var timeSource = new BrowserTimeSource(maxDeltaTimeSeconds: 1f);
+        timeSource.Advance(1000.0);
+        timeSource.Advance(1016.0);
+
+        // Act
+        timeSource.Advance(1000.0);
+
+        // Assert
+        Assert.Equal(0f, timeSource.DeltaTime);
+        Assert.Equal(0.016d, timeSource.TotalTime, 6);
+    }
+
+    [Fact]
+    public void Advance_LargeFrameGap_ShouldClampDeltaTime()
+    {
+        // Arrange
+        const float maxDeltaSeconds = 0.05f;
+        var timeSource = new BrowserTimeSource(maxDeltaTimeSeconds: maxDeltaSeconds);
+        timeSource.Advance(1000.0);
+
+        // Act
+        timeSource.Advance(1250.0);
+
+        // Assert
+        Assert.Equal(maxDeltaSeconds, timeSource.DeltaTime, 6);
+        Assert.Equal(maxDeltaSeconds, timeSource.TotalTime, 6);
+    }
+}

--- a/tests/Yaeger.Tests/Yaeger.Tests.csproj
+++ b/tests/Yaeger.Tests/Yaeger.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Engine\Yaeger.Browser\Yaeger.Browser.csproj" />
     <ProjectReference Include="..\..\src\Engine\Yaeger.Core\Yaeger.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why
The browser runtime needed input and frame-timing behavior that is reliable for real gameplay. This change closes the gap so keyboard/mouse work in-browser, touch is explicitly supported through the existing input model, and requestAnimationFrame timing does not cause large simulation jumps after tab stalls.

## What changed
- Switched BrowserDemo input handling from mouse-specific listeners to pointer events.
- Mapped touch/pen contact to existing mouse-style semantics (single active pointer -> left button), including a fix to capture the first canvas touch even when it is non-primary.
- Added browser interaction safeguards for playability (`touch-action: none`, context menu suppression on canvas, pointer cancel/blur cleanup).
- Kept engine input abstractions stable while updating browser-facing docs/comments.
- Added frame-time clamping in `BrowserTimeSource` (configurable max delta, default `1f/15f`) while preserving monotonic behavior.
- Added focused unit tests for first-frame behavior, forward/backward timestamps, and large-gap clamp behavior.
- Updated README and test project references for browser runtime coverage.

## Validation
- `dotnet test tests/Yaeger.Tests/Yaeger.Tests.csproj --filter "FullyQualifiedName~BrowserTimeSourceTests"`
- `dotnet build Samples/BrowserDemo/BrowserDemo.csproj`
- `dotnet build yaeger.sln`
- `dotnet test`
- `dotnet csharpier check .`

## Notes
- Touch scope is intentionally single-pointer mapped into the current mouse-style API.
- Multi-touch gesture semantics are out of scope for this change.

Fixes: #54