### PR TITLE
Add HTTP asset loading for scenes, prefabs, and fonts (issue #55)

### DIFF
--- a/src/Engine/Yaeger/ECS/PrefabLoader.cs
+++ b/src/Engine/Yaeger/ECS/PrefabLoader.cs
@@ -82,6 +82,12 @@ public sealed class PrefabLoader
         ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
         ArgumentNullException.ThrowIfNull(httpClient);
 
+        if (
+            !Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || uri.Scheme is not ("http" or "https")
+        )
+            throw new ArgumentException("Must be an absolute http or https URL.", nameof(url));
+
         try
         {
             using var response = await httpClient

--- a/src/Engine/Yaeger/ECS/PrefabLoader.cs
+++ b/src/Engine/Yaeger/ECS/PrefabLoader.cs
@@ -102,6 +102,10 @@ public sealed class PrefabLoader
         {
             throw new PrefabLoadException($"Failed to fetch prefab from '{url}': {ex.Message}", ex);
         }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new PrefabLoadException($"Request timed out fetching prefab from '{url}'.", ex);
+        }
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/ECS/PrefabLoader.cs
+++ b/src/Engine/Yaeger/ECS/PrefabLoader.cs
@@ -82,12 +82,21 @@ public sealed class PrefabLoader
         ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
         ArgumentNullException.ThrowIfNull(httpClient);
 
-        HttpResponseMessage response;
         try
         {
-            response = await httpClient
+            using var response = await httpClient
                 .GetAsync(url, cancellationToken)
                 .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+                throw new PrefabLoadException(
+                    $"HTTP {(int)response.StatusCode} fetching prefab from '{url}'."
+                );
+
+            var json = await response
+                .Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return Parse(json);
         }
         catch (HttpRequestException ex)
         {
@@ -96,16 +105,6 @@ public sealed class PrefabLoader
                 ex
             );
         }
-
-        if (!response.IsSuccessStatusCode)
-            throw new PrefabLoadException(
-                $"HTTP {(int)response.StatusCode} fetching prefab from '{url}'."
-            );
-
-        var json = await response
-            .Content.ReadAsStringAsync(cancellationToken)
-            .ConfigureAwait(false);
-        return Parse(json);
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/ECS/PrefabLoader.cs
+++ b/src/Engine/Yaeger/ECS/PrefabLoader.cs
@@ -63,6 +63,52 @@ public sealed class PrefabLoader
     }
 
     /// <summary>
+    /// Loads a <see cref="Prefab"/> from a URL over HTTP.
+    /// Works in desktop and WASM environments (the WASM HttpClient routes through the
+    /// browser Fetch API, making this call async-safe with no blocking I/O).
+    /// </summary>
+    /// <param name="url">Absolute HTTP/HTTPS URL of the <c>.prefab.json</c> resource.</param>
+    /// <param name="httpClient">The <see cref="HttpClient"/> to use for the request.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <exception cref="PrefabLoadException">
+    /// When the request fails, returns a non-success HTTP status, or the JSON is invalid.
+    /// </exception>
+    public async Task<Prefab> LoadAsync(
+        string url,
+        HttpClient httpClient,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await httpClient
+                .GetAsync(url, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new PrefabLoadException(
+                $"Failed to fetch prefab from '{url}': {ex.Message}",
+                ex
+            );
+        }
+
+        if (!response.IsSuccessStatusCode)
+            throw new PrefabLoadException(
+                $"HTTP {(int)response.StatusCode} fetching prefab from '{url}'."
+            );
+
+        var json = await response
+            .Content.ReadAsStringAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return Parse(json);
+    }
+
+    /// <summary>
     /// Parses a <see cref="Prefab"/> from a JSON string.
     /// </summary>
     /// <param name="json">The JSON string to parse.</param>

--- a/src/Engine/Yaeger/ECS/PrefabLoader.cs
+++ b/src/Engine/Yaeger/ECS/PrefabLoader.cs
@@ -100,10 +100,7 @@ public sealed class PrefabLoader
         }
         catch (HttpRequestException ex)
         {
-            throw new PrefabLoadException(
-                $"Failed to fetch prefab from '{url}': {ex.Message}",
-                ex
-            );
+            throw new PrefabLoadException($"Failed to fetch prefab from '{url}': {ex.Message}", ex);
         }
     }
 

--- a/src/Engine/Yaeger/ECS/SceneLoader.cs
+++ b/src/Engine/Yaeger/ECS/SceneLoader.cs
@@ -84,10 +84,7 @@ public sealed class SceneLoader
         }
         catch (HttpRequestException ex)
         {
-            throw new SceneLoadException(
-                $"Failed to fetch scene from '{url}': {ex.Message}",
-                ex
-            );
+            throw new SceneLoadException($"Failed to fetch scene from '{url}': {ex.Message}", ex);
         }
     }
 

--- a/src/Engine/Yaeger/ECS/SceneLoader.cs
+++ b/src/Engine/Yaeger/ECS/SceneLoader.cs
@@ -66,12 +66,21 @@ public sealed class SceneLoader
         ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
         ArgumentNullException.ThrowIfNull(httpClient);
 
-        HttpResponseMessage response;
         try
         {
-            response = await httpClient
+            using var response = await httpClient
                 .GetAsync(url, cancellationToken)
                 .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+                throw new SceneLoadException(
+                    $"HTTP {(int)response.StatusCode} fetching scene from '{url}'."
+                );
+
+            var json = await response
+                .Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return Parse(json);
         }
         catch (HttpRequestException ex)
         {
@@ -80,16 +89,6 @@ public sealed class SceneLoader
                 ex
             );
         }
