### PR TITLE
Add ParallaxLayer component and ParallaxSystem

### DIFF
--- a/src/Engine/Yaeger.Core/Yaeger.Core.csproj
+++ b/src/Engine/Yaeger.Core/Yaeger.Core.csproj
@@ -21,6 +21,7 @@
     />
     <Compile Include="..\Yaeger\Systems\AnimationSystem.cs" Link="Systems\AnimationSystem.cs" />
     <Compile Include="..\Yaeger\Systems\IUpdateSystem.cs" Link="Systems\IUpdateSystem.cs" />
+    <Compile Include="..\Yaeger\Systems\ParallaxSystem.cs" Link="Systems\ParallaxSystem.cs" />
     <Compile Include="..\Yaeger\Input\Keys.cs" Link="Input\Keys.cs" />
     <Compile Include="..\Yaeger\Input\MouseButton.cs" Link="Input\MouseButton.cs" />
   </ItemGroup>

--- a/src/Engine/Yaeger/Graphics/ParallaxLayer.cs
+++ b/src/Engine/Yaeger/Graphics/ParallaxLayer.cs
@@ -1,0 +1,27 @@
+using System.Numerics;
+
+namespace Yaeger.Graphics;
+
+/// <summary>
+/// Marks an entity as a parallax background layer. The layer's world-space position is
+/// recomputed each frame from <see cref="BasePosition"/> and the active camera position:
+/// <c>worldPos = BasePosition + cameraPos * (1 - ScrollFactor)</c>.
+///
+/// ScrollFactor of 0 = screen-fixed (sky/far background that never scrolls).
+/// ScrollFactor of 1 = world-fixed (same behaviour as a regular game entity).
+/// Values between 0 and 1 create the classic parallax depth effect.
+/// </summary>
+public struct ParallaxLayer(float scrollFactorX = 0.5f, float scrollFactorY = 0f)
+{
+    /// <summary>Horizontal parallax factor. 0 = screen-fixed, 1 = world-fixed.</summary>
+    public float ScrollFactorX = scrollFactorX;
+
+    /// <summary>Vertical parallax factor. 0 = screen-fixed, 1 = world-fixed.</summary>
+    public float ScrollFactorY = scrollFactorY;
+
+    /// <summary>
+    /// World-space anchor position for this layer at camera origin (0, 0).
+    /// Defaults to <see cref="Vector2.Zero"/>.
+    /// </summary>
+    public Vector2 BasePosition;
+}

