### PR TITLE
Replace Canvas 2D browser backend with WebGL 2.0

### DIFF
--- a/Samples/BrowserDemo/wwwroot/yaeger-browser.js
+++ b/Samples/BrowserDemo/wwwroot/yaeger-browser.js
@@ -330,6 +330,8 @@ export function initWebGL(canvasId) {
     gl = canvas.getContext('webgl2');
     if (!gl) throw new Error('[Yaeger] WebGL 2.0 is not supported in this browser.');
 
+    canvas.style.touchAction = 'none';
+
     // Shaders
     shaderProgram = createShaderProgram(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
     viewProjUniformLocation = gl.getUniformLocation(shaderProgram, 'uViewProj');

--- a/Samples/BrowserDemo/wwwroot/yaeger-browser.js
+++ b/Samples/BrowserDemo/wwwroot/yaeger-browser.js
@@ -1,12 +1,156 @@
 /**
- * Yaeger browser interop module.
+ * Yaeger browser interop module — WebGL 2.0 rendering backend.
  *
  * All exports are imported by Yaeger.Browser via [JSImport("functionName", "yaeger-browser")].
  * Load this module once at startup with JSHost.ImportAsync("yaeger-browser", "./yaeger-browser.js").
  */
 
+// ---------------------------------------------------------------------------
+// WebGL state
+// ---------------------------------------------------------------------------
+
 let canvas;
-let ctx;
+let gl;
+let shaderProgram;
+let vao;
+let vbo;
+let ebo;
+let viewProjUniformLocation;
+let textureUniformLocation;
+let whiteTexture;
+
+const MAX_QUADS = 1000;
+const VERTICES_PER_QUAD = 4;
+const FLOATS_PER_VERTEX = 9; // pos(3) + uv(2) + color(4)
+const INDICES_PER_QUAD = 6;
+
+/** url -> WebGLTexture, or null while loading, or whiteTexture after a 404. */
+const textureCache = new Map();
+
+const VERTEX_SHADER_SOURCE = `#version 300 es
+layout(location = 0) in vec3 aPosition;
+layout(location = 1) in vec2 aTexCoord;
+layout(location = 2) in vec4 aColor;
+
+uniform mat4 uViewProj;
+
+out vec2 vTexCoord;
+out vec4 vColor;
+
+void main() {
+    gl_Position = uViewProj * vec4(aPosition, 1.0);
+    vTexCoord = aTexCoord;
+    vColor = aColor;
+}`;
+
+const FRAGMENT_SHADER_SOURCE = `#version 300 es
+precision mediump float;
+
+in vec2 vTexCoord;
+in vec4 vColor;
+out vec4 FragColor;
+
+uniform sampler2D uTexture;
+
+void main() {
+    FragColor = texture(uTexture, vTexCoord) * vColor;
+}`;
+
+function compileShader(type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const log = gl.getShaderInfoLog(shader);
+        gl.deleteShader(shader);
+        throw new Error(`[Yaeger] Shader compile error: ${log}`);
+    }
+    return shader;
+}
+
+function createShaderProgram(vertSrc, fragSrc) {
+    const vert = compileShader(gl.VERTEX_SHADER, vertSrc);
+    const frag = compileShader(gl.FRAGMENT_SHADER, fragSrc);
+    const prog = gl.createProgram();
+    gl.attachShader(prog, vert);
+    gl.attachShader(prog, frag);
+    gl.linkProgram(prog);
+    gl.deleteShader(vert);
+    gl.deleteShader(frag);
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+        throw new Error(`[Yaeger] Shader link error: ${gl.getProgramInfoLog(prog)}`);
+    }
+    return prog;
+}
+
+function generateQuadIndices(maxQuads) {
+    const indices = new Uint32Array(maxQuads * INDICES_PER_QUAD);
+    for (let i = 0; i < maxQuads; i++) {
+        const v = i * VERTICES_PER_QUAD;
+        const idx = i * INDICES_PER_QUAD;
+        // Winding: TR(0), BR(1), TL(3)  +  BR(1), BL(2), TL(3)
+        indices[idx + 0] = v;
+        indices[idx + 1] = v + 1;
+        indices[idx + 2] = v + 3;
+        indices[idx + 3] = v + 1;
+        indices[idx + 4] = v + 2;
+        indices[idx + 5] = v + 3;
+    }
+    return indices;
+}
+
+function createWhiteTexture() {
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(
+        gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0,
+        gl.RGBA, gl.UNSIGNED_BYTE,
+        new Uint8Array([255, 255, 255, 255])
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    return tex;
+}
+
+/**
+ * Returns the WebGLTexture for the given URL, starting an async load on first access.
+ * Returns whiteTexture (1×1 white) while loading or when url is empty/null.
+ */
+function getOrLoadTexture(url) {
+    if (!url) return whiteTexture;
+
+    if (textureCache.has(url)) {
+        return textureCache.get(url) || whiteTexture;
+    }
+
+    textureCache.set(url, null); // mark as in-flight
+
+    const img = new Image();
+    img.onload = () => {
+        if (!gl) return;
+        const tex = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+        gl.generateMipmap(gl.TEXTURE_2D);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+        textureCache.set(url, tex);
+    };
+    img.onerror = () => {
+        console.warn(`[Yaeger] Failed to load texture: ${url}`);
+        textureCache.set(url, whiteTexture);
+    };
+    img.src = url;
+
+    return whiteTexture;
+}
+
+// ---------------------------------------------------------------------------
+// Input state  (unchanged from Canvas 2D version)
+// ---------------------------------------------------------------------------
+
 const pressedKeys = new Set();
 let mouseX = 0;
 let mouseY = 0;
@@ -46,67 +190,29 @@ function normalizeWheelDeltaToPixels(e) {
     return e.deltaY;
 }
 
-/**
- * Initialises the 2D rendering context and input listeners for the given canvas element.
- * Must be called once before any other export.
- */
-export function initCanvas(canvasId) {
-    disposeCanvas();
-
-    canvas = document.getElementById(canvasId);
-    if (!canvas) {
-        throw new Error(`[Yaeger] Canvas element '#${canvasId}' not found.`);
-    }
-    ctx = canvas.getContext('2d');
-    if (!ctx) {
-        throw new Error(`[Yaeger] Failed to acquire 2D context for canvas '#${canvasId}'.`);
-    }
-    canvas.style.touchAction = 'none';
-
+function setupInputListeners() {
     resizeCanvasHandler = () => {
-        if (!canvas) {
-            return;
-        }
-
+        if (!canvas) return;
         const dpr = window.devicePixelRatio || 1;
         canvas.width = Math.round(canvas.clientWidth * dpr);
         canvas.height = Math.round(canvas.clientHeight * dpr);
+        if (gl) gl.viewport(0, 0, canvas.width, canvas.height);
     };
 
-    keyDownHandler = (e) => {
-        if (e.code) {
-            pressedKeys.add(e.code);
-        }
-    };
-    keyUpHandler = (e) => {
-        if (e.code) {
-            pressedKeys.delete(e.code);
-        }
-    };
+    keyDownHandler = (e) => { if (e.code) pressedKeys.add(e.code); };
+    keyUpHandler = (e) => { if (e.code) pressedKeys.delete(e.code); };
 
     pointerMoveHandler = (e) => {
-        if (!canvas) {
-            return;
-        }
-
-        if (e.pointerType !== 'mouse' && e.pointerId !== activePrimaryPointerId) {
-            return;
-        }
-
+        if (!canvas) return;
+        if (e.pointerType !== 'mouse' && e.pointerId !== activePrimaryPointerId) return;
         const rect = canvas.getBoundingClientRect();
         mouseX = e.clientX - rect.left;
         mouseY = e.clientY - rect.top;
-
-        if (e.pointerType !== 'mouse') {
-            e.preventDefault();
-        }
+        if (e.pointerType !== 'mouse') e.preventDefault();
     };
 
     pointerDownHandler = (e) => {
-        if (!canvas) {
-            return;
-        }
-
+        if (!canvas) return;
         if (e.pointerType === 'mouse') {
             const rect = canvas.getBoundingClientRect();
             mouseX = e.clientX - rect.left;
@@ -114,64 +220,35 @@ export function initCanvas(canvasId) {
             mouseButtons.add(e.button);
             return;
         }
-
-        if (activePrimaryPointerId === undefined) {
-            activePrimaryPointerId = e.pointerId;
-        }
-
-        if (e.pointerId !== activePrimaryPointerId) {
-            return;
-        }
-
+        if (activePrimaryPointerId === undefined) activePrimaryPointerId = e.pointerId;
+        if (e.pointerId !== activePrimaryPointerId) return;
         const rect = canvas.getBoundingClientRect();
         mouseX = e.clientX - rect.left;
         mouseY = e.clientY - rect.top;
         mouseButtons.add(0);
-        if (canvas.setPointerCapture) {
-            canvas.setPointerCapture(e.pointerId);
-        }
+        if (canvas.setPointerCapture) canvas.setPointerCapture(e.pointerId);
         e.preventDefault();
     };
 
     pointerUpHandler = (e) => {
-        if (!canvas) {
-            return;
-        }
-
-        if (e.pointerType === 'mouse') {
-            mouseButtons.delete(e.button);
-            return;
-        }
-
-        if (e.pointerId !== activePrimaryPointerId) {
-            return;
-        }
-
+        if (!canvas) return;
+        if (e.pointerType === 'mouse') { mouseButtons.delete(e.button); return; }
+        if (e.pointerId !== activePrimaryPointerId) return;
         mouseButtons.delete(0);
         activePrimaryPointerId = undefined;
-        if (canvas.hasPointerCapture?.(e.pointerId)) {
-            canvas.releasePointerCapture(e.pointerId);
-        }
+        if (canvas.hasPointerCapture?.(e.pointerId)) canvas.releasePointerCapture(e.pointerId);
         e.preventDefault();
     };
 
     pointerCancelHandler = (e) => {
-        if (!canvas || e.pointerType === 'mouse' || e.pointerId !== activePrimaryPointerId) {
-            return;
-        }
-
+        if (!canvas || e.pointerType === 'mouse' || e.pointerId !== activePrimaryPointerId) return;
         mouseButtons.delete(0);
         activePrimaryPointerId = undefined;
-        if (canvas.hasPointerCapture?.(e.pointerId)) {
-            canvas.releasePointerCapture(e.pointerId);
-        }
+        if (canvas.hasPointerCapture?.(e.pointerId)) canvas.releasePointerCapture(e.pointerId);
         e.preventDefault();
     };
 
-    wheelHandler = (e) => {
-        scrollDelta += normalizeWheelDeltaToPixels(e);
-        e.preventDefault();
-    };
+    wheelHandler = (e) => { scrollDelta += normalizeWheelDeltaToPixels(e); e.preventDefault(); };
     blurHandler = () => clearInputState();
     contextMenuHandler = (e) => e.preventDefault();
 
@@ -188,96 +265,202 @@ export function initCanvas(canvasId) {
     canvas.addEventListener('contextmenu', contextMenuHandler);
 }
 
-/**
- * Removes canvas/input event listeners and clears browser-side input state.
- */
-export function disposeCanvas() {
+function removeInputListeners() {
     if (resizeCanvasHandler) {
         window.removeEventListener('resize', resizeCanvasHandler);
         resizeCanvasHandler = undefined;
     }
-
     if (keyDownHandler) {
         window.removeEventListener('keydown', keyDownHandler);
         keyDownHandler = undefined;
     }
-
     if (keyUpHandler) {
         window.removeEventListener('keyup', keyUpHandler);
         keyUpHandler = undefined;
     }
-
     if (pointerMoveHandler && canvas) {
         canvas.removeEventListener('pointermove', pointerMoveHandler, POINTER_EVENT_OPTIONS);
         pointerMoveHandler = undefined;
     }
-
     if (pointerDownHandler && canvas) {
         canvas.removeEventListener('pointerdown', pointerDownHandler, POINTER_EVENT_OPTIONS);
         pointerDownHandler = undefined;
     }
-
     if (pointerUpHandler) {
         window.removeEventListener('pointerup', pointerUpHandler, POINTER_EVENT_OPTIONS);
         pointerUpHandler = undefined;
     }
-
     if (pointerCancelHandler) {
         window.removeEventListener('pointercancel', pointerCancelHandler, POINTER_EVENT_OPTIONS);
         pointerCancelHandler = undefined;
     }
-
     if (wheelHandler && canvas) {
         canvas.removeEventListener('wheel', wheelHandler, WHEEL_EVENT_OPTIONS);
         wheelHandler = undefined;
     }
-
     if (blurHandler) {
         window.removeEventListener('blur', blurHandler);
         blurHandler = undefined;
     }
-
     if (contextMenuHandler && canvas) {
         canvas.removeEventListener('contextmenu', contextMenuHandler);
         contextMenuHandler = undefined;
     }
+}
 
+// ---------------------------------------------------------------------------
+// Exported API
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialises the WebGL 2.0 rendering context, compiles shaders, allocates GPU
+ * buffers, and registers input event listeners for the given canvas element.
+ * Must be called once before any other export.
+ */
+export function initWebGL(canvasId) {
+    disposeCanvas();
+
+    canvas = document.getElementById(canvasId);
+    if (!canvas) throw new Error(`[Yaeger] Canvas element '#${canvasId}' not found.`);
+
+    gl = canvas.getContext('webgl2');
+    if (!gl) throw new Error('[Yaeger] WebGL 2.0 is not supported in this browser.');
+
+    // Shaders
+    shaderProgram = createShaderProgram(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
+    viewProjUniformLocation = gl.getUniformLocation(shaderProgram, 'uViewProj');
+    textureUniformLocation = gl.getUniformLocation(shaderProgram, 'uTexture');
+
+    gl.useProgram(shaderProgram);
+    gl.uniform1i(textureUniformLocation, 0);
+    // Identity view-projection as default
+    gl.uniformMatrix4fv(viewProjUniformLocation, false, [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    ]);
+
+    // VBO — dynamic, large enough for one full batch
+    vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(
+        gl.ARRAY_BUFFER,
+        MAX_QUADS * VERTICES_PER_QUAD * FLOATS_PER_VERTEX * 4, // bytes
+        gl.DYNAMIC_DRAW
+    );
+
+    // EBO — static index buffer, shared across all batches
+    ebo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ebo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, generateQuadIndices(MAX_QUADS), gl.STATIC_DRAW);
+
+    // VAO — captures attribute layout once
+    vao = gl.createVertexArray();
+    gl.bindVertexArray(vao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ebo);
+
+    const stride = FLOATS_PER_VERTEX * 4; // bytes per vertex
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, stride, 0);        // position (3 floats)
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 2, gl.FLOAT, false, stride, 3 * 4);    // texcoord (2 floats)
+    gl.enableVertexAttribArray(2);
+    gl.vertexAttribPointer(2, 4, gl.FLOAT, false, stride, 5 * 4);    // color    (4 floats)
+
+    gl.bindVertexArray(null);
+
+    // 1×1 white fallback texture (used for empty paths and while async loads are in flight)
+    whiteTexture = createWhiteTexture();
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    setupInputListeners();
+}
+
+/**
+ * Clears the colour buffer and updates the WebGL viewport if the canvas was resized.
+ */
+export function clearFrame() {
+    if (!gl) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const w = Math.round(canvas.clientWidth * dpr);
+    const h = Math.round(canvas.clientHeight * dpr);
+    if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w;
+        canvas.height = h;
+        gl.viewport(0, 0, w, h);
+    }
+
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+}
+
+/**
+ * Updates the view-projection matrix uniform used for all subsequent draw calls.
+ * <paramref name="matrix"/> is a Float32Array of 16 elements in row-major order
+ * (System.Numerics.Matrix4x4 layout). Passing it with transpose=false to
+ * uniformMatrix4fv matches the convention used by the desktop OpenGL renderer.
+ */
+export function setViewProjection(matrix) {
+    if (!gl || !shaderProgram) return;
+    gl.useProgram(shaderProgram);
+    gl.uniformMatrix4fv(viewProjUniformLocation, false, matrix);
+}
+
+/**
+ * Renders one texture batch.  <paramref name="vertices"/> is the C# vertex scratch buffer
+ * (Float32Array, 9 floats per vertex, 4 vertices per quad); only the first
+ * <c>quadCount * 4 * 9</c> floats are uploaded.  The texture for
+ * <paramref name="textureUrl"/> is loaded asynchronously on first use; a 1×1 white
+ * fallback is used while it is in flight so the tint colour still renders correctly.
+ */
+export function drawBatch(textureUrl, vertices, quadCount) {
+    if (!gl || quadCount <= 0) return;
+
+    const texture = getOrLoadTexture(textureUrl);
+    const floatCount = quadCount * VERTICES_PER_QUAD * FLOATS_PER_VERTEX;
+
+    gl.useProgram(shaderProgram);
+    gl.bindVertexArray(vao);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    // Upload only the live portion of the scratch buffer (element-count form of bufferSubData).
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, vertices, 0, floatCount);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+
+    gl.drawElements(gl.TRIANGLES, quadCount * INDICES_PER_QUAD, gl.UNSIGNED_INT, 0);
+
+    gl.bindVertexArray(null);
+}
+
+/**
+ * Releases all WebGL resources, removes input event listeners, and resets state.
+ */
+export function disposeCanvas() {
+    if (gl) {
+        textureCache.forEach((tex) => {
+            if (tex && tex !== whiteTexture) gl.deleteTexture(tex);
+        });
+        textureCache.clear();
+        if (whiteTexture) { gl.deleteTexture(whiteTexture); whiteTexture = null; }
+        if (vao) { gl.deleteVertexArray(vao); vao = null; }
+        if (vbo) { gl.deleteBuffer(vbo); vbo = null; }
+        if (ebo) { gl.deleteBuffer(ebo); ebo = null; }
+        if (shaderProgram) { gl.deleteProgram(shaderProgram); shaderProgram = null; }
+        gl = null;
+    }
+
+    removeInputListeners();
     clearInputState();
     mouseX = 0;
     mouseY = 0;
-    ctx = undefined;
-    canvas = undefined;
-}
-
-/**
- * Clears the canvas and establishes the NDC-to-pixel base transform.
- * After this call the canvas coordinate system maps NDC [-1, 1] to pixels,
- * with the Y-axis pointing upward (matching OpenGL conventions).
- */
-export function clearFrame() {
-    if (!ctx) return;
-    ctx.resetTransform();
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    const hw = canvas.width / 2;
-    const hh = canvas.height / 2;
-    // NDC (0, 0) → canvas centre; NDC y increases upward; canvas y increases downward.
-    ctx.setTransform(hw, 0, 0, -hh, hw, hh);
-}
-
-/**
- * Draws a unit quad [-0.5, 0.5]^2 using the given 2-D affine model matrix and RGBA fill color.
- *
- * The six matrix parameters map directly from System.Numerics.Matrix4x4 (row-major):
- *   Canvas ctx.transform(a, b, c, d, e, f) where a=m11, b=m12, c=m21, d=m22, e=tx, f=ty.
- */
-export function drawQuad(m11, m12, m21, m22, tx, ty, r, g, b, a) {
-    if (!ctx) return;
-    ctx.save();
-    ctx.transform(m11, m12, m21, m22, tx, ty);
-    ctx.fillStyle = `rgba(${Math.round(r * 255)},${Math.round(g * 255)},${Math.round(b * 255)},${a})`;
-    ctx.fillRect(-0.5, -0.5, 1, 1);
-    ctx.restore();
+    canvas = null;
 }
 
 export function isKeyPressed(key) {

--- a/Samples/BrowserDemo/wwwroot/yaeger-browser.js
+++ b/Samples/BrowserDemo/wwwroot/yaeger-browser.js
@@ -130,7 +130,11 @@ function getOrLoadTexture(url) {
         if (!gl) return;
         const tex = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D, tex);
+        // Flip Y so row 0 is at the bottom, matching StbImageSharp FlipVerticallyOnLoad
+        // used by the desktop Texture loader. Without this, sprites render upside-down.
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
         gl.generateMipmap(gl.TEXTURE_2D);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
@@ -401,35 +405,39 @@ export function clearFrame() {
 
 /**
  * Updates the view-projection matrix uniform used for all subsequent draw calls.
- * <paramref name="matrix"/> is a Float32Array of 16 elements in row-major order
- * (System.Numerics.Matrix4x4 layout). Passing it with transpose=false to
- * uniformMatrix4fv matches the convention used by the desktop OpenGL renderer.
+ * <paramref name="matrixBytes"/> is a Uint8Array of 64 bytes — the raw memory of a
+ * System.Numerics.Matrix4x4 (16 × IEEE 754 float, row-major). The bytes are
+ * reinterpreted as a Float32Array and passed with transpose=false, matching the
+ * convention used by the desktop OpenGL renderer.
  */
-export function setViewProjection(matrix) {
+export function setViewProjection(matrixBytes) {
     if (!gl || !shaderProgram) return;
     gl.useProgram(shaderProgram);
-    gl.uniformMatrix4fv(viewProjUniformLocation, false, matrix);
+    // Copy to a fresh aligned buffer so Float32Array view is always valid.
+    const aligned = new Uint8Array(64);
+    aligned.set(matrixBytes.subarray(0, 64));
+    gl.uniformMatrix4fv(viewProjUniformLocation, false, new Float32Array(aligned.buffer));
 }
 
 /**
- * Renders one texture batch.  <paramref name="vertices"/> is the C# vertex scratch buffer
- * (Float32Array, 9 floats per vertex, 4 vertices per quad); only the first
- * <c>quadCount * 4 * 9</c> floats are uploaded.  The texture for
- * <paramref name="textureUrl"/> is loaded asynchronously on first use; a 1×1 white
- * fallback is used while it is in flight so the tint colour still renders correctly.
+ * Renders one texture batch.  <paramref name="vertexBytes"/> is a Uint8Array containing
+ * the raw bytes of the C# float vertex scratch buffer (9 floats × 4 bytes per vertex,
+ * 4 vertices per quad); only the first <c>quadCount * 4 * 9 * 4</c> bytes are uploaded.
+ * The texture for <paramref name="textureUrl"/> is loaded asynchronously on first use;
+ * a 1×1 white fallback is used while it is in flight so tint colour still renders.
  */
-export function drawBatch(textureUrl, vertices, quadCount) {
+export function drawBatch(textureUrl, vertexBytes, quadCount) {
     if (!gl || quadCount <= 0) return;
 
     const texture = getOrLoadTexture(textureUrl);
-    const floatCount = quadCount * VERTICES_PER_QUAD * FLOATS_PER_VERTEX;
+    const byteCount = quadCount * VERTICES_PER_QUAD * FLOATS_PER_VERTEX * 4;
 
     gl.useProgram(shaderProgram);
     gl.bindVertexArray(vao);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
-    // Upload only the live portion of the scratch buffer (element-count form of bufferSubData).
-    gl.bufferSubData(gl.ARRAY_BUFFER, 0, vertices, 0, floatCount);
+    // Upload only the live portion. bufferSubData with a Uint8Array uses byte counts.
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, vertexBytes, 0, byteCount);
 
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, texture);

--- a/src/Engine/Yaeger.Browser/BrowserRenderSurface.cs
+++ b/src/Engine/Yaeger.Browser/BrowserRenderSurface.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Numerics;
 using Yaeger.Browser.Interop;
 using Yaeger.Platform;
@@ -6,21 +5,30 @@ using Yaeger.Platform;
 namespace Yaeger.Browser;
 
 /// <summary>
-/// <see cref="IRenderSurface"/> implementation that draws colored quads onto an HTML5
-/// Canvas 2D context via JavaScript interop.
-/// Texture paths and UV coordinates are ignored; the quad's <c>color</c> tint is used instead.
-/// When <see cref="SetCamera"/> has been called with a non-identity matrix, that
-/// view-projection is incorporated into every quad's transform before submission.
+/// <see cref="IRenderSurface"/> implementation that renders textured, tinted quads onto an
+/// HTML5 canvas via a WebGL 2.0 context.  Sprites and sprite-sheet UV sub-regions are
+/// fully supported.  Contiguous quads that share a texture path are coalesced into a single
+/// WebGL draw call (up to 1 000 quads), matching the batching strategy of the desktop
+/// <c>Renderer</c>.
 /// </summary>
 public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDisposable
 {
-    private Matrix4x4 _viewProjection = Matrix4x4.Identity;
+    private const int MaxQuadsPerBatch = 1000;
+    private const int VerticesPerQuad = 4;
+    private const int FloatsPerVertex = 9; // pos(3) + uv(2) + color(4)
+
+    private readonly List<QuadSubmission> _submissionQueue = [];
+
+    // Scratch buffer large enough for one full batch; reused every flush.
+    private readonly float[] _vertexBuffer = new float[
+        MaxQuadsPerBatch * VerticesPerQuad * FloatsPerVertex
+    ];
 
     /// <summary>
-    /// Initialises the canvas 2D context. Must be called once, after
+    /// Initialises the WebGL context. Must be called once, after
     /// <c>JSHost.ImportAsync("yaeger-browser", …)</c> has completed.
     /// </summary>
-    public void Initialize() => JsInterop.InitCanvas(canvasId);
+    public void Initialize() => JsInterop.InitWebGL(canvasId);
 
     public void Dispose()
     {
@@ -30,48 +38,48 @@ public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDis
 
     public void BeginFrame()
     {
-        // Primary path: BrowserInputState.BeginFrame() is called at the host tick boundary
-        // (before update systems run), so scroll is snapshotted before Update runs.
-        // This call is a defensive fallback if a host misses that boundary call; gameplay
-        // code should still read ScrollDelta during Update.
         BrowserInputState.BeginFrame();
         JsInterop.ClearFrame();
+        _submissionQueue.Clear();
     }
 
-    public void EndFrame() => BrowserInputState.EndFrame();
-
-    public void FlushQueuedQuads() { }
-
-    /// <summary>
-    /// Stores the view-projection matrix that will be combined with every subsequent
-    /// quad transform.  Uses row-major (System.Numerics) convention:
-    /// <c>combined = model * viewProjection</c>.
-    /// </summary>
-    public void SetCamera(Matrix4x4 viewProjection) => _viewProjection = viewProjection;
-
-    /// <inheritdoc/>
-    /// <remarks>
-    /// The model <paramref name="transform"/> is multiplied by the stored view-projection
-    /// matrix (row-major: <c>combined = transform * _viewProjection</c>) and the six 2-D
-    /// affine components (m11, m12, m21, m22, tx, ty) of the result are passed to the
-    /// Canvas 2D <c>ctx.transform()</c> call.
-    /// </remarks>
-    public void SubmitQuad(Matrix4x4 transform, string texturePath, Vector4 color)
+    public void EndFrame()
     {
-        var combined = transform * _viewProjection;
-        JsInterop.DrawQuad(
-            combined.M11,
-            combined.M12,
-            combined.M21,
-            combined.M22,
-            combined.M41,
-            combined.M42,
-            color.X,
-            color.Y,
-            color.Z,
-            color.W
-        );
+        FlushQueuedQuads();
+        BrowserInputState.EndFrame();
     }
+
+    public void FlushQueuedQuads()
+    {
+        if (_submissionQueue.Count == 0)
+            return;
+
+        var startIndex = 0;
+        while (startIndex < _submissionQueue.Count)
+        {
+            var texturePath = _submissionQueue[startIndex].TexturePath;
+            var batchSize = 1;
+            while (
+                startIndex + batchSize < _submissionQueue.Count
+                && batchSize < MaxQuadsPerBatch
+                && _submissionQueue[startIndex + batchSize].TexturePath == texturePath
+            )
+            {
+                batchSize++;
+            }
+
+            RenderBatch(texturePath, startIndex, batchSize);
+            startIndex += batchSize;
+        }
+
+        _submissionQueue.Clear();
+    }
+
+    public void SetCamera(Matrix4x4 viewProjection) =>
+        JsInterop.SetViewProjection(MatrixToFloats(viewProjection));
+
+    public void SubmitQuad(Matrix4x4 transform, string texturePath, Vector4 color) =>
+        SubmitQuad(transform, texturePath, Vector2.Zero, Vector2.One, color);
 
     public void SubmitQuad(
         Matrix4x4 transform,
@@ -79,5 +87,80 @@ public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDis
         Vector2 uvMin,
         Vector2 uvMax,
         Vector4 color
-    ) => SubmitQuad(transform, texturePath, color);
+    ) => _submissionQueue.Add(new QuadSubmission(texturePath, transform, uvMin, uvMax, color));
+
+    private void RenderBatch(string texturePath, int startIndex, int batchSize)
+    {
+        FillVertexBuffer(startIndex, batchSize);
+        JsInterop.DrawBatch(texturePath, _vertexBuffer, batchSize);
+    }
+
+    private void FillVertexBuffer(int startIndex, int count)
+    {
+        // Corner order matches the quad winding baked into the JS index buffer: TR, BR, BL, TL.
+        ReadOnlySpan<Vector3> basePositions =
+        [
+            new Vector3(0.5f, 0.5f, 0f),
+            new Vector3(0.5f, -0.5f, 0f),
+            new Vector3(-0.5f, -0.5f, 0f),
+            new Vector3(-0.5f, 0.5f, 0f),
+        ];
+
+        for (var q = 0; q < count; q++)
+        {
+            var sub = _submissionQueue[startIndex + q];
+
+            ReadOnlySpan<Vector2> uvs =
+            [
+                new Vector2(sub.UvMax.X, sub.UvMax.Y), // TR
+                new Vector2(sub.UvMax.X, sub.UvMin.Y), // BR
+                new Vector2(sub.UvMin.X, sub.UvMin.Y), // BL
+                new Vector2(sub.UvMin.X, sub.UvMax.Y), // TL
+            ];
+
+            var baseOffset = q * VerticesPerQuad * FloatsPerVertex;
+            for (var c = 0; c < VerticesPerQuad; c++)
+            {
+                var pos = Vector3.Transform(basePositions[c], sub.Transform);
+                var offset = baseOffset + c * FloatsPerVertex;
+                _vertexBuffer[offset + 0] = pos.X;
+                _vertexBuffer[offset + 1] = pos.Y;
+                _vertexBuffer[offset + 2] = pos.Z;
+                _vertexBuffer[offset + 3] = uvs[c].X;
+                _vertexBuffer[offset + 4] = uvs[c].Y;
+                _vertexBuffer[offset + 5] = sub.Color.X;
+                _vertexBuffer[offset + 6] = sub.Color.Y;
+                _vertexBuffer[offset + 7] = sub.Color.Z;
+                _vertexBuffer[offset + 8] = sub.Color.W;
+            }
+        }
+    }
+
+    private static float[] MatrixToFloats(in Matrix4x4 m) =>
+        [
+            m.M11,
+            m.M12,
+            m.M13,
+            m.M14,
+            m.M21,
+            m.M22,
+            m.M23,
+            m.M24,
+            m.M31,
+            m.M32,
+            m.M33,
+            m.M34,
+            m.M41,
+            m.M42,
+            m.M43,
+            m.M44,
+        ];
+
+    private readonly record struct QuadSubmission(
+        string TexturePath,
+        Matrix4x4 Transform,
+        Vector2 UvMin,
+        Vector2 UvMax,
+        Vector4 Color
+    );
 }

--- a/src/Engine/Yaeger.Browser/BrowserRenderSurface.cs
+++ b/src/Engine/Yaeger.Browser/BrowserRenderSurface.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Runtime.InteropServices;
 using Yaeger.Browser.Interop;
 using Yaeger.Platform;
 
@@ -19,9 +20,12 @@ public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDis
 
     private readonly List<QuadSubmission> _submissionQueue = [];
 
-    // Scratch buffer large enough for one full batch; reused every flush.
+    // Scratch float buffer, filled per batch; _vertexBytes is its raw-byte view passed to JS.
     private readonly float[] _vertexBuffer = new float[
         MaxQuadsPerBatch * VerticesPerQuad * FloatsPerVertex
+    ];
+    private readonly byte[] _vertexBytes = new byte[
+        MaxQuadsPerBatch * VerticesPerQuad * FloatsPerVertex * 4
     ];
 
     /// <summary>
@@ -75,8 +79,13 @@ public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDis
         _submissionQueue.Clear();
     }
 
-    public void SetCamera(Matrix4x4 viewProjection) =>
-        JsInterop.SetViewProjection(MatrixToFloats(viewProjection));
+    public void SetCamera(Matrix4x4 viewProjection)
+    {
+        // Reinterpret the 64-byte struct as a byte[] for the JSImport byte[] marshal path.
+        var bytes = new byte[64];
+        MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref viewProjection, 1)).CopyTo(bytes);
+        JsInterop.SetViewProjection(bytes);
+    }
 
     public void SubmitQuad(Matrix4x4 transform, string texturePath, Vector4 color) =>
         SubmitQuad(transform, texturePath, Vector2.Zero, Vector2.One, color);
@@ -92,7 +101,8 @@ public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDis
     private void RenderBatch(string texturePath, int startIndex, int batchSize)
     {
         FillVertexBuffer(startIndex, batchSize);
-        JsInterop.DrawBatch(texturePath, _vertexBuffer, batchSize);
+        Buffer.BlockCopy(_vertexBuffer, 0, _vertexBytes, 0, batchSize * VerticesPerQuad * FloatsPerVertex * 4);
+        JsInterop.DrawBatch(texturePath, _vertexBytes, batchSize);
     }
 
     private void FillVertexBuffer(int startIndex, int count)
@@ -135,26 +145,6 @@ public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDis
             }
         }
     }