-
-        if (!response.IsSuccessStatusCode)
-            throw new SceneLoadException(
-                $"HTTP {(int)response.StatusCode} fetching scene from '{url}'."
-            );
-
-        var json = await response
-            .Content.ReadAsStringAsync(cancellationToken)
-            .ConfigureAwait(false);
-        return Parse(json);
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/ECS/SceneLoader.cs
+++ b/src/Engine/Yaeger/ECS/SceneLoader.cs
@@ -66,6 +66,12 @@ public sealed class SceneLoader
         ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
         ArgumentNullException.ThrowIfNull(httpClient);
 
+        if (
+            !Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || uri.Scheme is not ("http" or "https")
+        )
+            throw new ArgumentException("Must be an absolute http or https URL.", nameof(url));
+
         try
         {
             using var response = await httpClient

--- a/src/Engine/Yaeger/ECS/SceneLoader.cs
+++ b/src/Engine/Yaeger/ECS/SceneLoader.cs
@@ -47,6 +47,52 @@ public sealed class SceneLoader
     }
 
     /// <summary>
+    /// Loads a <see cref="Scene"/> from a URL over HTTP.
+    /// Works in desktop and WASM environments (the WASM HttpClient routes through the
+    /// browser Fetch API, making this call async-safe with no blocking I/O).
+    /// </summary>
+    /// <param name="url">Absolute HTTP/HTTPS URL of the <c>.scene.json</c> resource.</param>
+    /// <param name="httpClient">The <see cref="HttpClient"/> to use for the request.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <exception cref="SceneLoadException">
+    /// When the request fails, returns a non-success HTTP status, or the JSON is invalid.
+    /// </exception>
+    public async Task<Scene> LoadAsync(
+        string url,
+        HttpClient httpClient,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await httpClient
+                .GetAsync(url, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new SceneLoadException(
+                $"Failed to fetch scene from '{url}': {ex.Message}",
+                ex
+            );
+        }
+
+        if (!response.IsSuccessStatusCode)
+            throw new SceneLoadException(
+                $"HTTP {(int)response.StatusCode} fetching scene from '{url}'."
+            );
+
+        var json = await response
+            .Content.ReadAsStringAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return Parse(json);
+    }
+
+    /// <summary>
     /// Loads a <see cref="Scene"/> from a JSON file on disk.
     /// </summary>
     public Scene Load(string path)

--- a/src/Engine/Yaeger/ECS/SceneLoader.cs
+++ b/src/Engine/Yaeger/ECS/SceneLoader.cs
@@ -86,6 +86,10 @@ public sealed class SceneLoader
         {
             throw new SceneLoadException($"Failed to fetch scene from '{url}': {ex.Message}", ex);
         }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new SceneLoadException($"Request timed out fetching scene from '{url}'.", ex);
+        }
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/Font/Font.cs
+++ b/src/Engine/Yaeger/Font/Font.cs
@@ -25,6 +25,25 @@ public class Font : IFontHandle, IDisposable
         _font = new HarfBuzzSharp.Font(_face);
     }
 
+    /// <summary>
+    /// Initialises a font from pre-loaded bytes (e.g. fetched over HTTP).
+    /// </summary>
+    /// <param name="id">Logical identifier for this font (typically the source URL or path).</param>
+    /// <param name="fontBytes">Raw font file bytes (TTF, OTF, etc.).</param>
+    public Font(string id, byte[] fontBytes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id, nameof(id));
+        ArgumentNullException.ThrowIfNull(fontBytes);
+        if (fontBytes.Length == 0)
+            throw new ArgumentException("Font bytes must not be empty.", nameof(fontBytes));
+
+        Id = id;
+        FontBytes = fontBytes;
+        _blob = Blob.FromStream(new MemoryStream(FontBytes));
+        _face = new Face(_blob, 0);
+        _font = new HarfBuzzSharp.Font(_face);
+    }
+
     public string Id { get; }
 
     public GlyphInfo[] Shape(string text)

--- a/src/Engine/Yaeger/Font/Font.cs
+++ b/src/Engine/Yaeger/Font/Font.cs
@@ -38,7 +38,7 @@ public class Font : IFontHandle, IDisposable
             throw new ArgumentException("Font bytes must not be empty.", nameof(fontBytes));
 
         Id = id;
-        FontBytes = fontBytes;
+        FontBytes = (byte[])fontBytes.Clone();
         _blob = Blob.FromStream(new MemoryStream(FontBytes));
         _face = new Face(_blob, 0);
         _font = new HarfBuzzSharp.Font(_face);

--- a/src/Engine/Yaeger/Font/FontLoadException.cs
+++ b/src/Engine/Yaeger/Font/FontLoadException.cs
@@ -1,0 +1,13 @@
+namespace Yaeger.Font;
+
+/// <summary>
+/// Thrown when a font cannot be loaded from disk or a remote URL.
+/// </summary>
+public sealed class FontLoadException : Exception
+{
+    public FontLoadException(string message)
+        : base(message) { }
+
+    public FontLoadException(string message, Exception inner)
+        : base(message, inner) { }
+}

--- a/src/Engine/Yaeger/Font/FontLoadException.cs
+++ b/src/Engine/Yaeger/Font/FontLoadException.cs
@@ -1,7 +1,7 @@
 namespace Yaeger.Font;
 
 /// <summary>