--- a/src/Engine/Yaeger/Graphics/ParallaxLayer.cs
+++ b/src/Engine/Yaeger/Graphics/ParallaxLayer.cs
@@ -13,6 +13,9 @@ namespace Yaeger.Graphics;
 /// </summary>
 public struct ParallaxLayer(float scrollFactorX = 0.5f, float scrollFactorY = 0f)
 {
+    public ParallaxLayer()
+        : this(0.5f, 0f) { }
+
     /// <summary>Horizontal parallax factor. 0 = screen-fixed, 1 = world-fixed.</summary>
     public float ScrollFactorX = scrollFactorX;
 

--- a/src/Engine/Yaeger/Systems/ParallaxSystem.cs
+++ b/src/Engine/Yaeger/Systems/ParallaxSystem.cs
@@ -1,0 +1,40 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+
+namespace Yaeger.Systems;
+
+/// <summary>
+/// Updates the <see cref="Transform2D"/> position of every entity that carries a
+/// <see cref="ParallaxLayer"/> component so that the layer appears to scroll at the
+/// fraction of the camera speed defined by the layer's scroll factors.
+///
+/// Call <see cref="Update"/> once per frame before rendering, after any camera movement.
+/// </summary>
+public class ParallaxSystem(World world) : IUpdateSystem
+{
+    public void Update(float deltaTime)
+    {
+        var cameraPos = Vector2.Zero;
+        foreach ((Entity _, Camera2D camera) in world.GetStore<Camera2D>().All())
+        {
+            cameraPos = camera.Position;
+            break;
+        }
+
+        foreach (
+            (Entity entity, ParallaxLayer layer, Transform2D transform) in world.Query<
+                ParallaxLayer,
+                Transform2D
+            >()
+        )
+        {
+            var newTransform = transform;
+            newTransform.Position = new Vector2(
+                layer.BasePosition.X + cameraPos.X * (1f - layer.ScrollFactorX),
+                layer.BasePosition.Y + cameraPos.Y * (1f - layer.ScrollFactorY)
+            );
+            world.AddComponent(entity, newTransform);
+        }
+    }
+}

--- a/src/Engine/Yaeger/Yaeger.csproj
+++ b/src/Engine/Yaeger/Yaeger.csproj
@@ -35,6 +35,7 @@
     <Compile Remove="Physics\**\*.cs" />
     <Compile Remove="Systems\AnimationSystem.cs" />
     <Compile Remove="Systems\IUpdateSystem.cs" />
+    <Compile Remove="Systems\ParallaxSystem.cs" />
     <Compile Remove="Input\Keys.cs" />
     <Compile Remove="Input\MouseButton.cs" />
     <Compile Include="Physics\PhysicsDebugRenderer.cs" />

--- a/tests/Yaeger.Tests/Graphics/ParallaxLayerTests.cs
+++ b/tests/Yaeger.Tests/Graphics/ParallaxLayerTests.cs
@@ -1,0 +1,41 @@
+using System.Numerics;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Graphics;
+
+public class ParallaxLayerTests
+{
+    [Fact]
+    public void Constructor_ShouldApplyDefaultScrollFactors()
+    {
+        var layer = new ParallaxLayer();
+
+        Assert.Equal(0.5f, layer.ScrollFactorX);
+        Assert.Equal(0f, layer.ScrollFactorY);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetScrollFactors()
+    {
+        var layer = new ParallaxLayer(scrollFactorX: 0.2f, scrollFactorY: 0.8f);
+
+        Assert.Equal(0.2f, layer.ScrollFactorX);
+        Assert.Equal(0.8f, layer.ScrollFactorY);
+    }
+
+    [Fact]
+    public void BasePosition_ShouldDefaultToZero()
+    {
+        var layer = new ParallaxLayer();
+
+        Assert.Equal(Vector2.Zero, layer.BasePosition);
+    }
+
+    [Fact]
+    public void BasePosition_ShouldBeSettable()
+    {
+        var layer = new ParallaxLayer { BasePosition = new Vector2(100f, 50f) };
+
+        Assert.Equal(new Vector2(100f, 50f), layer.BasePosition);
+    }
+}

--- a/tests/Yaeger.Tests/Systems/ParallaxSystemTests.cs
+++ b/tests/Yaeger.Tests/Systems/ParallaxSystemTests.cs
@@ -1,0 +1,187 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Systems;
+
+namespace Yaeger.Tests.Systems;
+
+public class ParallaxSystemTests
+{
+    [Fact]
+    public void Update_WithScrollFactorZero_ShouldFixLayerToScreen()
+    {
+        // A factor of 0 means the layer tracks the camera completely → appears
+        // fixed on screen regardless of where the camera is.
+        var world = new World();
+        var cameraEntity = world.CreateEntity();
+        world.AddComponent(cameraEntity, new Camera2D(new Vector2(100f, 60f)));
+
+        var layerEntity = world.CreateEntity();
+        world.AddComponent(layerEntity, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            layerEntity,
+            new ParallaxLayer(scrollFactorX: 0f, scrollFactorY: 0f)
+        );
+
+        new ParallaxSystem(world).Update(0f);
+
+        var transform = world.GetComponent<Transform2D>(layerEntity);
+        // worldPos = basePos(0,0) + cameraPos(100,60) * (1 - 0) = (100, 60)
+        // screenPos = worldPos - cameraPos = (0, 0)  → fixed on screen
+        Assert.Equal(100f, transform.Position.X, 0.001f);
+        Assert.Equal(60f, transform.Position.Y, 0.001f);
+    }
+
+    [Fact]
+    public void Update_WithScrollFactorOne_ShouldLeaveLayerWorldFixed()
+    {
+        // A factor of 1 means no tracking adjustment → layer stays at BasePosition,
+        // which is the same as any regular game entity.
+        var world = new World();
+        var cameraEntity = world.CreateEntity();
+        world.AddComponent(cameraEntity, new Camera2D(new Vector2(100f, 0f)));
+
+        var layerEntity = world.CreateEntity();
+        world.AddComponent(layerEntity, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            layerEntity,
+            new ParallaxLayer(scrollFactorX: 1f, scrollFactorY: 1f)
+        );
+
+        new ParallaxSystem(world).Update(0f);
+
+        var transform = world.GetComponent<Transform2D>(layerEntity);
+        // worldPos = basePos(0,0) + cameraPos(100,0) * (1 - 1) = (0, 0)
+        Assert.Equal(0f, transform.Position.X, 0.001f);
+        Assert.Equal(0f, transform.Position.Y, 0.001f);
+    }
+
+    [Fact]
+    public void Update_WithHalfScrollFactor_ShouldScrollAtHalfCameraSpeed()
+    {
+        var world = new World();
+        var cameraEntity = world.CreateEntity();
+        world.AddComponent(cameraEntity, new Camera2D(new Vector2(100f, 0f)));
+
+        var layerEntity = world.CreateEntity();
+        world.AddComponent(layerEntity, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            layerEntity,
+            new ParallaxLayer(scrollFactorX: 0.5f, scrollFactorY: 0f)
+        );
+
+        new ParallaxSystem(world).Update(0f);
+
+        var transform = world.GetComponent<Transform2D>(layerEntity);
+        // worldPos.X = 0 + 100 * (1 - 0.5) = 50
+        // screenPos.X = 50 - 100 = -50  → half camera speed
+        Assert.Equal(50f, transform.Position.X, 0.001f);
+        // scrollFactorY=0 → worldPos.Y = 0 + 0 * 1 = 0
+        Assert.Equal(0f, transform.Position.Y, 0.001f);
+    }
+
+    [Fact]
+    public void Update_WithNoCameraEntity_ShouldPositionLayerAtBasePosition()
+    {
+        var world = new World();
+        var layerEntity = world.CreateEntity();
+        world.AddComponent(layerEntity, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            layerEntity,
+            new ParallaxLayer(scrollFactorX: 0.3f) { BasePosition = new Vector2(10f, 5f) }
+        );
+
+        new ParallaxSystem(world).Update(0f);
+
+        var transform = world.GetComponent<Transform2D>(layerEntity);
+        // cameraPos defaults to (0,0) → worldPos = basePos + (0,0) * anything = basePos
+        Assert.Equal(10f, transform.Position.X, 0.001f);
+        Assert.Equal(5f, transform.Position.Y, 0.001f);
+    }
+
+    [Fact]
+    public void Update_ShouldRespectNonZeroBasePosition()
+    {
+        var world = new World();
+        var cameraEntity = world.CreateEntity();
+        world.AddComponent(cameraEntity, new Camera2D(new Vector2(50f, 0f)));
+
+        var layerEntity = world.CreateEntity();
+        world.AddComponent(layerEntity, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            layerEntity,
+            new ParallaxLayer(scrollFactorX: 0f) { BasePosition = new Vector2(200f, 0f) }
+        );
+
+        new ParallaxSystem(world).Update(0f);
+
+        var transform = world.GetComponent<Transform2D>(layerEntity);
+        // worldPos.X = 200 + 50 * (1 - 0) = 250
+        Assert.Equal(250f, transform.Position.X, 0.001f);
+    }
+
+    [Fact]
+    public void Update_ShouldNotAffectEntitiesWithoutParallaxLayer()
+    {
+        var world = new World();
+        var cameraEntity = world.CreateEntity();
+        world.AddComponent(cameraEntity, new Camera2D(new Vector2(100f, 0f)));
+
+        var regularEntity = world.CreateEntity();
+        world.AddComponent(regularEntity, new Transform2D(new Vector2(42f, 7f)));
+
+        new ParallaxSystem(world).Update(0f);
+
+        var transform = world.GetComponent<Transform2D>(regularEntity);
+        Assert.Equal(42f, transform.Position.X, 0.001f);
+        Assert.Equal(7f, transform.Position.Y, 0.001f);
+    }
+
+    [Fact]
+    public void Update_ShouldPreserveScaleAndRotation()
+    {
+        var world = new World();
+        var cameraEntity = world.CreateEntity();
+        world.AddComponent(cameraEntity, new Camera2D(new Vector2(50f, 0f)));
+
+        var layerEntity = world.CreateEntity();
+        world.AddComponent(
+            layerEntity,
+            new Transform2D(Vector2.Zero, rotation: 1.5f, scale: new Vector2(3f, 2f))
+        );
+        world.AddComponent(layerEntity, new ParallaxLayer(scrollFactorX: 0.5f));
+
+        new ParallaxSystem(world).Update(0f);
+
+        var transform = world.GetComponent<Transform2D>(layerEntity);
+        Assert.Equal(1.5f, transform.Rotation, 0.001f);
+        Assert.Equal(3f, transform.Scale.X, 0.001f);
+        Assert.Equal(2f, transform.Scale.Y, 0.001f);
+    }
+
+    [Fact]
+    public void Update_WithMultipleLayers_ShouldScrollEachIndependently()
+    {
+        var world = new World();
+        var cameraEntity = world.CreateEntity();
+        world.AddComponent(cameraEntity, new Camera2D(new Vector2(100f, 0f)));
+
+        var farLayer = world.CreateEntity();
+        world.AddComponent(farLayer, new Transform2D(Vector2.Zero));
+        world.AddComponent(farLayer, new ParallaxLayer(scrollFactorX: 0.1f));
+
+        var nearLayer = world.CreateEntity();
+        world.AddComponent(nearLayer, new Transform2D(Vector2.Zero));
+        world.AddComponent(nearLayer, new ParallaxLayer(scrollFactorX: 0.8f));
+
+        new ParallaxSystem(world).Update(0f);
+
+        var farTransform = world.GetComponent<Transform2D>(farLayer);
+        var nearTransform = world.GetComponent<Transform2D>(nearLayer);
+
+        // Far layer: worldPos.X = 100 * (1 - 0.1) = 90
+        Assert.Equal(90f, farTransform.Position.X, 0.001f);
+        // Near layer: worldPos.X = 100 * (1 - 0.8) = 20
+        Assert.Equal(20f, nearTransform.Position.X, 0.001f);
+    }
+}

--- a/tests/Yaeger.Tests/Systems/ParallaxSystemTests.cs
+++ b/tests/Yaeger.Tests/Systems/ParallaxSystemTests.cs
@@ -18,10 +18,7 @@ public class ParallaxSystemTests
 
         var layerEntity = world.CreateEntity();
         world.AddComponent(layerEntity, new Transform2D(Vector2.Zero));
-        world.AddComponent(
-            layerEntity,
-            new ParallaxLayer(scrollFactorX: 0f, scrollFactorY: 0f)
-        );
+        world.AddComponent(layerEntity, new ParallaxLayer(scrollFactorX: 0f, scrollFactorY: 0f));
 
         new ParallaxSystem(world).Update(0f);
 
@@ -43,10 +40,7 @@ public class ParallaxSystemTests
 
         var layerEntity = world.CreateEntity();
         world.AddComponent(layerEntity, new Transform2D(Vector2.Zero));
-        world.AddComponent(
-            layerEntity,
-            new ParallaxLayer(scrollFactorX: 1f, scrollFactorY: 1f)
-        );
+        world.AddComponent(layerEntity, new ParallaxLayer(scrollFactorX: 1f, scrollFactorY: 1f));
 
         new ParallaxSystem(world).Update(0f);
 
@@ -65,10 +59,7 @@ public class ParallaxSystemTests
 
         var layerEntity = world.CreateEntity();
         world.AddComponent(layerEntity, new Transform2D(Vector2.Zero));
-        world.AddComponent(
-            layerEntity,
-            new ParallaxLayer(scrollFactorX: 0.5f, scrollFactorY: 0f)
-        );
+        world.AddComponent(layerEntity, new ParallaxLayer(scrollFactorX: 0.5f, scrollFactorY: 0f));
 
         new ParallaxSystem(world).Update(0f);
 


### PR DESCRIPTION
Implements parallax scrolling via two new types:
- ParallaxLayer struct: marks an entity as a background layer with
  ScrollFactorX/Y (0 = screen-fixed, 1 = world-fixed) and a BasePosition anchor.
- ParallaxSystem: recomputes each layer's Transform2D.Position each frame as
  basePosition + cameraPos * (1 - scrollFactor), producing the depth-illusion
  effect where distant layers drift slower than near layers.

Includes unit tests for both component defaults and system behaviour across
zero/half/full scroll factors, no-camera fallback, multi-layer independence,
and scale/rotation preservation.

https://claude.ai/code/session_0144uZGRth9aGgcNAQUHDXEc