### PR TITLE
feat(inspector): add ImGui in-game entity inspector overlay (issue #36)

### DIFF
--- a/src/Engine/Yaeger/ECS/IComponentSerializer.cs
+++ b/src/Engine/Yaeger/ECS/IComponentSerializer.cs
@@ -25,6 +25,14 @@ public interface IComponentSerializer
     string TypeId { get; }
 
     /// <summary>
+    /// The CLR type of the component handled by this serializer, or <c>null</c> if the
+    /// serializer does not expose type information (e.g. game-specific serializers that opt
+    /// out). Used by tooling such as <c>ImGuiInspector</c> to create default instances and
+    /// perform generic add/remove operations via reflection.
+    /// </summary>
+    Type? ComponentType => null;
+
+    /// <summary>
     /// Deserializes a component from a <see cref="JsonElement"/> and returns an action
     /// that adds the resulting component to an entity.
     /// </summary>

--- a/src/Engine/Yaeger/ECS/Serializers/AnimationSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/AnimationSerializer.cs
@@ -27,6 +27,9 @@ public sealed class AnimationSerializer : IComponentSerializer
     public string TypeId => "Animation";
 
     /// <inheritdoc/>
+    public Type? ComponentType => typeof(Animation);
+
+    /// <inheritdoc/>
     public Action<World, Entity> Deserialize(JsonElement element)
     {
         var loop = true;

--- a/src/Engine/Yaeger/ECS/Serializers/AnimationStateSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/AnimationStateSerializer.cs
@@ -25,6 +25,9 @@ public sealed class AnimationStateSerializer : IComponentSerializer
     public string TypeId => "AnimationState";
 
     /// <inheritdoc/>
+    public Type? ComponentType => typeof(AnimationState);
+
+    /// <inheritdoc/>
     public Action<World, Entity> Deserialize(JsonElement element)
     {
         var frameIndex = GetOptionalInt32(element, "currentFrameIndex", 0);

--- a/src/Engine/Yaeger/ECS/Serializers/RenderLayerSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/RenderLayerSerializer.cs
@@ -20,6 +20,9 @@ public sealed class RenderLayerSerializer : IComponentSerializer
     public string TypeId => "RenderLayer";
 
     /// <inheritdoc/>
+    public Type? ComponentType => typeof(RenderLayer);
+
+    /// <inheritdoc/>
     public Action<World, Entity> Deserialize(JsonElement element)
     {
         var value = 0;

--- a/src/Engine/Yaeger/ECS/Serializers/SpriteSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/SpriteSerializer.cs
@@ -20,6 +20,9 @@ public sealed class SpriteSerializer : IComponentSerializer
     public string TypeId => "Sprite";
 
     /// <inheritdoc/>
+    public Type? ComponentType => typeof(Sprite);
+
+    /// <inheritdoc/>
     public Action<World, Entity> Deserialize(JsonElement element)
     {
         var texturePath = GetRequiredTexturePath(element);

--- a/src/Engine/Yaeger/ECS/Serializers/SpriteSheetSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/SpriteSheetSerializer.cs
@@ -28,6 +28,9 @@ public sealed class SpriteSheetSerializer : IComponentSerializer
     public string TypeId => "SpriteSheet";
 
     /// <inheritdoc/>
+    public Type? ComponentType => typeof(SpriteSheet);
+
+    /// <inheritdoc/>
     public Action<World, Entity> Deserialize(JsonElement element)
     {
         var texturePath = GetRequiredString(element, "texturePath");

--- a/src/Engine/Yaeger/ECS/Serializers/Transform2DSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/Transform2DSerializer.cs
@@ -27,6 +27,9 @@ public sealed class Transform2DSerializer : IComponentSerializer
     public string TypeId => "Transform2D";
 
     /// <inheritdoc/>
+    public Type? ComponentType => typeof(Transform2D);
+
+    /// <inheritdoc/>
     public Action<World, Entity> Deserialize(JsonElement element)
     {
         var position = element.TryGetProperty("position", out var posEl)

--- a/src/Engine/Yaeger/Input/KeyMapper.cs
+++ b/src/Engine/Yaeger/Input/KeyMapper.cs
@@ -26,6 +26,7 @@ public static class KeyMapper
         { Key.Number2, Keys.Num2 },
         { Key.Number3, Keys.Num3 },
         { Key.C, Keys.C },
+        { Key.F1, Keys.F1 },
         // Add more mappings as needed
     };
 

--- a/src/Engine/Yaeger/Input/Keys.cs
+++ b/src/Engine/Yaeger/Input/Keys.cs
@@ -22,5 +22,6 @@ public enum Keys
     Num2,
     Num3,
     C,
+    F1,
     // Add more keys as needed
 }

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -44,8 +44,9 @@ public sealed class ImGuiInspector : IDisposable
         ["RenderLayer"] = static (w, e) => w.AddComponent(e, default(RenderLayer)),
     };
 
-    private static readonly MethodInfo WorldRemoveMethod = typeof(World)
-        .GetMethod(nameof(World.RemoveComponent))!;
+    private static readonly MethodInfo WorldRemoveMethod = typeof(World).GetMethod(
+        nameof(World.RemoveComponent)
+    )!;
 
     public ImGuiInspector(Window window, World world, ComponentRegistry? registry = null)
     {

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -155,7 +155,8 @@ public sealed class ImGuiInspector : IDisposable
         var entity = _selectedEntity.Value;
 
         // The game may have destroyed this entity externally between frames
-        if (!_world.Entities.Contains(entity))
+        var entitySet = _world.Entities as ICollection<Entity>;
+        if (!(entitySet?.Contains(entity) ?? _world.Entities.Contains(entity)))
         {
             _selectedEntity = null;
             ImGui.TextDisabled("Entity no longer exists.");
@@ -390,7 +391,10 @@ public sealed class ImGuiInspector : IDisposable
     {
         var items = new List<string>();
 
-        // Camera2D is a curated inspector type but not in the default registry
+        if (!_world.TryGetComponent<Transform2D>(entity, out _))
+            items.Add("Transform2D");
+
+        // Camera2D is not in the default registry, so it is always handled explicitly
         if (!_world.TryGetComponent<Camera2D>(entity, out _))
             items.Add("Camera2D");
 
@@ -398,6 +402,9 @@ public sealed class ImGuiInspector : IDisposable
         {
             foreach (var serializer in _registry.Serializers)
             {
+                // Skip curated types already handled above to avoid duplicates
+                if (serializer.TypeId is "Transform2D" or "Camera2D")
+                    continue;
                 if (!EntityHasComponent(entity, serializer))
                     items.Add(serializer.TypeId);
             }
@@ -464,7 +471,8 @@ public sealed class ImGuiInspector : IDisposable
         if (serializer.ComponentType is { } type && type.IsValueType)
         {
             var method = WorldTryGetComponentMethod.MakeGenericMethod(type);
-            var args = new object?[] { entity, null };
+            // Pass a boxed default for the out parameter; null can misfire for value types
+            var args = new object?[] { entity, Activator.CreateInstance(type) };
             return (bool)method.Invoke(_world, args)!;
         }
 

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -66,11 +66,15 @@ public sealed class ImGuiInspector : IDisposable
     /// </summary>
     public void Render(double delta)
     {
+        if (!_visible)
+        {
+            // Still flush any ops queued on the frame visibility was toggled off
+            FlushPendingCommands();
+            return;
+        }
+
         _controller.Update((float)delta);
-
-        if (_visible)
-            DrawInspectorWindow();
-
+        DrawInspectorWindow();
         _controller.Render();
         FlushPendingCommands();
     }

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -327,7 +327,12 @@ public sealed class ImGuiInspector : IDisposable
             _addComponentComboIndex = 0;
 
         ImGui.SetNextItemWidth(180);
-        ImGui.Combo($"##addCombo_{entity.Id}", ref _addComponentComboIndex, typeIds, typeIds.Length);
+        ImGui.Combo(
+            $"##addCombo_{entity.Id}",
+            ref _addComponentComboIndex,
+            typeIds,
+            typeIds.Length
+        );
         ImGui.SameLine();
 
         var selectedId = typeIds[_addComponentComboIndex];

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -1,0 +1,432 @@
+using System.Numerics;
+using System.Reflection;
+using ImGuiNET;
+using Silk.NET.OpenGL.Extensions.ImGui;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Windowing;
+
+namespace Yaeger.Inspector;
+
+/// <summary>
+/// In-game ImGui overlay for live entity inspection and editing.
+/// Wire it up in your render loop and toggle with a key binding:
+/// <code>
+/// var inspector = new ImGuiInspector(window, world, componentRegistry);
+/// window.OnRender += delta => { renderSystem.Render(); inspector.Render(delta); };
+/// Keyboard.AddKeyDown(Keys.F1, inspector.Toggle);
+/// </code>
+/// The inspector renders after your game systems so the overlay sits on top.
+/// </summary>
+public sealed class ImGuiInspector : IDisposable
+{
+    private readonly World _world;
+    private readonly ComponentRegistry? _registry;
+    private readonly SceneSaver? _sceneSaver;
+    private readonly ImGuiController _controller;
+
+    private bool _visible;
+    private Entity? _selectedEntity;
+    private int _addComponentComboIndex;
+    private string _saveScenePath = "Scenes/scene.json";
+    private string _saveStatusMessage = string.Empty;
+
+    // Deferred commands — mutations run after all ImGui draw calls to avoid iterator invalidation
+    private Entity? _pendingDestroyEntity;
+    private Action<World>? _pendingWorldOp;
+
+    // TypeIds that can be added with a sensible zero/default value
+    private static readonly Dictionary<string, Action<World, Entity>> DefaultAddActions = new()
+    {
+        ["Transform2D"] = static (w, e) => w.AddComponent(e, new Transform2D(Vector2.Zero)),
+        ["Camera2D"] = static (w, e) => w.AddComponent(e, new Camera2D()),
+        ["AnimationState"] = static (w, e) => w.AddComponent(e, default(AnimationState)),
+        ["RenderLayer"] = static (w, e) => w.AddComponent(e, default(RenderLayer)),
+    };
+
+    private static readonly MethodInfo WorldRemoveMethod = typeof(World)
+        .GetMethod(nameof(World.RemoveComponent))!;
+
+    public ImGuiInspector(Window window, World world, ComponentRegistry? registry = null)
+    {
+        _world = world;
+        _registry = registry;
+        _sceneSaver = registry is not null ? new SceneSaver(registry) : null;
+        _controller = new ImGuiController(window.Gl, window.InnerView, window.InputContext);
+    }
+
+    /// <summary>Toggles the inspector overlay on or off.</summary>
+    public void Toggle() => _visible = !_visible;
+
+    /// <summary>
+    /// Updates and renders the inspector overlay.  Call inside <c>OnRender</c> after all game
+    /// rendering so the overlay sits on top.
+    /// </summary>
+    public void Render(double delta)
+    {
+        _controller.Update((float)delta);
+
+        if (_visible)
+            DrawInspectorWindow();
+
+        _controller.Render();
+        FlushPendingCommands();
+    }
+
+    // ── Main window ──────────────────────────────────────────────────────────────
+
+    private void DrawInspectorWindow()
+    {
+        ImGui.SetNextWindowSize(new Vector2(720, 520), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowPos(new Vector2(10, 10), ImGuiCond.FirstUseEver);
+
+        var open = true;
+        if (!ImGui.Begin("Scene Inspector", ref open))
+        {
+            ImGui.End();
+            if (!open) _visible = false;
+            return;
+        }
+
+        if (!open)
+            _visible = false;
+
+        // Two-column layout: entity list left, component inspector right
+        ImGui.Columns(2, "inspector_columns");
+        ImGui.SetColumnWidth(0, 210);
+
+        DrawEntityListColumn();
+
+        ImGui.NextColumn();
+
+        DrawComponentInspectorColumn();
+
+        ImGui.Columns(1);
+
+        ImGui.Separator();
+        DrawSaveRow();
+
+        ImGui.End();
+    }
+
+    // ── Entity list (left column) ─────────────────────────────────────────────
+
+    private void DrawEntityListColumn()
+    {
+        ImGui.Text("Entities");
+        ImGui.Separator();
+
+        // Snapshot to a sorted list so we don't mutate during iteration
+        var entities = _world.Entities.OrderBy(e => e.Id).ToArray();
+
+        foreach (var entity in entities)
+        {
+            var label = _world.TryGetTag(entity, out var tag)
+                ? $"{tag}  (#{entity.Id})"
+                : $"Entity#{entity.Id}";
+
+            var selected = _selectedEntity == entity;
+            if (ImGui.Selectable(label, selected))
+                _selectedEntity = entity;
+        }
+
+        ImGui.Separator();
+
+        if (ImGui.SmallButton("New Entity"))
+            _pendingWorldOp = static w => w.CreateEntity();
+    }
+
+    // ── Component inspector (right column) ───────────────────────────────────
+
+    private void DrawComponentInspectorColumn()
+    {
+        if (!_selectedEntity.HasValue)
+        {
+            ImGui.TextDisabled("Select an entity.");
+            return;
+        }
+
+        var entity = _selectedEntity.Value;
+        var entityLabel = _world.TryGetTag(entity, out var tag)
+            ? $"\"{tag}\"  (#{entity.Id})"
+            : $"Entity#{entity.Id}";
+
+        ImGui.Text(entityLabel);
+        ImGui.Separator();
+
+        // ── Curated editable components ──────────────────────────────────────
+        if (_world.TryGetComponent<Transform2D>(entity, out var transform))
+            DrawTransform2DSection(entity, transform);
+
+        if (_world.TryGetComponent<Camera2D>(entity, out var camera))
+            DrawCamera2DSection(entity, camera);
+
+        if (_world.TryGetComponent<Sprite>(entity, out var sprite))
+            DrawSpriteSection(entity, sprite);
+
+        // ── Other registered components (read-only + remove button) ──────────
+        if (_registry != null)
+        {
+            foreach (var serializer in _registry.Serializers)
+            {
+                if (serializer.TypeId is "Transform2D" or "Camera2D" or "Sprite")
+                    continue;
+
+                var json = serializer.TrySerialize(_world, entity);
+                if (json == null)
+                    continue;
+
+                if (ImGui.CollapsingHeader(serializer.TypeId))
+                {
+                    ImGui.TextWrapped(json.ToJsonString());
+                    ImGui.Spacing();
+
+                    if (
+                        serializer.ComponentType is { } cType
+                        && ImGui.SmallButton($"Remove##{serializer.TypeId}_{entity.Id}")
+                    )
+                    {
+                        ScheduleRemove(entity, cType);
+                    }
+                }
+            }
+        }
+
+        ImGui.Spacing();
+        DrawAddComponentRow(entity);
+
+        ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.7f, 0.15f, 0.15f, 1f));
+        if (ImGui.Button($"Destroy Entity##destroy_{entity.Id}"))
+        {
+            _pendingDestroyEntity = entity;
+            _selectedEntity = null;
+        }
+        ImGui.PopStyleColor();
+    }
+
+    // ── Curated component editors ─────────────────────────────────────────────
+
+    private void DrawTransform2DSection(Entity entity, Transform2D t)
+    {
+        if (!ImGui.CollapsingHeader("Transform2D"))
+            return;
+
+        var posX = t.Position.X;
+        var posY = t.Position.Y;
+        var rot = t.Rotation;
+        var scaleX = t.Scale.X;
+        var scaleY = t.Scale.Y;
+        var changed = false;
+
+        ImGui.SetNextItemWidth(75);
+        changed |= ImGui.DragFloat($"X##posX_{entity.Id}", ref posX, 0.01f);
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(75);
+        changed |= ImGui.DragFloat($"Y##posY_{entity.Id}", ref posY, 0.01f);
+        ImGui.SameLine();
+        ImGui.Text("Position");
+
+        ImGui.SetNextItemWidth(120);
+        changed |= ImGui.DragFloat($"Rotation##rot_{entity.Id}", ref rot, 0.001f);
+
+        ImGui.SetNextItemWidth(75);
+        changed |= ImGui.DragFloat($"X##scX_{entity.Id}", ref scaleX, 0.01f);
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(75);
+        changed |= ImGui.DragFloat($"Y##scY_{entity.Id}", ref scaleY, 0.01f);
+        ImGui.SameLine();
+        ImGui.Text("Scale");
+
+        if (changed)
+        {
+            t.Position = new Vector2(posX, posY);
+            t.Rotation = rot;
+            t.Scale = new Vector2(scaleX, scaleY);
+            _world.AddComponent(entity, t);
+        }
+
+        ImGui.Spacing();
+        if (ImGui.SmallButton($"Remove##Transform2D_{entity.Id}"))
+            ScheduleRemove(entity, typeof(Transform2D));
+
+        ImGui.Spacing();
+    }
+
+    private void DrawCamera2DSection(Entity entity, Camera2D cam)
+    {
+        if (!ImGui.CollapsingHeader("Camera2D"))
+            return;
+
+        var posX = cam.Position.X;
+        var posY = cam.Position.Y;
+        var zoom = cam.Zoom;
+        var rot = cam.Rotation;
+        var changed = false;
+
+        ImGui.SetNextItemWidth(75);
+        changed |= ImGui.DragFloat($"X##camX_{entity.Id}", ref posX, 0.01f);
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(75);
+        changed |= ImGui.DragFloat($"Y##camY_{entity.Id}", ref posY, 0.01f);
+        ImGui.SameLine();
+        ImGui.Text("Position");
+
+        ImGui.SetNextItemWidth(120);
+        changed |= ImGui.DragFloat($"Zoom##camZ_{entity.Id}", ref zoom, 0.01f, 0.01f, 100f);
+
+        ImGui.SetNextItemWidth(120);
+        changed |= ImGui.DragFloat($"Rotation##camR_{entity.Id}", ref rot, 0.001f);
+
+        if (changed)
+        {
+            cam.Position = new Vector2(posX, posY);
+            cam.Zoom = zoom;
+            cam.Rotation = rot;
+            _world.AddComponent(entity, cam);
+        }
+
+        ImGui.Spacing();
+        if (ImGui.SmallButton($"Remove##Camera2D_{entity.Id}"))
+            ScheduleRemove(entity, typeof(Camera2D));
+
+        ImGui.Spacing();
+    }
+
+    private void DrawSpriteSection(Entity entity, Sprite sprite)
+    {
+        if (!ImGui.CollapsingHeader("Sprite"))
+            return;
+
+        var path = sprite.TexturePath ?? string.Empty;
+        ImGui.SetNextItemWidth(200);
+        if (ImGui.InputText($"TexturePath##sp_{entity.Id}", ref path, 512))
+            _world.AddComponent(entity, new Sprite(path, sprite.Tint));
+
+        ImGui.Spacing();
+        if (ImGui.SmallButton($"Remove##Sprite_{entity.Id}"))
+            ScheduleRemove(entity, typeof(Sprite));
+
+        ImGui.Spacing();
+    }
+
+    // ── Add component row ────────────────────────────────────────────────────
+
+    private void DrawAddComponentRow(Entity entity)
+    {
+        var typeIds = BuildAddableTypeIds(entity);
+        if (typeIds.Length == 0)
+            return;
+
+        ImGui.Text("Add Component");
+
+        if (_addComponentComboIndex >= typeIds.Length)
+            _addComponentComboIndex = 0;
+
+        ImGui.SetNextItemWidth(180);
+        ImGui.Combo($"##addCombo_{entity.Id}", ref _addComponentComboIndex, typeIds, typeIds.Length);
+        ImGui.SameLine();
+
+        var selectedId = typeIds[_addComponentComboIndex];
+        var hasDefaultAction = DefaultAddActions.ContainsKey(selectedId);
+
+        if (hasDefaultAction)
+        {
+            if (ImGui.SmallButton($"+##add_{entity.Id}"))
+            {
+                var addAction = DefaultAddActions[selectedId];
+                _pendingWorldOp = w => addAction(w, entity);
+            }
+        }
+        else
+        {
+            ImGui.TextDisabled("(no default — add in code)");
+        }
+    }
+
+    private string[] BuildAddableTypeIds(Entity entity)
+    {
+        var items = new List<string>();
+
+        // Camera2D is a curated inspector type but not in the default registry
+        if (!_world.TryGetComponent<Camera2D>(entity, out _))
+            items.Add("Camera2D");
+
+        if (_registry != null)
+        {
+            foreach (var serializer in _registry.Serializers)
+            {
+                // Only show types the entity doesn't already have
+                if (serializer.TrySerialize(_world, entity) == null)
+                    items.Add(serializer.TypeId);
+            }
+        }
+
+        return items.ToArray();
+    }
+
+    // ── Save scene row ────────────────────────────────────────────────────────
+
+    private void DrawSaveRow()
+    {
+        ImGui.SetNextItemWidth(300);
+        ImGui.InputText("##savePath", ref _saveScenePath, 512);
+        ImGui.SameLine();
+
+        var canSave = _sceneSaver != null;
+
+        if (!canSave)
+            ImGui.BeginDisabled();
+
+        if (ImGui.SmallButton("Save Scene") && canSave)
+        {
+            try
+            {
+                _sceneSaver!.Save(_world, _saveScenePath);
+                _saveStatusMessage = $"Saved at {DateTime.Now:HH:mm:ss}";
+            }
+            catch (Exception ex)
+            {
+                _saveStatusMessage = $"Error: {ex.Message}";
+            }
+        }
+
+        if (!canSave)
+            ImGui.EndDisabled();
+
+        if (!string.IsNullOrEmpty(_saveStatusMessage))
+        {
+            ImGui.SameLine();
+            ImGui.TextDisabled(_saveStatusMessage);
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void ScheduleRemove(Entity entity, Type componentType)
+    {
+        _pendingWorldOp = w =>
+        {
+            var method = WorldRemoveMethod.MakeGenericMethod(componentType);
+            method.Invoke(w, [entity]);
+        };
+    }
+
+    private void FlushPendingCommands()
+    {
+        if (_pendingDestroyEntity.HasValue)
+        {
+            _world.DestroyEntity(_pendingDestroyEntity.Value);
+            _pendingDestroyEntity = null;
+        }
+
+        if (_pendingWorldOp != null)
+        {
+            _pendingWorldOp(_world);
+            _pendingWorldOp = null;
+        }
+    }
+
+    public void Dispose() => _controller.Dispose();
+}

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -264,7 +264,8 @@ public sealed class ImGuiInspector : IDisposable
             t.Position = new Vector2(posX, posY);
             t.Rotation = rot;
             t.Scale = new Vector2(scaleX, scaleY);
-            _world.AddComponent(entity, t);
+            var snapshot = t;
+            _pendingWorldOps.Add(w => w.AddComponent(entity, snapshot));
         }
 
         ImGui.Spacing();
@@ -304,7 +305,8 @@ public sealed class ImGuiInspector : IDisposable
             cam.Position = new Vector2(posX, posY);
             cam.Zoom = zoom;
             cam.Rotation = rot;
-            _world.AddComponent(entity, cam);
+            var snapshot = cam;
+            _pendingWorldOps.Add(w => w.AddComponent(entity, snapshot));
         }
 
         ImGui.Spacing();
@@ -322,7 +324,11 @@ public sealed class ImGuiInspector : IDisposable
         var path = sprite.TexturePath ?? string.Empty;
         ImGui.SetNextItemWidth(200);
         if (ImGui.InputText($"TexturePath##sp_{entity.Id}", ref path, 512))
-            _world.AddComponent(entity, new Sprite(path, sprite.Tint));
+        {
+            var tint = sprite.Tint;
+            var newPath = path;
+            _pendingWorldOps.Add(w => w.AddComponent(entity, new Sprite(newPath, tint)));
+        }
 
         ImGui.Spacing();
         if (ImGui.SmallButton($"Remove##Sprite_{entity.Id}"))
@@ -344,19 +350,29 @@ public sealed class ImGuiInspector : IDisposable
         if (_addComponentComboIndex >= typeIds.Length)
             _addComponentComboIndex = 0;
 
+        var currentLabel = typeIds[_addComponentComboIndex];
         ImGui.SetNextItemWidth(180);
-        ImGui.Combo(
-            $"##addCombo_{entity.Id}",
-            ref _addComponentComboIndex,
-            typeIds,
-            typeIds.Length
-        );
+        if (ImGui.BeginCombo($"##addCombo_{entity.Id}", currentLabel))
+        {
+            for (var i = 0; i < typeIds.Length; i++)
+            {
+                var typeId = typeIds[i];
+                var supported = DefaultAddActions.ContainsKey(typeId);
+                if (!supported)
+                    ImGui.BeginDisabled();
+
+                if (ImGui.Selectable(typeId, _addComponentComboIndex == i))
+                    _addComponentComboIndex = i;
+
+                if (!supported)
+                    ImGui.EndDisabled();
+            }
+            ImGui.EndCombo();
+        }
         ImGui.SameLine();
 
         var selectedId = typeIds[_addComponentComboIndex];
-        var hasDefaultAction = DefaultAddActions.ContainsKey(selectedId);
-
-        if (hasDefaultAction)
+        if (DefaultAddActions.ContainsKey(selectedId))
         {
             if (ImGui.SmallButton($"+##add_{entity.Id}"))
             {

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -178,17 +178,22 @@ public sealed class ImGuiInspector : IDisposable
                 if (serializer.TypeId is "Transform2D" or "Camera2D" or "Sprite")
                     continue;
 
-                var json = serializer.TrySerialize(_world, entity);
-                if (json == null)
+                if (!EntityHasComponent(entity, serializer))
                     continue;
 
                 if (ImGui.CollapsingHeader(serializer.TypeId))
                 {
-                    ImGui.TextWrapped(json.ToJsonString());
+                    var json = serializer.TrySerialize(_world, entity);
+                    if (json != null)
+                        ImGui.TextWrapped(json.ToJsonString());
+                    else
+                        ImGui.TextDisabled("(serialization not supported)");
+
                     ImGui.Spacing();
 
                     if (
                         serializer.ComponentType is { } cType
+                        && cType.IsValueType
                         && ImGui.SmallButton($"Remove##{serializer.TypeId}_{entity.Id}")
                     )
                     {
@@ -418,8 +423,36 @@ public sealed class ImGuiInspector : IDisposable
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
+    private static readonly MethodInfo WorldTryGetComponentMethod = typeof(World).GetMethod(
+        nameof(World.TryGetComponent)
+    )!;
+
+    /// <summary>
+    /// Checks whether <paramref name="entity"/> carries the component handled by
+    /// <paramref name="serializer"/>.  When <see cref="IComponentSerializer.ComponentType"/>
+    /// is known, reflection is used for an authoritative presence check — this handles
+    /// serializers that return <c>null</c> from TrySerialize even when the entity has the
+    /// component (e.g. load-only / write-unsupported serializers).  Falls back to
+    /// TrySerialize for serializers that don't expose a ComponentType.
+    /// </summary>
+    private bool EntityHasComponent(Entity entity, IComponentSerializer serializer)
+    {
+        if (serializer.ComponentType is { } type && type.IsValueType)
+        {
+            var method = WorldTryGetComponentMethod.MakeGenericMethod(type);
+            var args = new object?[] { entity, null };
+            return (bool)method.Invoke(_world, args)!;
+        }
+
+        return serializer.TrySerialize(_world, entity) != null;
+    }
+
     private void ScheduleRemove(Entity entity, Type componentType)
     {
+        // componentType must be a struct (World.RemoveComponent<T> where T : struct)
+        if (!componentType.IsValueType)
+            return;
+
         _pendingWorldOps.Add(w =>
         {
             var method = WorldRemoveMethod.MakeGenericMethod(componentType);
@@ -429,15 +462,17 @@ public sealed class ImGuiInspector : IDisposable
 
     private void FlushPendingCommands()
     {
+        // World ops run first so that an Add queued in the same frame as Destroy
+        // doesn't create zombie components on an entity that no longer exists.
+        foreach (var op in _pendingWorldOps)
+            op(_world);
+        _pendingWorldOps.Clear();
+
         if (_pendingDestroyEntity.HasValue)
         {
             _world.DestroyEntity(_pendingDestroyEntity.Value);
             _pendingDestroyEntity = null;
         }
-
-        foreach (var op in _pendingWorldOps)
-            op(_world);
-        _pendingWorldOps.Clear();
     }
 
     public void Dispose() => _controller.Dispose();

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -85,7 +85,8 @@ public sealed class ImGuiInspector : IDisposable
         if (!ImGui.Begin("Scene Inspector", ref open))
         {
             ImGui.End();
-            if (!open) _visible = false;
+            if (!open)
+                _visible = false;
             return;
         }
 

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -139,7 +139,7 @@ public sealed class ImGuiInspector : IDisposable
         ImGui.Separator();
 
         if (ImGui.SmallButton("New Entity"))
-            _pendingWorldOps.Add(static w => w.CreateEntity());
+            _pendingWorldOps.Add(w => _selectedEntity = w.CreateEntity());
     }
 
     // ── Component inspector (right column) ───────────────────────────────────

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -153,6 +153,15 @@ public sealed class ImGuiInspector : IDisposable
         }
 
         var entity = _selectedEntity.Value;
+
+        // The game may have destroyed this entity externally between frames
+        if (!_world.Entities.Contains(entity))
+        {
+            _selectedEntity = null;
+            ImGui.TextDisabled("Entity no longer exists.");
+            return;
+        }
+
         var entityLabel = _world.TryGetTag(entity, out var tag)
             ? $"\"{tag}\"  (#{entity.Id})"
             : $"Entity#{entity.Id}";
@@ -373,8 +382,7 @@ public sealed class ImGuiInspector : IDisposable
         {
             foreach (var serializer in _registry.Serializers)
             {
-                // Only show types the entity doesn't already have
-                if (serializer.TrySerialize(_world, entity) == null)
+                if (!EntityHasComponent(entity, serializer))
                     items.Add(serializer.TypeId);
             }
         }

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -31,9 +31,10 @@ public sealed class ImGuiInspector : IDisposable
     private string _saveScenePath = "Scenes/scene.json";
     private string _saveStatusMessage = string.Empty;
 
-    // Deferred commands — mutations run after all ImGui draw calls to avoid iterator invalidation
+    // Deferred commands — mutations run after all ImGui draw calls to avoid iterator invalidation.
+    // A List is used so multiple operations queued in the same frame (e.g. remove + add) all execute.
     private Entity? _pendingDestroyEntity;
-    private Action<World>? _pendingWorldOp;
+    private readonly List<Action<World>> _pendingWorldOps = [];
 
     // TypeIds that can be added with a sensible zero/default value
     private static readonly Dictionary<string, Action<World, Entity>> DefaultAddActions = new()
@@ -123,19 +124,22 @@ public sealed class ImGuiInspector : IDisposable
 
         foreach (var entity in entities)
         {
-            var label = _world.TryGetTag(entity, out var tag)
-                ? $"{tag}  (#{entity.Id})"
+            // Tags are user-provided; strip "##" so ImGui doesn't treat it as an ID separator.
+            // The explicit "##entity_{id}" suffix gives each Selectable a unique stable ID.
+            var display = _world.TryGetTag(entity, out var tag)
+                ? $"{tag.Replace("##", "#-#")}  (#{entity.Id})"
                 : $"Entity#{entity.Id}";
+            var selectableId = $"{display}##entity_{entity.Id}";
 
             var selected = _selectedEntity == entity;
-            if (ImGui.Selectable(label, selected))
+            if (ImGui.Selectable(selectableId, selected))
                 _selectedEntity = entity;
         }
 
         ImGui.Separator();
 
         if (ImGui.SmallButton("New Entity"))
-            _pendingWorldOp = static w => w.CreateEntity();
+            _pendingWorldOps.Add(static w => w.CreateEntity());
     }
 
     // ── Component inspector (right column) ───────────────────────────────────
@@ -343,7 +347,7 @@ public sealed class ImGuiInspector : IDisposable
             if (ImGui.SmallButton($"+##add_{entity.Id}"))
             {
                 var addAction = DefaultAddActions[selectedId];
-                _pendingWorldOp = w => addAction(w, entity);
+                _pendingWorldOps.Add(w => addAction(w, entity));
             }
         }
         else
@@ -390,6 +394,9 @@ public sealed class ImGuiInspector : IDisposable
         {
             try
             {
+                var dir = Path.GetDirectoryName(AssetPath.Resolve(_saveScenePath));
+                if (!string.IsNullOrEmpty(dir))
+                    Directory.CreateDirectory(dir);
                 _sceneSaver!.Save(_world, _saveScenePath);
                 _saveStatusMessage = $"Saved at {DateTime.Now:HH:mm:ss}";
             }
@@ -413,11 +420,11 @@ public sealed class ImGuiInspector : IDisposable
 
     private void ScheduleRemove(Entity entity, Type componentType)
     {
-        _pendingWorldOp = w =>
+        _pendingWorldOps.Add(w =>
         {
             var method = WorldRemoveMethod.MakeGenericMethod(componentType);
             method.Invoke(w, [entity]);
-        };
+        });
     }
 
     private void FlushPendingCommands()
@@ -428,11 +435,9 @@ public sealed class ImGuiInspector : IDisposable
             _pendingDestroyEntity = null;
         }
 
-        if (_pendingWorldOp != null)
-        {
-            _pendingWorldOp(_world);
-            _pendingWorldOp = null;
-        }
+        foreach (var op in _pendingWorldOps)
+            op(_world);
+        _pendingWorldOps.Clear();
     }
 
     public void Dispose() => _controller.Dispose();

--- a/src/Engine/Yaeger/Windowing/Window.cs
+++ b/src/Engine/Yaeger/Windowing/Window.cs
@@ -10,7 +10,10 @@ namespace Yaeger.Windowing;
 public sealed class Window : IDisposable
 {
     private readonly IWindow _innerWindow;
+    private readonly IInputContext _inputContext;
     internal GL Gl { get; }
+    internal IView InnerView => _innerWindow;
+    internal IInputContext InputContext => _inputContext;
 
     /// <summary>
     /// Gets the audio context for this window.
@@ -42,12 +45,12 @@ public sealed class Window : IDisposable
 
         // Initialize keyboard and mouse. Mouse needs the window size to expose NDC coords;
         // seed it now and update on resize.
-        var inputContext = _innerWindow.CreateInput();
-        Keyboard.Initialize(inputContext);
-        Mouse.Initialize(inputContext);
+        _inputContext = _innerWindow.CreateInput();
+        Keyboard.Initialize(_inputContext);
+        Mouse.Initialize(_inputContext);
         Mouse.SetWindowSize(new Vector2(_innerWindow.Size.X, _innerWindow.Size.Y));
         _innerWindow.Resize += size => Mouse.SetWindowSize(new Vector2(size.X, size.Y));
-        // Note: inputContext lifecycle is managed by _innerWindow, which will dispose it
+        // Note: _inputContext lifecycle is managed by _innerWindow, which will dispose it
 
         // Initialize audio - if this fails, we need to clean up resources
         try

--- a/src/Engine/Yaeger/Yaeger.csproj
+++ b/src/Engine/Yaeger/Yaeger.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <PackageReference Include="HarfBuzzSharp" Version="8.3.1.2" />
     <PackageReference Include="Silk.NET" Version="2.22.0" />
+    <PackageReference Include="Silk.NET.OpenGL.Extensions.ImGui" Version="2.22.0" />
     <PackageReference Include="Silk.NET.OpenAL" Version="2.22.0" />
     <PackageReference Include="Silk.NET.OpenAL.Soft.Native" Version="1.23.1" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.1" />

--- a/tests/Yaeger.Tests/ECS/SerializerComponentTypeTests.cs
+++ b/tests/Yaeger.Tests/ECS/SerializerComponentTypeTests.cs
@@ -1,0 +1,49 @@
+using Yaeger.ECS.Serializers;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.ECS;
+
+public class SerializerComponentTypeTests
+{
+    [Fact]
+    public void Transform2DSerializer_ComponentType_ReturnsTransform2DType()
+    {
+        var serializer = new Transform2DSerializer();
+        Assert.Equal(typeof(Transform2D), serializer.ComponentType);
+    }
+
+    [Fact]
+    public void SpriteSerializer_ComponentType_ReturnsSpriteType()
+    {
+        var serializer = new SpriteSerializer();
+        Assert.Equal(typeof(Sprite), serializer.ComponentType);
+    }
+
+    [Fact]
+    public void SpriteSheetSerializer_ComponentType_ReturnsSpriteSheetType()
+    {
+        var serializer = new SpriteSheetSerializer();
+        Assert.Equal(typeof(SpriteSheet), serializer.ComponentType);
+    }
+
+    [Fact]
+    public void AnimationSerializer_ComponentType_ReturnsAnimationType()
+    {
+        var serializer = new AnimationSerializer();
+        Assert.Equal(typeof(Animation), serializer.ComponentType);
+    }
+
+    [Fact]
+    public void AnimationStateSerializer_ComponentType_ReturnsAnimationStateType()
+    {
+        var serializer = new AnimationStateSerializer();
+        Assert.Equal(typeof(AnimationState), serializer.ComponentType);
+    }
+
+    [Fact]
+    public void RenderLayerSerializer_ComponentType_ReturnsRenderLayerType()
+    {
+        var serializer = new RenderLayerSerializer();
+        Assert.Equal(typeof(RenderLayer), serializer.ComponentType);
+    }
+}


### PR DESCRIPTION
Adds an opt-in ImGuiInspector class that lets developers inspect and live-edit
entities in any running Yaeger game without rebuilding.

Engine changes:
- Add Silk.NET.OpenGL.Extensions.ImGui v2.22.0 NuGet dependency
- Store IInputContext in Window and expose it (along with InnerView) as
  internal properties so ImGuiController can be constructed from a Window
- Add F1 to the Keys enum and KeyMapper for the recommended toggle binding
- Add Type? ComponentType default property to IComponentSerializer; override
  it in all six built-in serializers so the inspector can drive generic
  add/remove operations via reflection without needing World-internal access

ImGuiInspector features (Yaeger.Inspector namespace):
- Two-column overlay: entity list (left) / component inspector (right)
- Editable fields for Transform2D (Position, Rotation, Scale),
  Camera2D (Position, Zoom, Rotation), and Sprite (TexturePath)
- Read-only JSON view for all other registered component types via
  IComponentSerializer.TrySerialize
- Add component combo (with sensible defaults for Transform2D, Camera2D,
  AnimationState, RenderLayer; unsupported types shown as disabled)
- Per-component Remove button and Destroy Entity button; mutations are
  deferred to after the ImGui draw pass to avoid iterator invalidation
- Save Scene button writes the current World to a JSON file via SceneSaver;
  pass a ComponentRegistry to enable it

Usage:
  var inspector = new ImGuiInspector(window, world, componentRegistry);
  window.OnRender += delta => { renderSystem.Render(); inspector.Render(delta); };
  Keyboard.AddKeyDown(Keys.F1, inspector.Toggle);

https://claude.ai/code/session_0181xyPJWDgAJR8dyBpf5zHb