-/// Thrown when a font cannot be loaded from disk or a remote URL.
+/// Thrown when a font cannot be loaded from a remote URL.
 /// </summary>
 public sealed class FontLoadException : Exception
 {

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -3,6 +3,7 @@ namespace Yaeger.Font;
 public class FontManager : IDisposable
 {
     private readonly Dictionary<string, Font> _fonts = new();
+    private readonly object _lock = new();
     private bool _disposed;
 
     /// <summary>
@@ -30,8 +31,11 @@ public class FontManager : IDisposable
             throw new ArgumentException("Must be an absolute http or https URL.", nameof(url));
 
         var cacheKey = uri.AbsoluteUri;
-        if (_fonts.TryGetValue(cacheKey, out var cached))
-            return cached;
+        lock (_lock)
+        {
+            if (_fonts.TryGetValue(cacheKey, out var cached))
+                return cached;
+        }
 
         try
         {
@@ -48,13 +52,16 @@ public class FontManager : IDisposable
                 .Content.ReadAsByteArrayAsync(cancellationToken)
                 .ConfigureAwait(false);
             var font = new Font(cacheKey, bytes);
-            if (_fonts.TryGetValue(cacheKey, out var existing))
+            lock (_lock)
             {
-                font.Dispose();
-                return existing;
+                if (_fonts.TryGetValue(cacheKey, out var existing))
+                {
+                    font.Dispose();
+                    return existing;
+                }
+                _fonts[cacheKey] = font;
+                return font;
             }
-            _fonts[cacheKey] = font;
-            return font;
         }
         catch (HttpRequestException ex)
         {
@@ -72,7 +79,7 @@ public class FontManager : IDisposable
 
     public Font Load(string fontPath)
     {
-        ArgumentNullException.ThrowIfNull(fontPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fontPath, nameof(fontPath));
 
         if (IsAbsoluteUrl(fontPath))
             throw new ArgumentException(
@@ -81,27 +88,38 @@ public class FontManager : IDisposable
             );
 
         var key = AssetPath.Resolve(fontPath);
-        if (_fonts.TryGetValue(key, out var existingFont))
-            return existingFont;
+        lock (_lock)
+        {
+            if (_fonts.TryGetValue(key, out var existingFont))
+                return existingFont;
 
-        var font = new Font(key);
-        _fonts[key] = font;
-        return font;
+            var font = new Font(key);
+            _fonts[key] = font;
+            return font;
+        }
     }
 
     public Font? Get(string fontPath)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fontPath, nameof(fontPath));
         var key = NormalizeKey(fontPath);
-        return _fonts.TryGetValue(key, out var font) ? font : null;
+        lock (_lock)
+        {
+            return _fonts.TryGetValue(key, out var font) ? font : null;
+        }
     }
 
     public void Unload(string fontPath)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fontPath, nameof(fontPath));
         var key = NormalizeKey(fontPath);
-        if (_fonts.TryGetValue(key, out var font))
+        lock (_lock)
         {
-            font.Dispose();
-            _fonts.Remove(key);
+            if (_fonts.TryGetValue(key, out var font))
+            {
+                font.Dispose();
+                _fonts.Remove(key);
+            }
         }
     }
 
@@ -111,7 +129,6 @@ public class FontManager : IDisposable
 
     private static string NormalizeKey(string path)
     {
-        ArgumentNullException.ThrowIfNull(path);
         if (Uri.TryCreate(path, UriKind.Absolute, out var uri) && uri.Scheme is ("http" or "https"))
             return uri.AbsoluteUri;
         return AssetPath.Resolve(path);
@@ -119,18 +136,17 @@ public class FontManager : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        lock (_lock)
         {
-            return;
-        }
+            if (_disposed)
+                return;
 
-        foreach (var font in _fonts.Values)
-        {
-            font.Dispose();
-        }
+            foreach (var font in _fonts.Values)
+                font.Dispose();
 
-        _fonts.Clear();
-        _disposed = true;
+            _fonts.Clear();
+            _disposed = true;
+        }
         GC.SuppressFinalize(this);
     }
 }

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -7,7 +7,6 @@ public class FontManager : IDisposable
 
     /// <summary>
     /// Loads a font from a URL over HTTP, caching the result by URL.
-    /// Works in desktop and WASM environments.
     /// </summary>
     /// <param name="url">Absolute HTTP/HTTPS URL of the font file.</param>
     /// <param name="httpClient">The <see cref="HttpClient"/> to use for the request.</param>
@@ -27,12 +26,23 @@ public class FontManager : IDisposable
         if (_fonts.TryGetValue(url, out var cached))
             return cached;
 
-        HttpResponseMessage response;
         try
         {
-            response = await httpClient
+            using var response = await httpClient
                 .GetAsync(url, cancellationToken)
                 .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+                throw new FontLoadException(
+                    $"HTTP {(int)response.StatusCode} fetching font from '{url}'."
+                );
+
+            var bytes = await response
+                .Content.ReadAsByteArrayAsync(cancellationToken)
+                .ConfigureAwait(false);
+            var font = new Font(url, bytes);
+            _fonts[url] = font;
+            return font;
         }
         catch (HttpRequestException ex)
         {
@@ -41,18 +51,6 @@ public class FontManager : IDisposable
                 ex
             );
         }
