### PR TITLE
feat(rendering): add SDF text rendering mode (issue #33, option 4)

### DIFF
--- a/Samples/TextRenderingExample/Program.cs
+++ b/Samples/TextRenderingExample/Program.cs
@@ -10,7 +10,8 @@ using Yaeger.Windowing;
 using var window = Window.Create();
 var world = new World();
 var fontManager = new FontManager();
-var textRenderer = new TextRenderer(window);
+// Switch between TextRenderMode.Standard and TextRenderMode.Sdf to compare rendering modes.
+var textRenderer = new TextRenderer(window, fontManager, TextRenderMode.Sdf);
 var renderSystem = new UnifiedRenderSystem(null, textRenderer, world);
 
 window.OnLoad += OnLoad;

--- a/Samples/TextRenderingExample/Program.cs
+++ b/Samples/TextRenderingExample/Program.cs
@@ -10,6 +10,7 @@ using Yaeger.Windowing;
 using var window = Window.Create();
 var world = new World();
 var fontManager = new FontManager();
+
 // Switch between TextRenderMode.Standard and TextRenderMode.Sdf to compare rendering modes.
 var textRenderer = new TextRenderer(window, fontManager, TextRenderMode.Sdf);
 var renderSystem = new UnifiedRenderSystem(null, textRenderer, world);

--- a/src/Engine/Yaeger/Font/GlyphAtlas.cs
+++ b/src/Engine/Yaeger/Font/GlyphAtlas.cs
@@ -9,7 +9,7 @@ namespace Yaeger.Font;
 /// Manages a texture atlas of rendered glyphs for efficient text rendering.
 /// Uses SkiaSharp for glyph rasterization and OpenGL for texture storage.
 /// </summary>
-public class GlyphAtlas : IDisposable
+public class GlyphAtlas : IGlyphAtlas
 {
     private readonly Font _font;
     private readonly int _fontSize;

--- a/src/Engine/Yaeger/Font/IGlyphAtlas.cs
+++ b/src/Engine/Yaeger/Font/IGlyphAtlas.cs
@@ -1,0 +1,12 @@
+namespace Yaeger.Font;
+
+internal interface IGlyphAtlas : IDisposable
+{
+    AtlasGlyph[] AddGlyphsForText(string text);
+
+    AtlasGlyph? GetGlyph(uint codepoint);
+
+    void BindTexture();
+
+    void UnbindTexture();
+}

--- a/src/Engine/Yaeger/Font/SdfGlyphAtlas.cs
+++ b/src/Engine/Yaeger/Font/SdfGlyphAtlas.cs
@@ -1,0 +1,322 @@
+using System.Numerics;
+using Silk.NET.OpenGL;
+using SkiaSharp;
+using Yaeger.Rendering;
+
+namespace Yaeger.Font;
+
+/// <summary>
+/// Glyph atlas that stores signed distance fields instead of raw alpha coverage.
+/// Each glyph is rendered internally at <see cref="SdfScale"/>× the atlas font size
+/// so the distance transform has sub-pixel accuracy; the result is then box-filtered
+/// down to the atlas cell.  The companion SDF fragment shader reconstructs a crisp
+/// edge at any display scale using <c>smoothstep</c> on the stored distance value,
+/// where 0.5 == the glyph boundary, values &gt;0.5 are inside, and values &lt;0.5
+/// are outside.
+/// </summary>
+public class SdfGlyphAtlas : IGlyphAtlas
+{
+    /// <summary>Upscale factor for the internal high-resolution render.</summary>
+    internal const int SdfScale = 2;
+
+    /// <summary>Distance-search radius in high-resolution pixels (= SdfSpread/SdfScale in atlas pixels).</summary>
+    internal const int SdfSpread = 16;
+
+    private readonly Font _font;
+    private readonly int _fontSize;
+    private readonly Dictionary<uint, AtlasGlyph> _glyphs = new();
+    private readonly FontTexture _texture;
+    private readonly int _atlasWidth;
+    private readonly int _atlasHeight;
+    private readonly SKTypeface _typeface;
+
+    // High-res font used for both measuring and rasterising.
+    // Metrics are divided by SdfScale to get atlas-space values.
+    private readonly SKFont _hrFont;
+    private bool _disposed;
+    private int _nextAtlasIndex;
+
+    public SdfGlyphAtlas(GL gl, Font font, int fontSize = 48, int atlasSize = 512)
+    {
+        _font = font ?? throw new ArgumentNullException(nameof(font));
+        _fontSize = fontSize;
+        _atlasWidth = atlasSize;
+        _atlasHeight = atlasSize;
+
+        _texture = new FontTexture(gl, _atlasWidth, _atlasHeight);
+
+        using var fontData = SKData.CreateCopy(_font.FontBytes);
+        _typeface =
+            SKTypeface.FromData(fontData)
+            ?? throw new InvalidOperationException("Failed to create typeface from font data");
+
+        // No hinting for SDF — we want smooth, hint-free outlines so the distance
+        // field represents the true vector shape rather than a hinted approximation.
+        _hrFont = new SKFont(_typeface, fontSize * SdfScale)
+        {
+            Edging = SKFontEdging.Antialias,
+            Hinting = SKFontHinting.None,
+            Subpixel = true,
+        };
+    }
+
+    private AtlasGlyph AddGlyph(uint codepoint)
+    {
+        if (_glyphs.TryGetValue(codepoint, out var existing))
+            return existing;
+
+        var glyph = RenderGlyph(codepoint);
+        _glyphs[codepoint] = glyph;
+        return glyph;
+    }
+
+    public AtlasGlyph[] AddGlyphsForText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return [];
+
+        return _font.Shape(text).Select(g => AddGlyph(g.Codepoint)).ToArray();
+    }
+
+    public AtlasGlyph? GetGlyph(uint codepoint) =>
+        _glyphs.TryGetValue(codepoint, out var g) ? g : null;
+
+    private AtlasGlyph RenderGlyph(uint codepoint)
+    {
+        int glyphIndex = _nextAtlasIndex++;
+        int glyphsPerRow = _atlasWidth / _fontSize;
+        int cellX = (glyphIndex % glyphsPerRow) * _fontSize;
+        int cellY = (glyphIndex / glyphsPerRow) * _fontSize;
+
+        var text = char.ConvertFromUtf32((int)codepoint);
+
+        // Measure using the high-res font; divide results by SdfScale for atlas-space metrics.
+        var hrAdvance = _hrFont.MeasureText(text, out SKRect hrBounds);
+        var advance = hrAdvance / SdfScale;
+        var glyphWidth = (int)Math.Ceiling(hrBounds.Width / SdfScale);
+        var glyphHeight = (int)Math.Ceiling(hrBounds.Height / SdfScale);
+
+        if (glyphWidth <= 0 || glyphHeight <= 0)
+            return CreateEmptyGlyph(codepoint, cellX, cellY, advance);
+
+        int renderWidth = Math.Min(Math.Max(glyphWidth, 1), _fontSize);
+        int renderHeight = Math.Min(Math.Max(glyphHeight, 1), _fontSize);
+
+        // --- High-resolution render ---
+        int hrSize = _fontSize * SdfScale;
+        var imageInfo = new SKImageInfo(hrSize, hrSize, SKColorType.Alpha8);
+        using var surface = SKSurface.Create(imageInfo);
+        if (surface == null)
+            return CreateEmptyGlyph(codepoint, cellX, cellY, advance);
+
+        var canvas = surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+
+        using var paint = new SKPaint();
+        paint.Color = SKColors.White;
+        paint.IsAntialias = true;
+
+        // Position the glyph so its bounding-box top-left lands at (0,0) in the HR surface,
+        // matching the layout used by GlyphAtlas for consistent metric behaviour.
+        canvas.DrawText(text, -hrBounds.Left, -hrBounds.Top, SKTextAlign.Left, _hrFont, paint);
+
+        using var image = surface.Snapshot();
+        using var pixmap = image.PeekPixels();
+        if (pixmap == null)
+            return CreateEmptyGlyph(codepoint, cellX, cellY, advance);
+
+        // --- SDF pipeline ---
+        var alphaBytes = pixmap.GetPixelSpan();
+        var binaryMask = ThresholdAlpha(alphaBytes, hrSize, hrSize, pixmap.RowBytes);
+        var sdfFloat = GenerateSdf(binaryMask, hrSize, hrSize, SdfSpread);
+        var sdfBytes = DownsampleSdf(sdfFloat, hrSize, hrSize, _fontSize, _fontSize, SdfScale);
+
+        _texture.SetData(new ReadOnlySpan<byte>(sdfBytes), cellX, cellY, _fontSize, _fontSize);
+
+        var bearing = new Vector2(hrBounds.Left / SdfScale, -hrBounds.Top / SdfScale);
+
+        return new AtlasGlyph
+        {
+            Codepoint = codepoint,
+            TexCoordMin = new Vector2(
+                (float)cellX / _atlasWidth,
+                (float)(cellY + renderHeight) / _atlasHeight
+            ),
+            TexCoordMax = new Vector2(
+                (float)(cellX + renderWidth) / _atlasWidth,
+                (float)cellY / _atlasHeight
+            ),
+            Size = new Vector2(renderWidth, renderHeight),
+            Bearing = bearing,
+            Advance = advance,
+        };
+    }
+
+    // --- Pure CPU helpers (internal so unit tests can exercise them without GL) ---
+
+    /// <summary>
+    /// Converts an Alpha8 pixel span into a boolean "inside" mask.
+    /// A pixel is considered inside when its alpha value exceeds 127.
+    /// <paramref name="rowStride"/> is the number of bytes between rows
+    /// (SkiaSharp may pad rows internally).
+    /// </summary>
+    internal static bool[] ThresholdAlpha(
+        ReadOnlySpan<byte> alpha,
+        int width,
+        int height,
+        int rowStride = 0
+    )
+    {
+        if (rowStride <= 0)
+            rowStride = width;
+
+        var mask = new bool[width * height];
+        for (int y = 0; y < height; y++)
+        {
+            int srcBase = y * rowStride;
+            int dstBase = y * width;
+            for (int x = 0; x < width; x++)
+            {
+                int srcIdx = srcBase + x;
+                mask[dstBase + x] = srcIdx < alpha.Length && alpha[srcIdx] > 127;
+            }
+        }
+        return mask;
+    }
+
+    /// <summary>
+    /// Brute-force signed Euclidean distance transform with radius <paramref name="spread"/>.
+    /// Returns a float array in [0, 1] where 0.5 == the glyph boundary,
+    /// values &gt; 0.5 are inside, and values &lt; 0.5 are outside.
+    /// </summary>
+    /// <remarks>
+    /// Complexity is O(W × H × spread²).  For the default SdfSpread=16 and a 96×96
+    /// high-resolution surface this is ≈2.7 M iterations per glyph, which is fast
+    /// enough given glyphs are cached after the first render.
+    /// </remarks>
+    internal static float[] GenerateSdf(bool[] insideMask, int w, int h, int spread)
+    {
+        var sdf = new float[w * h];
+        float spreadF = spread;
+
+        for (int y = 0; y < h; y++)
+        {
+            for (int x = 0; x < w; x++)
+            {
+                bool isInside = insideMask[y * w + x];
+                float minDistSq = (spreadF + 1) * (spreadF + 1);
+
+                int xLo = Math.Max(0, x - spread);
+                int xHi = Math.Min(w - 1, x + spread);
+                int yLo = Math.Max(0, y - spread);
+                int yHi = Math.Min(h - 1, y + spread);
+
+                for (int ny = yLo; ny <= yHi; ny++)
+                {
+                    float dy = ny - y;
+                    float dy2 = dy * dy;
+                    if (dy2 >= minDistSq)
+                        continue;
+
+                    for (int nx = xLo; nx <= xHi; nx++)
+                    {
+                        if (insideMask[ny * w + nx] != isInside)
+                        {
+                            float dx = nx - x;
+                            float dSq = dx * dx + dy2;
+                            if (dSq < minDistSq)
+                                minDistSq = dSq;
+                        }
+                    }
+                }
+
+                float dist = Math.Min(MathF.Sqrt(minDistSq), spreadF);
+                float signedDist = isInside ? dist : -dist;
+                sdf[y * w + x] = Math.Clamp(0.5f + 0.5f * signedDist / spreadF, 0f, 1f);
+            }
+        }
+
+        return sdf;
+    }
+
+    /// <summary>
+    /// Box-filters a high-resolution SDF float array down to <paramref name="outW"/> × <paramref name="outH"/>
+    /// and encodes the result as bytes (0–255).
+    /// </summary>
+    internal static byte[] DownsampleSdf(
+        float[] highRes,
+        int hrW,
+        int hrH,
+        int outW,
+        int outH,
+        int scale
+    )
+    {
+        var result = new byte[outW * outH];
+
+        for (int y = 0; y < outH; y++)
+        {
+            for (int x = 0; x < outW; x++)
+            {
+                float sum = 0f;
+                int count = 0;
+                for (int dy = 0; dy < scale; dy++)
+                {
+                    int hy = y * scale + dy;
+                    if (hy >= hrH)
+                        continue;
+                    for (int dx = 0; dx < scale; dx++)
+                    {
+                        int hx = x * scale + dx;
+                        if (hx < hrW)
+                        {
+                            sum += highRes[hy * hrW + hx];
+                            count++;
+                        }
+                    }
+                }
+                result[y * outW + x] = count > 0 ? (byte)(sum / count * 255f + 0.5f) : (byte)0;
+            }
+        }
+
+        return result;
+    }
+
+    private AtlasGlyph CreateEmptyGlyph(uint codepoint, int cellX, int cellY, float advance)
+    {
+        var empty = new byte[_fontSize * _fontSize];
+        _texture.SetData(new ReadOnlySpan<byte>(empty), cellX, cellY, _fontSize, _fontSize);
+
+        return new AtlasGlyph
+        {
+            Codepoint = codepoint,
+            TexCoordMin = new Vector2(
+                (float)cellX / _atlasWidth,
+                (float)(cellY + _fontSize) / _atlasHeight
+            ),
+            TexCoordMax = new Vector2(
+                (float)(cellX + _fontSize) / _atlasWidth,
+                (float)cellY / _atlasHeight
+            ),
+            Size = Vector2.Zero,
+            Bearing = Vector2.Zero,
+            Advance = advance,
+        };
+    }
+
+    public void BindTexture() => _texture.Bind();
+
+    public void UnbindTexture() => _texture.Unbind();
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _hrFont.Dispose();
+        _typeface.Dispose();
+        _texture.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Engine/Yaeger/Properties/AssemblyInfo.cs
+++ b/src/Engine/Yaeger/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Yaeger.Tests")]

--- a/src/Engine/Yaeger/Rendering/TextRenderMode.cs
+++ b/src/Engine/Yaeger/Rendering/TextRenderMode.cs
@@ -1,0 +1,18 @@
+namespace Yaeger.Rendering;
+
+public enum TextRenderMode
+{
+    /// <summary>
+    /// Alpha-coverage rendering. Glyphs are rasterised at the requested pixel size and
+    /// composited with a simple coverage shader. Cheap but blurs when scaled.
+    /// </summary>
+    Standard,
+
+    /// <summary>
+    /// Signed-distance-field rendering. Each glyph is rasterised at 2× the atlas size,
+    /// a CPU distance-transform is applied, and the result is downsampled to the atlas.
+    /// The SDF fragment shader uses <c>smoothstep</c> on the stored distance to reconstruct
+    /// a crisp edge at any render scale.
+    /// </summary>
+    Sdf,
+}

--- a/src/Engine/Yaeger/Rendering/TextRenderer.cs
+++ b/src/Engine/Yaeger/Rendering/TextRenderer.cs
@@ -17,10 +17,11 @@ public class TextRenderer : ITextRenderSurface, IDisposable
     private readonly Shader _textShader;
     private readonly FontManager _fontManager;
     private readonly bool _ownsFontManager;
+    private readonly TextRenderMode _mode;
 
     // Keyed by (font, fontSize) so the same font rendered at different sizes gets its own
     // atlas. Previously keyed by Font alone, which silently reused the first size forever.
-    private readonly Dictionary<(Font.Font Font, int FontSize), GlyphAtlas> _glyphAtlases = new();
+    private readonly Dictionary<(Font.Font Font, int FontSize), IGlyphAtlas> _glyphAtlases = new();
     private readonly FontVertexArray _vao;
     private readonly Buffer<float> _vbo;
     private readonly Buffer<uint> _ebo;
@@ -65,10 +66,33 @@ public class TextRenderer : ITextRenderSurface, IDisposable
         }
         """;
 
+    // SDF shader: the atlas stores a signed distance field where 0.5 == the glyph edge.
+    // fwidth() gives the screen-space derivative of the distance value, yielding an AA
+    // band that is exactly one pixel wide regardless of zoom level.
+    private const string SdfFragmentShaderSource = """
+        #version 330 core
+        in vec2 vTexCoord;
+        in vec4 vColor;
+        out vec4 FragColor;
+
+        uniform sampler2D uTexture;
+
+        void main()
+        {
+            float dist  = texture(uTexture, vTexCoord).r;
+            float width = fwidth(dist);
+            float alpha = smoothstep(0.5 - width, 0.5 + width, dist);
+            FragColor = vec4(vColor.rgb, vColor.a * alpha);
+        }
+        """;
+
     public TextRenderer(Window window)
-        : this(window, fontManager: null) { }
+        : this(window, fontManager: null, TextRenderMode.Standard) { }
 
     public TextRenderer(Window window, FontManager? fontManager)
+        : this(window, fontManager, TextRenderMode.Standard) { }
+
+    public TextRenderer(Window window, FontManager? fontManager, TextRenderMode mode)
     {
         ArgumentNullException.ThrowIfNull(window);
         _gl =
@@ -78,7 +102,10 @@ public class TextRenderer : ITextRenderSurface, IDisposable
             );
         _fontManager = fontManager ?? new FontManager();
         _ownsFontManager = fontManager is null;
-        _textShader = new Shader(_gl, VertexShaderSource, FragmentShaderSource);
+        _mode = mode;
+        var fragmentSource =
+            mode == TextRenderMode.Sdf ? SdfFragmentShaderSource : FragmentShaderSource;
+        _textShader = new Shader(_gl, VertexShaderSource, fragmentSource);
 
         _vertexBuffer = new float[MaxQuadsPerBatch * VerticesPerQuad * FloatsPerVertex];
 
@@ -103,21 +130,21 @@ public class TextRenderer : ITextRenderSurface, IDisposable
         _gl.Enable(EnableCap.Blend);
         _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
 
-        Console.WriteLine($"TextRenderer initialized with max {MaxQuadsPerBatch} glyphs per batch");
+        Console.WriteLine(
+            $"TextRenderer initialized with max {MaxQuadsPerBatch} glyphs per batch (mode: {_mode})"
+        );
     }
 
-    /// <summary>
-    /// Gets or creates a glyph atlas for the specified font.
-    /// </summary>
-    private GlyphAtlas GetOrCreateAtlas(Font.Font font, int fontSize = 48)
+    private IGlyphAtlas GetOrCreateAtlas(Font.Font font, int fontSize = 48)
     {
         var key = (font, fontSize);
         if (_glyphAtlases.TryGetValue(key, out var atlas))
-        {
             return atlas;
-        }
 
-        atlas = new GlyphAtlas(_gl, font, fontSize);
+        atlas = _mode == TextRenderMode.Sdf
+            ? new SdfGlyphAtlas(_gl, font, fontSize)
+            : new GlyphAtlas(_gl, font, fontSize);
+
         _glyphAtlases[key] = atlas;
         return atlas;
     }
@@ -286,7 +313,7 @@ public class TextRenderer : ITextRenderSurface, IDisposable
         _quadCount++;
     }
 
-    private unsafe void RenderBatch(GlyphAtlas atlas)
+    private unsafe void RenderBatch(IGlyphAtlas atlas)
     {
         if (_quadCount == 0)
             return;

--- a/src/Engine/Yaeger/Rendering/TextRenderer.cs
+++ b/src/Engine/Yaeger/Rendering/TextRenderer.cs
@@ -141,9 +141,10 @@ public class TextRenderer : ITextRenderSurface, IDisposable
         if (_glyphAtlases.TryGetValue(key, out var atlas))
             return atlas;
 
-        atlas = _mode == TextRenderMode.Sdf
-            ? new SdfGlyphAtlas(_gl, font, fontSize)
-            : new GlyphAtlas(_gl, font, fontSize);
+        atlas =
+            _mode == TextRenderMode.Sdf
+                ? new SdfGlyphAtlas(_gl, font, fontSize)
+                : new GlyphAtlas(_gl, font, fontSize);
 
         _glyphAtlases[key] = atlas;
         return atlas;

--- a/tests/Yaeger.Tests/Font/SdfGlyphAtlasTests.cs
+++ b/tests/Yaeger.Tests/Font/SdfGlyphAtlasTests.cs
@@ -1,0 +1,150 @@
+using Yaeger.Font;
+
+namespace Yaeger.Tests.Font;
+
+public class SdfGlyphAtlasTests
+{
+    // ── ThresholdAlpha ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ThresholdAlpha_AboveThreshold_IsMarkedInside()
+    {
+        byte[] alpha = [0, 128, 255];
+        var mask = SdfGlyphAtlas.ThresholdAlpha(alpha, 3, 1);
+        Assert.False(mask[0]);
+        Assert.True(mask[1]);
+        Assert.True(mask[2]);
+    }
+
+    [Fact]
+    public void ThresholdAlpha_AtThreshold_IsMarkedOutside()
+    {
+        byte[] alpha = [127];
+        var mask = SdfGlyphAtlas.ThresholdAlpha(alpha, 1, 1);
+        Assert.False(mask[0]);
+    }
+
+    [Fact]
+    public void ThresholdAlpha_WithRowStride_SkipsStridePadding()
+    {
+        // 2-pixel-wide image with 4-byte row stride (2 real + 2 padding)
+        byte[] alpha = [200, 50, 0xFF, 0xFF, 200, 50, 0xFF, 0xFF];
+        var mask = SdfGlyphAtlas.ThresholdAlpha(alpha, 2, 2, rowStride: 4);
+        Assert.True(mask[0]);  // (0,0) = 200
+        Assert.False(mask[1]); // (1,0) = 50
+        Assert.True(mask[2]);  // (0,1) = 200
+        Assert.False(mask[3]); // (1,1) = 50
+    }
+
+    // ── GenerateSdf ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GenerateSdf_InsidePixels_HaveValueAboveHalf()
+    {
+        // 3×3 grid: all inside
+        var mask = new bool[9];
+        Array.Fill(mask, true);
+        var sdf = SdfGlyphAtlas.GenerateSdf(mask, 3, 3, spread: 4);
+        foreach (var v in sdf)
+            Assert.True(v > 0.5f, $"Expected inside pixel > 0.5 but got {v}");
+    }
+
+    [Fact]
+    public void GenerateSdf_OutsidePixels_HaveValueBelowHalf()
+    {
+        // 3×3 grid: all outside
+        var mask = new bool[9];
+        Array.Fill(mask, false);
+        var sdf = SdfGlyphAtlas.GenerateSdf(mask, 3, 3, spread: 4);
+        foreach (var v in sdf)
+            Assert.True(v < 0.5f, $"Expected outside pixel < 0.5 but got {v}");
+    }
+
+    [Fact]
+    public void GenerateSdf_EdgePixel_IsNearHalf()
+    {
+        // A 3×1 row: [outside, boundary-inside, inside].
+        // The middle pixel is adjacent to an outside pixel, so its signed
+        // distance to the nearest outside pixel is 1 unit → should be
+        // 0.5 + 0.5 * (1 / spread).  With spread=4 that's 0.625.
+        var mask = new bool[] { false, true, true };
+        var sdf = SdfGlyphAtlas.GenerateSdf(mask, 3, 1, spread: 4);
+
+        // The outside pixel (index 0) is adjacent to an inside pixel → dist = 1 → value < 0.5
+        Assert.True(sdf[0] < 0.5f);
+        // The first inside pixel (index 1) is adjacent to an outside pixel → dist = 1 → value > 0.5
+        Assert.True(sdf[1] > 0.5f);
+        // The second inside pixel (index 2) is two steps from outside → dist = 2 → larger
+        Assert.True(sdf[2] > sdf[1]);
+    }
+
+    [Fact]
+    public void GenerateSdf_OutputIsClampedTo01()
+    {
+        var mask = new bool[16];
+        Array.Fill(mask, true);
+        var sdf = SdfGlyphAtlas.GenerateSdf(mask, 4, 4, spread: 1);
+        foreach (var v in sdf)
+        {
+            Assert.True(v >= 0f && v <= 1f, $"SDF value {v} is out of [0,1]");
+        }
+    }
+
+    // ── DownsampleSdf ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DownsampleSdf_2xScale_AveragesQuadrant()
+    {
+        // 2×2 high-res → 1×1 output at scale 2
+        // All pixels are 1.0 → output should be 255
+        float[] highRes = [1f, 1f, 1f, 1f];
+        var result = SdfGlyphAtlas.DownsampleSdf(highRes, 2, 2, 1, 1, 2);
+        Assert.Single(result);
+        Assert.Equal(255, result[0]);
+    }
+
+    [Fact]
+    public void DownsampleSdf_ZeroInput_ProducesZeroOutput()
+    {
+        float[] highRes = new float[16]; // all zeros
+        var result = SdfGlyphAtlas.DownsampleSdf(highRes, 4, 4, 2, 2, 2);
+        Assert.All(result, b => Assert.Equal(0, b));
+    }
+
+    [Fact]
+    public void DownsampleSdf_OutputSizeMatchesExpected()
+    {
+        float[] highRes = new float[4 * 4];
+        var result = SdfGlyphAtlas.DownsampleSdf(highRes, 4, 4, 2, 2, 2);
+        Assert.Equal(4, result.Length); // 2×2 output
+    }
+
+    // ── Integration: full SDF pipeline ────────────────────────────────────────
+
+    [Fact]
+    public void SdfPipeline_SolidSquare_CenterIsInside_CornersAreOutside()
+    {
+        // Build a 6×6 binary mask with a 4×4 solid square in the centre.
+        int w = 8, h = 8;
+        var mask = new bool[w * h];
+        for (int y = 2; y < 6; y++)
+        {
+            for (int x = 2; x < 6; x++)
+            {
+                mask[y * w + x] = true;
+            }
+        }
+
+        var sdf = SdfGlyphAtlas.GenerateSdf(mask, w, h, spread: 3);
+
+        // Centre of the square should be solidly inside (> 0.5)
+        float centre = sdf[4 * w + 4];
+        Assert.True(centre > 0.5f, $"Centre should be > 0.5, got {centre}");
+
+        // Corners of the image are outside
+        Assert.True(sdf[0] < 0.5f, "Top-left corner should be outside");
+        Assert.True(sdf[w - 1] < 0.5f, "Top-right corner should be outside");
+        Assert.True(sdf[(h - 1) * w] < 0.5f, "Bottom-left corner should be outside");
+        Assert.True(sdf[h * w - 1] < 0.5f, "Bottom-right corner should be outside");
+    }
+}

--- a/tests/Yaeger.Tests/Font/SdfGlyphAtlasTests.cs
+++ b/tests/Yaeger.Tests/Font/SdfGlyphAtlasTests.cs
@@ -30,9 +30,9 @@ public class SdfGlyphAtlasTests
         // 2-pixel-wide image with 4-byte row stride (2 real + 2 padding)
         byte[] alpha = [200, 50, 0xFF, 0xFF, 200, 50, 0xFF, 0xFF];
         var mask = SdfGlyphAtlas.ThresholdAlpha(alpha, 2, 2, rowStride: 4);
-        Assert.True(mask[0]);  // (0,0) = 200
+        Assert.True(mask[0]); // (0,0) = 200
         Assert.False(mask[1]); // (1,0) = 50
-        Assert.True(mask[2]);  // (0,1) = 200
+        Assert.True(mask[2]); // (0,1) = 200
         Assert.False(mask[3]); // (1,1) = 50
     }
 
@@ -125,7 +125,8 @@ public class SdfGlyphAtlasTests
     public void SdfPipeline_SolidSquare_CenterIsInside_CornersAreOutside()
     {
         // Build a 6×6 binary mask with a 4×4 solid square in the centre.
-        int w = 8, h = 8;
+        int w = 8,
+            h = 8;
         var mask = new bool[w * h];
         for (int y = 2; y < 6; y++)
         {

--- a/tests/Yaeger.Tests/Font/SdfGlyphAtlasTests.cs
+++ b/tests/Yaeger.Tests/Font/SdfGlyphAtlasTests.cs
@@ -124,7 +124,7 @@ public class SdfGlyphAtlasTests
     [Fact]
     public void SdfPipeline_SolidSquare_CenterIsInside_CornersAreOutside()
     {
-        // Build a 6×6 binary mask with a 4×4 solid square in the centre.
+        // Build an 8×8 binary mask with a 4×4 solid square in the centre.
         int w = 8,
             h = 8;
         var mask = new bool[w * h];


### PR DESCRIPTION
Implements signed distance field text rendering as an opt-in mode on
TextRenderer. Glyphs are rasterised at 2× atlas resolution using
SkiaSharp (no font hinting, for clean vector outlines), then a
brute-force Euclidean distance transform converts the binary alpha mask
into a float SDF image. The result is box-filtered back to the atlas
cell and stored as R8. A new GLSL fragment shader reconstructs a crisp
edge at any render scale via smoothstep on the stored distance value,
using fwidth() to derive an AA band exactly one screen-pixel wide.

Public surface changes:
- New `TextRenderMode` enum (Standard | Sdf)
- `TextRenderer` gains a third constructor parameter `TextRenderMode mode`
  (default Standard, fully backward-compatible)
- New `SdfGlyphAtlas` class (same atlas layout as GlyphAtlas)
- `IGlyphAtlas` internal interface shared by both atlas types
- `TextRenderingExample` sample switched to SDF mode to demonstrate it

Unit tests cover the three pure-CPU helpers (ThresholdAlpha,
GenerateSdf, DownsampleSdf) without requiring a GL context.

https://claude.ai/code/session_01US5ded2jW2MyXdk8qtR14V