-
-    private static float[] MatrixToFloats(in Matrix4x4 m) =>
-        [
-            m.M11,
-            m.M12,
-            m.M13,
-            m.M14,
-            m.M21,
-            m.M22,
-            m.M23,
-            m.M24,
-            m.M31,
-            m.M32,
-            m.M33,
-            m.M34,
-            m.M41,
-            m.M42,
-            m.M43,
-            m.M44,
-        ];
 
     private readonly record struct QuadSubmission(
         string TexturePath,

--- a/src/Engine/Yaeger.Browser/BrowserRenderSurface.cs
+++ b/src/Engine/Yaeger.Browser/BrowserRenderSurface.cs
@@ -81,9 +81,9 @@ public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDis
 
     public void SetCamera(Matrix4x4 viewProjection)
     {
-        // Reinterpret the 64-byte struct as a byte[] for the JSImport byte[] marshal path.
+        var span = MemoryMarshal.CreateReadOnlySpan(ref viewProjection, 1);
         var bytes = new byte[64];
-        MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref viewProjection, 1)).CopyTo(bytes);
+        MemoryMarshal.AsBytes(span).CopyTo(bytes);
         JsInterop.SetViewProjection(bytes);
     }
 
@@ -101,7 +101,8 @@ public sealed class BrowserRenderSurface(string canvasId) : IRenderSurface, IDis
     private void RenderBatch(string texturePath, int startIndex, int batchSize)
     {
         FillVertexBuffer(startIndex, batchSize);
-        Buffer.BlockCopy(_vertexBuffer, 0, _vertexBytes, 0, batchSize * VerticesPerQuad * FloatsPerVertex * 4);
+        var byteCount = batchSize * VerticesPerQuad * FloatsPerVertex * 4;
+        Buffer.BlockCopy(_vertexBuffer, 0, _vertexBytes, 0, byteCount);
         JsInterop.DrawBatch(texturePath, _vertexBytes, batchSize);
     }
 