-
-        if (!response.IsSuccessStatusCode)
-            throw new FontLoadException(
-                $"HTTP {(int)response.StatusCode} fetching font from '{url}'."
-            );
-
-        var bytes = await response
-            .Content.ReadAsByteArrayAsync(cancellationToken)
-            .ConfigureAwait(false);
-        var font = new Font(url, bytes);
-        _fonts[url] = font;
-        return font;
     }
 
     public Font Load(string fontPath)

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -48,6 +48,10 @@ public class FontManager : IDisposable
         {
             throw new FontLoadException($"Failed to fetch font from '{url}': {ex.Message}", ex);
         }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new FontLoadException($"Request timed out fetching font from '{url}'.", ex);
+        }
         catch (Exception ex) when (ex is not (OperationCanceledException or FontLoadException))
         {
             throw new FontLoadException($"Failed to load font from '{url}': {ex.Message}", ex);
@@ -56,32 +60,39 @@ public class FontManager : IDisposable
 
     public Font Load(string fontPath)
     {
-        var resolvedPath = AssetPath.Resolve(fontPath);
-        if (_fonts.TryGetValue(resolvedPath, out var existingFont))
+        var key = NormalizeKey(fontPath);
+        if (_fonts.TryGetValue(key, out var existingFont))
         {
             return existingFont;
         }
 
-        var font = new Font(resolvedPath);
-        _fonts[resolvedPath] = font;
+        var font = new Font(key);
+        _fonts[key] = font;
         return font;
     }
 
     public Font? Get(string fontPath)
     {
-        var resolvedPath = AssetPath.Resolve(fontPath);
-        return _fonts.TryGetValue(resolvedPath, out var font) ? font : null;
+        var key = NormalizeKey(fontPath);
+        return _fonts.TryGetValue(key, out var font) ? font : null;
     }
 
     public void Unload(string fontPath)
     {
-        var resolvedPath = AssetPath.Resolve(fontPath);
-        if (_fonts.TryGetValue(resolvedPath, out var font))
+        var key = NormalizeKey(fontPath);
+        if (_fonts.TryGetValue(key, out var font))
         {
             font.Dispose();
-            _fonts.Remove(resolvedPath);
+            _fonts.Remove(key);
         }
     }
+
+    private static bool IsAbsoluteUrl(string path) =>
+        path.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+        || path.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizeKey(string path) =>
+        IsAbsoluteUrl(path) ? path : AssetPath.Resolve(path);
 
     public void Dispose()
     {

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -51,6 +51,13 @@ public class FontManager : IDisposable
                 ex
             );
         }
+        catch (Exception ex) when (ex is not (OperationCanceledException or FontLoadException))
+        {
+            throw new FontLoadException(
+                $"Failed to load font from '{url}': {ex.Message}",
+                ex
+            );
+        }
     }
 
     public Font Load(string fontPath)

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -69,7 +69,7 @@ public class FontManager : IDisposable
 
         if (IsAbsoluteUrl(fontPath))
             throw new ArgumentException(
-                "URL fonts must be fetched via LoadAsync; this URL is not cached.",
+                "URL fonts must be fetched via LoadAsync.",
                 nameof(fontPath)
             );
 
@@ -98,8 +98,11 @@ public class FontManager : IDisposable
         path.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
         || path.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
 
-    private static string NormalizeKey(string path) =>
-        IsAbsoluteUrl(path) ? path : AssetPath.Resolve(path);
+    private static string NormalizeKey(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return IsAbsoluteUrl(path) ? path : AssetPath.Resolve(path);
+    }
 
     public void Dispose()
     {

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -5,6 +5,56 @@ public class FontManager : IDisposable
     private readonly Dictionary<string, Font> _fonts = new();
     private bool _disposed;
 
+    /// <summary>
+    /// Loads a font from a URL over HTTP, caching the result by URL.
+    /// Works in desktop and WASM environments.
+    /// </summary>
+    /// <param name="url">Absolute HTTP/HTTPS URL of the font file.</param>
+    /// <param name="httpClient">The <see cref="HttpClient"/> to use for the request.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <exception cref="FontLoadException">
+    /// When the request fails or returns a non-success HTTP status.
+    /// </exception>
+    public async Task<Font> LoadAsync(
+        string url,
+        HttpClient httpClient,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        if (_fonts.TryGetValue(url, out var cached))
+            return cached;
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await httpClient
+                .GetAsync(url, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new FontLoadException(
+                $"Failed to fetch font from '{url}': {ex.Message}",
+                ex
+            );
+        }
+
+        if (!response.IsSuccessStatusCode)
+            throw new FontLoadException(
+                $"HTTP {(int)response.StatusCode} fetching font from '{url}'."
+            );
+
+        var bytes = await response
+            .Content.ReadAsByteArrayAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var font = new Font(url, bytes);
+        _fonts[url] = font;
+        return font;
+    }
+
     public Font Load(string fontPath)
     {
         var resolvedPath = AssetPath.Resolve(fontPath);

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -23,10 +23,14 @@ public class FontManager : IDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
         ArgumentNullException.ThrowIfNull(httpClient);
 
-        if (!IsAbsoluteUrl(url))
+        if (
+            !Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || uri.Scheme is not ("http" or "https")
+        )
             throw new ArgumentException("Must be an absolute http or https URL.", nameof(url));
 
-        if (_fonts.TryGetValue(url, out var cached))
+        var cacheKey = uri.AbsoluteUri;
+        if (_fonts.TryGetValue(cacheKey, out var cached))
             return cached;
 
         try
@@ -43,8 +47,13 @@ public class FontManager : IDisposable
             var bytes = await response
                 .Content.ReadAsByteArrayAsync(cancellationToken)
                 .ConfigureAwait(false);
-            var font = new Font(url, bytes);
-            _fonts[url] = font;
+            var font = new Font(cacheKey, bytes);
+            if (_fonts.TryGetValue(cacheKey, out var existing))
+            {
+                font.Dispose();
+                return existing;
+            }
+            _fonts[cacheKey] = font;
             return font;
         }
         catch (HttpRequestException ex)
@@ -103,7 +112,9 @@ public class FontManager : IDisposable
     private static string NormalizeKey(string path)
     {
         ArgumentNullException.ThrowIfNull(path);
-        return IsAbsoluteUrl(path) ? path : AssetPath.Resolve(path);
+        if (Uri.TryCreate(path, UriKind.Absolute, out var uri) && uri.Scheme is ("http" or "https"))
+            return uri.AbsoluteUri;
+        return AssetPath.Resolve(path);
     }
 
     public void Dispose()

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -23,6 +23,9 @@ public class FontManager : IDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(url, nameof(url));
         ArgumentNullException.ThrowIfNull(httpClient);
 
+        if (!IsAbsoluteUrl(url))
+            throw new ArgumentException("Must be an absolute http or https URL.", nameof(url));
+
         if (_fonts.TryGetValue(url, out var cached))
             return cached;
 
@@ -62,9 +65,13 @@ public class FontManager : IDisposable
     {
         var key = NormalizeKey(fontPath);
         if (_fonts.TryGetValue(key, out var existingFont))
-        {
             return existingFont;
-        }
+
+        if (IsAbsoluteUrl(fontPath))
+            throw new ArgumentException(
+                "URL fonts must be fetched via LoadAsync; this URL is not cached.",
+                nameof(fontPath)
+            );
 
         var font = new Font(key);
         _fonts[key] = font;

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -46,17 +46,11 @@ public class FontManager : IDisposable
         }
         catch (HttpRequestException ex)
         {
-            throw new FontLoadException(
-                $"Failed to fetch font from '{url}': {ex.Message}",
-                ex
-            );
+            throw new FontLoadException($"Failed to fetch font from '{url}': {ex.Message}", ex);
         }
         catch (Exception ex) when (ex is not (OperationCanceledException or FontLoadException))
         {
-            throw new FontLoadException(
-                $"Failed to load font from '{url}': {ex.Message}",
-                ex
-            );
+            throw new FontLoadException($"Failed to load font from '{url}': {ex.Message}", ex);
         }
     }
 

--- a/src/Engine/Yaeger/Font/FontManager.cs
+++ b/src/Engine/Yaeger/Font/FontManager.cs
@@ -63,15 +63,17 @@ public class FontManager : IDisposable
 
     public Font Load(string fontPath)
     {
-        var key = NormalizeKey(fontPath);
-        if (_fonts.TryGetValue(key, out var existingFont))
-            return existingFont;
+        ArgumentNullException.ThrowIfNull(fontPath);
 
         if (IsAbsoluteUrl(fontPath))
             throw new ArgumentException(
                 "URL fonts must be fetched via LoadAsync.",
                 nameof(fontPath)
             );
+
+        var key = AssetPath.Resolve(fontPath);
+        if (_fonts.TryGetValue(key, out var existingFont))
+            return existingFont;
 
         var font = new Font(key);
         _fonts[key] = font;

--- a/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
@@ -975,10 +975,7 @@ public class PrefabLoaderTests
             CancellationToken cancellationToken
         ) =>
             Task.FromResult(
-                new HttpResponseMessage(statusCode)
-                {
-                    Content = new StringContent(content),
-                }
+                new HttpResponseMessage(statusCode) { Content = new StringContent(content) }
             );
     }
 

--- a/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
@@ -964,8 +964,7 @@ public class PrefabLoaderTests
     private static HttpClient MakeFakeClient(HttpStatusCode statusCode, string content) =>
         new(new FakeHttpMessageHandler(statusCode, content));
 
-    private static HttpClient MakeThrowingClient() =>
-        new(new ThrowingHttpMessageHandler());
+    private static HttpClient MakeThrowingClient() => new(new ThrowingHttpMessageHandler());
 
     private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, string content)
         : HttpMessageHandler

--- a/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using Yaeger.ECS;
 using Yaeger.ECS.Serializers;
@@ -799,6 +800,91 @@ public class PrefabLoaderTests
         Assert.Contains("RenderLayer", registry.RegisteredTypeIds);
     }
 