--- a/src/Engine/Yaeger.Browser/Interop/JsInterop.cs
+++ b/src/Engine/Yaeger.Browser/Interop/JsInterop.cs
@@ -19,20 +19,21 @@ internal static partial class JsInterop
 
     /// <summary>
     /// Sets the view-projection matrix uniform used by all subsequent draw calls.
-    /// <paramref name="matrix16"/> is the 16 elements of a System.Numerics.Matrix4x4 in
-    /// row-major order (M11…M44). WebGL reads it as column-major (transpose=false), which
-    /// matches the convention used by the desktop OpenGL renderer.
+    /// <paramref name="matrix64bytes"/> is the 64 raw bytes of a System.Numerics.Matrix4x4
+    /// (16 × IEEE 754 single-precision floats, row-major). The JS side reinterprets the
+    /// Uint8Array as a Float32Array before passing it to uniformMatrix4fv(transpose=false),
+    /// matching the convention used by the desktop OpenGL renderer.
     /// </summary>
     [JSImport("setViewProjection", "yaeger-browser")]
-    public static partial void SetViewProjection(float[] matrix16);
+    public static partial void SetViewProjection(byte[] matrix64bytes);
 
     /// <summary>
-    /// Draws one texture batch. <paramref name="vertices"/> is the full vertex scratch buffer
-    /// (9 floats per vertex, 4 vertices per quad); only the first
-    /// <c>quadCount * 4 * 9</c> floats are uploaded to the GPU.
+    /// Draws one texture batch. <paramref name="vertexBytes"/> contains the raw bytes of the
+    /// float vertex scratch buffer (9 floats × 4 bytes per vertex, 4 vertices per quad);
+    /// only the first <c>quadCount * 4 * 9 * 4</c> bytes are uploaded to the GPU.
     /// </summary>
     [JSImport("drawBatch", "yaeger-browser")]