+    // ── PrefabLoader.LoadAsync – HTTP loading ─────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_ValidUrl_ReturnsParsedPrefab()
+    {
+        var registry = new ComponentRegistry();
+        registry.Register(new StubSerializer("Stub"));
+        var loader = new PrefabLoader(registry);
+        var json = """{ "components": [ { "type": "Stub" } ] }""";
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, json);
+
+        var prefab = await loader.LoadAsync("http://example.com/ball.prefab.json", httpClient);
+
+        var world = new World();
+        var entity = world.Instantiate(prefab);
+        Assert.True(world.TryGetComponent<StubComponent>(entity, out _));
+    }
+
+    [Fact]
+    public async Task LoadAsync_NotFoundResponse_ThrowsPrefabLoadExceptionWithStatusCode()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeFakeClient(HttpStatusCode.NotFound, "");
+
+        var ex = await Assert.ThrowsAsync<PrefabLoadException>(() =>
+            loader.LoadAsync("http://example.com/missing.prefab.json", httpClient)
+        );
+        Assert.Contains("404", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ServerError_ThrowsPrefabLoadExceptionWithStatusCode()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeFakeClient(HttpStatusCode.InternalServerError, "");
+
+        var ex = await Assert.ThrowsAsync<PrefabLoadException>(() =>
+            loader.LoadAsync("http://example.com/error.prefab.json", httpClient)
+        );
+        Assert.Contains("500", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NetworkFailure_ThrowsPrefabLoadException()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeThrowingClient();
+
+        await Assert.ThrowsAsync<PrefabLoadException>(() =>
+            loader.LoadAsync("http://example.com/ball.prefab.json", httpClient)
+        );
+    }
+
+    [Fact]
+    public async Task LoadAsync_NullHttpClient_ThrowsArgumentNullException()
+    {
+        var loader = MakeLoader();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            loader.LoadAsync("http://example.com/ball.prefab.json", null!)
+        );
+    }
+
+    [Fact]
+    public async Task LoadAsync_EmptyUrl_ThrowsArgumentException()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, "{}");
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            loader.LoadAsync("", httpClient)
+        );
+    }
+
+    [Fact]
+    public async Task LoadAsync_InvalidJson_ThrowsPrefabLoadException()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, "NOT JSON");
+
+        await Assert.ThrowsAsync<PrefabLoadException>(() =>
+            loader.LoadAsync("http://example.com/bad.prefab.json", httpClient)
+        );
+    }
+
     // ── PrefabLoader.Load – file-not-found ────────────────────────────────────
 
     [Fact]
@@ -875,6 +961,35 @@ public class PrefabLoaderTests
     {
         var registry = new ComponentRegistry();
         return new PrefabLoader(registry);
+    }
+
+    private static HttpClient MakeFakeClient(HttpStatusCode statusCode, string content) =>
+        new(new FakeHttpMessageHandler(statusCode, content));
+
+    private static HttpClient MakeThrowingClient() =>
+        new(new ThrowingHttpMessageHandler());
+
+    private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, string content)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(content),
+                }
+            );
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => throw new HttpRequestException("Simulated network failure.");
     }
 
     // Minimal stub serializer that adds a StubComponent to the entity.

--- a/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/PrefabLoaderTests.cs
@@ -869,9 +869,7 @@ public class PrefabLoaderTests
         var loader = MakeLoader();
         using var httpClient = MakeFakeClient(HttpStatusCode.OK, "{}");
 
-        await Assert.ThrowsAsync<ArgumentException>(() =>
-            loader.LoadAsync("", httpClient)
-        );
+        await Assert.ThrowsAsync<ArgumentException>(() => loader.LoadAsync("", httpClient));
     }
 
     [Fact]

--- a/tests/Yaeger.Tests/ECS/SceneLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/SceneLoaderTests.cs
@@ -341,10 +341,7 @@ public class SceneLoaderTests
             CancellationToken cancellationToken
         ) =>
             Task.FromResult(
-                new HttpResponseMessage(statusCode)
-                {
-                    Content = new StringContent(content),
-                }
+                new HttpResponseMessage(statusCode) { Content = new StringContent(content) }
             );
     }
 

--- a/tests/Yaeger.Tests/ECS/SceneLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/SceneLoaderTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using Yaeger.ECS;
 using Yaeger.ECS.Serializers;
@@ -238,6 +239,87 @@ public class SceneLoaderTests
         Assert.Throws<FileNotFoundException>(() => MakeLoader().Load("does/not/exist.json"));
     }
 
+    // ── SceneLoader.LoadAsync – HTTP loading ──────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_ValidUrl_ReturnsParsedScene()
+    {
+        var loader = MakeLoader();
+        var json = """{ "entities": [ { "components": [ { "type": "Stub" } ] } ] }""";
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, json);
+
+        var scene = await loader.LoadAsync("http://example.com/level1.scene.json", httpClient);
+
+        Assert.Equal(1, scene.EntityCount);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NotFoundResponse_ThrowsSceneLoadExceptionWithStatusCode()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeFakeClient(HttpStatusCode.NotFound, "");
+
+        var ex = await Assert.ThrowsAsync<SceneLoadException>(() =>
+            loader.LoadAsync("http://example.com/missing.scene.json", httpClient)
+        );
+        Assert.Contains("404", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ServerError_ThrowsSceneLoadExceptionWithStatusCode()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeFakeClient(HttpStatusCode.InternalServerError, "");
+
+        var ex = await Assert.ThrowsAsync<SceneLoadException>(() =>
+            loader.LoadAsync("http://example.com/error.scene.json", httpClient)
+        );
+        Assert.Contains("500", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NetworkFailure_ThrowsSceneLoadException()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeThrowingClient();
+
+        await Assert.ThrowsAsync<SceneLoadException>(() =>
+            loader.LoadAsync("http://example.com/level1.scene.json", httpClient)
+        );
+    }
+
+    [Fact]
+    public async Task LoadAsync_NullHttpClient_ThrowsArgumentNullException()
+    {
+        var loader = MakeLoader();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            loader.LoadAsync("http://example.com/level1.scene.json", null!)
+        );
+    }
+
+    [Fact]
+    public async Task LoadAsync_EmptyUrl_ThrowsArgumentException()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, "{}");
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            loader.LoadAsync("", httpClient)
+        );
+    }
+
+    [Fact]
+    public async Task LoadAsync_InvalidJson_ThrowsSceneLoadException()
+    {
+        var loader = MakeLoader();
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, "NOT JSON");
+
+        await Assert.ThrowsAsync<SceneLoadException>(() =>
+            loader.LoadAsync("http://example.com/bad.scene.json", httpClient)
+        );
+    }
+
     // ── Test helpers ─────────────────────────────────────────────────────────
 
     private static SceneLoader MakeLoader()
@@ -245,6 +327,35 @@ public class SceneLoaderTests
         var registry = new ComponentRegistry();
         registry.Register(new StubSerializer("Stub"));
         return new SceneLoader(registry);
+    }
+
+    private static HttpClient MakeFakeClient(HttpStatusCode statusCode, string content) =>
+        new(new FakeHttpMessageHandler(statusCode, content));
+
+    private static HttpClient MakeThrowingClient() =>
+        new(new ThrowingHttpMessageHandler());
+
+    private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, string content)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(content),
+                }
+            );
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => throw new HttpRequestException("Simulated network failure.");
     }
 
     private sealed class StubSerializer : IComponentSerializer

--- a/tests/Yaeger.Tests/ECS/SceneLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/SceneLoaderTests.cs
@@ -330,8 +330,7 @@ public class SceneLoaderTests
     private static HttpClient MakeFakeClient(HttpStatusCode statusCode, string content) =>
         new(new FakeHttpMessageHandler(statusCode, content));
 
-    private static HttpClient MakeThrowingClient() =>
-        new(new ThrowingHttpMessageHandler());
+    private static HttpClient MakeThrowingClient() => new(new ThrowingHttpMessageHandler());
 
     private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, string content)
         : HttpMessageHandler

--- a/tests/Yaeger.Tests/ECS/SceneLoaderTests.cs
+++ b/tests/Yaeger.Tests/ECS/SceneLoaderTests.cs
@@ -304,9 +304,7 @@ public class SceneLoaderTests
         var loader = MakeLoader();
         using var httpClient = MakeFakeClient(HttpStatusCode.OK, "{}");
 
-        await Assert.ThrowsAsync<ArgumentException>(() =>
-            loader.LoadAsync("", httpClient)
-        );
+        await Assert.ThrowsAsync<ArgumentException>(() => loader.LoadAsync("", httpClient));
     }
 
     [Fact]

--- a/tests/Yaeger.Tests/Font/FontManagerTests.cs
+++ b/tests/Yaeger.Tests/Font/FontManagerTests.cs
@@ -63,6 +63,36 @@ public class FontManagerTests : IDisposable
         );
     }
 
+    // ── Success and caching ───────────────────────────────────────────────────
+
+    [SkippableFact]
+    public async Task LoadAsync_ValidFontBytes_ReturnsFontAndCaches()
+    {
+        var fontPath = Path.Combine(AppContext.BaseDirectory, "TestAssets", "Roboto-Regular.ttf");
+        Skip.IfNot(File.Exists(fontPath), "Roboto-Regular.ttf test asset is missing.");
+        Skip.IfNot(IsHarfBuzzAvailable(), "HarfBuzz native library not available.");
+
+        var fontBytes = File.ReadAllBytes(fontPath);
+        using var manager = new FontManager();
+        using var firstClient = MakeFakeClient(HttpStatusCode.OK, fontBytes);
+        using var secondClient = MakeThrowingClient();
+
+        var font1 = await manager.LoadAsync("http://example.com/font.ttf", firstClient);
+        var font2 = await manager.LoadAsync("http://example.com/font.ttf", secondClient);
+
+        Assert.NotNull(font1);
+        Assert.Same(font1, font2);
+    }
+
+    private static bool IsHarfBuzzAvailable()
+    {
+        var dir = AppContext.BaseDirectory;
+        return File.Exists(Path.Combine(dir, "libHarfBuzzSharp.so"))
+            || File.Exists(
+                Path.Combine(dir, "runtimes", "linux-x64", "native", "libHarfBuzzSharp.so")
+            );
+    }
+
     // ── Invalid/empty payload ─────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Yaeger.Tests/Font/FontManagerTests.cs
+++ b/tests/Yaeger.Tests/Font/FontManagerTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using Yaeger.Font;
+
+namespace Yaeger.Tests.Font;
+
+public class FontManagerTests : IDisposable
+{
+    private readonly FontManager _manager = new();
+
+    public void Dispose() => _manager.Dispose();
+
+    // ── Argument validation ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_NullHttpClient_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            _manager.LoadAsync("http://example.com/font.ttf", null!)
+        );
+    }
+
+    [Fact]
+    public async Task LoadAsync_EmptyUrl_ThrowsArgumentException()
+    {
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, []);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _manager.LoadAsync("", httpClient));
+    }
+
+    // ── HTTP error responses ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_NotFoundResponse_ThrowsFontLoadExceptionWithStatusCode()
+    {
+        using var httpClient = MakeFakeClient(HttpStatusCode.NotFound, []);
+
+        var ex = await Assert.ThrowsAsync<FontLoadException>(() =>
+            _manager.LoadAsync("http://example.com/missing.ttf", httpClient)
+        );
+        Assert.Contains("404", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ServerError_ThrowsFontLoadExceptionWithStatusCode()
+    {
+        using var httpClient = MakeFakeClient(HttpStatusCode.InternalServerError, []);
+
+        var ex = await Assert.ThrowsAsync<FontLoadException>(() =>
+            _manager.LoadAsync("http://example.com/error.ttf", httpClient)
+        );
+        Assert.Contains("500", ex.Message);
+    }
+
+    // ── Network failure ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_NetworkFailure_ThrowsFontLoadException()
+    {
+        using var httpClient = MakeThrowingClient();
+
+        await Assert.ThrowsAsync<FontLoadException>(() =>
+            _manager.LoadAsync("http://example.com/font.ttf", httpClient)
+        );
+    }
+
+    // ── Invalid/empty payload ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_EmptyBytesResponse_ThrowsFontLoadException()
+    {
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, []);
+
+        await Assert.ThrowsAsync<FontLoadException>(() =>
+            _manager.LoadAsync("http://example.com/empty.ttf", httpClient)
+        );
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static HttpClient MakeFakeClient(HttpStatusCode statusCode, byte[] content) =>
+        new(new FakeHttpMessageHandler(statusCode, content));
+
+    private static HttpClient MakeThrowingClient() =>
+        new(new ThrowingHttpMessageHandler());
+
+    private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, byte[] content)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(statusCode) { Content = new ByteArrayContent(content) }
+            );
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => throw new HttpRequestException("Simulated network failure.");
+    }
+}