-    public static partial void DrawBatch(string textureUrl, float[] vertices, int quadCount);
+    public static partial void DrawBatch(string textureUrl, byte[] vertexBytes, int quadCount);
 
     [JSImport("isKeyPressed", "yaeger-browser")]
     public static partial bool IsKeyPressed(string key);

--- a/src/Engine/Yaeger.Browser/Interop/JsInterop.cs
+++ b/src/Engine/Yaeger.Browser/Interop/JsInterop.cs
@@ -8,8 +8,8 @@ namespace Yaeger.Browser.Interop;
 /// </summary>
 internal static partial class JsInterop
 {
-    [JSImport("initCanvas", "yaeger-browser")]
-    public static partial void InitCanvas(string canvasId);
+    [JSImport("initWebGL", "yaeger-browser")]
+    public static partial void InitWebGL(string canvasId);
 
     [JSImport("clearFrame", "yaeger-browser")]
     public static partial void ClearFrame();
@@ -18,23 +18,21 @@ internal static partial class JsInterop
     public static partial void DisposeCanvas();
 
     /// <summary>
-    /// Draws a unit quad [-0.5, 0.5]^2.
-    /// m11/m12/m21/m22 are the 2-D linear part of the model matrix (row-major .NET convention).
-    /// tx/ty are the translation.  r/g/b/a are the fill color (0–1 each).
+    /// Sets the view-projection matrix uniform used by all subsequent draw calls.
+    /// <paramref name="matrix16"/> is the 16 elements of a System.Numerics.Matrix4x4 in
+    /// row-major order (M11…M44). WebGL reads it as column-major (transpose=false), which
+    /// matches the convention used by the desktop OpenGL renderer.
     /// </summary>
-    [JSImport("drawQuad", "yaeger-browser")]
-    public static partial void DrawQuad(
-        double m11,
-        double m12,
-        double m21,
-        double m22,
-        double tx,
-        double ty,
-        double r,
-        double g,
-        double b,
-        double a
-    );
+    [JSImport("setViewProjection", "yaeger-browser")]
+    public static partial void SetViewProjection(float[] matrix16);
+
+    /// <summary>
+    /// Draws one texture batch. <paramref name="vertices"/> is the full vertex scratch buffer
+    /// (9 floats per vertex, 4 vertices per quad); only the first
+    /// <c>quadCount * 4 * 9</c> floats are uploaded to the GPU.
+    /// </summary>
+    [JSImport("drawBatch", "yaeger-browser")]
+    public static partial void DrawBatch(string textureUrl, float[] vertices, int quadCount);
 
     [JSImport("isKeyPressed", "yaeger-browser")]
     public static partial bool IsKeyPressed(string key);


### PR DESCRIPTION
The previous BrowserRenderSurface used an HTML5 Canvas 2D context and
silently ignored texture paths and UV coordinates, rendering only solid
tinted quads.  This replaces it with a full WebGL 2.0 renderer that
supports textured sprites, sprite-sheet UV sub-regions, and the same
texture-grouped batching strategy as the desktop OpenGL Renderer.

Key changes:
- BrowserRenderSurface now queues QuadSubmission records, builds a
  shared float[] vertex scratch buffer (9 floats/vertex, same layout as
  Renderer), and issues one JS drawBatch() call per texture group per
  frame — matching the desktop batching logic exactly.
- JsInterop drops InitCanvas/DrawQuad in favour of InitWebGL,
  SetViewProjection(float[16]), and DrawBatch(url, Float32Array, count).
- yaeger-browser.js compiles GLSL ES 3.00 shaders, allocates a VAO/VBO
  (dynamic) / EBO (static, pre-generated indices for 1000 quads), and
  loads textures asynchronously with a 1×1 white fallback so tint colour
  renders immediately while images are in flight.  All input handling is
  preserved unchanged.

Desktop OpenGL path (Renderer.cs, Window.cs) is unaffected.

https://claude.ai/code/session_015U8gKtBNmXopFCW7p8sixt