--- a/tests/Yaeger.Tests/Font/FontManagerTests.cs
+++ b/tests/Yaeger.Tests/Font/FontManagerTests.cs
@@ -80,8 +80,7 @@ public class FontManagerTests : IDisposable
     private static HttpClient MakeFakeClient(HttpStatusCode statusCode, byte[] content) =>
         new(new FakeHttpMessageHandler(statusCode, content));
 
-    private static HttpClient MakeThrowingClient() =>
-        new(new ThrowingHttpMessageHandler());
+    private static HttpClient MakeThrowingClient() => new(new ThrowingHttpMessageHandler());
 
     private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, byte[] content)
         : HttpMessageHandler

--- a/tests/Yaeger.Tests/Font/FontManagerTests.cs
+++ b/tests/Yaeger.Tests/Font/FontManagerTests.cs
@@ -27,6 +27,26 @@ public class FontManagerTests : IDisposable
         await Assert.ThrowsAsync<ArgumentException>(() => _manager.LoadAsync("", httpClient));
     }
 
+    [Fact]
+    public async Task LoadAsync_RelativePath_ThrowsArgumentException()
+    {
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, []);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _manager.LoadAsync("relative/font.ttf", httpClient)
+        );
+    }
+
+    [Fact]
+    public async Task LoadAsync_NonHttpScheme_ThrowsArgumentException()
+    {
+        using var httpClient = MakeFakeClient(HttpStatusCode.OK, []);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _manager.LoadAsync("ftp://example.com/font.ttf", httpClient)
+        );
+    }
+
     // ── HTTP error responses ──────────────────────────────────────────────────
 
     [Fact]
@@ -91,6 +111,40 @@ public class FontManagerTests : IDisposable
             || File.Exists(
                 Path.Combine(dir, "runtimes", "linux-x64", "native", "libHarfBuzzSharp.so")
             );
+    }
+
+    // ── Load argument validation ──────────────────────────────────────────────
+
+    [Fact]
+    public void Load_NullPath_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _manager.Load(null!));
+    }
+
+    [Fact]
+    public void Load_WhitespacePath_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _manager.Load("   "));
+    }
+
+    [Fact]
+    public void Load_UrlPath_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _manager.Load("http://example.com/font.ttf"));
+    }
+
+    // ── Get ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Get_NullPath_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _manager.Get(null!));
+    }
+
+    [Fact]
+    public void Get_UnknownPath_ReturnsNull()
+    {
+        Assert.Null(_manager.Get("nonexistent.ttf"));
     }
 
     // ── Invalid/empty payload ─────────────────────────────────────────────────

--- a/tests/Yaeger.Tests/Yaeger.Tests.csproj
+++ b/tests/Yaeger.Tests/Yaeger.Tests.csproj
@@ -23,4 +23,12 @@
     <ProjectReference Include="..\..\src\Engine\Yaeger.Core\Yaeger.Core.csproj" />
     <ProjectReference Include="..\..\src\Engine\Yaeger\Yaeger.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None
+      Include="..\..\Samples\Pong\Assets\Roboto-Regular.ttf"
+      CopyToOutputDirectory="PreserveNewest"
+      Link="TestAssets\Roboto-Regular.ttf"
+    />
+  </ItemGroup>
 </Project>

--- a/tests/Yaeger.Tests/Yaeger.Tests.csproj
+++ b/tests/Yaeger.Tests/Yaeger.Tests.csproj
@@ -21,5 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Engine\Yaeger.Browser\Yaeger.Browser.csproj" />
     <ProjectReference Include="..\..\src\Engine\Yaeger.Core\Yaeger.Core.csproj" />
+    <ProjectReference Include="..\..\src\Engine\Yaeger\Yaeger.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds `LoadAsync(url, httpClient, ct)` to `PrefabLoader` and `SceneLoader`
so JSON assets can be fetched over HTTP in both desktop and WASM builds.
In WASM, `HttpClient` routes through the browser Fetch API making these
calls async-safe without blocking I/O. HTTP errors and network failures
surface as `PrefabLoadException`/`SceneLoadException` with the URL and
status code in the message.

Adds a `Font(id, byte[])` constructor plus `FontManager.LoadAsync` and
`FontLoadException` so font files can be loaded from remote URLs on the
desktop runtime. Texture loading over HTTP was already handled by the
browser JS layer (`getOrLoadTexture` in yaeger-browser.js).

https://claude.ai/code/session_01RDp74KypLLnEe2PdVy8W6A