### PR TITLE
Add Camera3D component with perspective projection

### DIFF
--- a/src/Engine/Yaeger/Graphics/Camera3D.cs
+++ b/src/Engine/Yaeger/Graphics/Camera3D.cs
@@ -3,9 +3,8 @@ using System.Numerics;
 namespace Yaeger.Graphics;
 
 /// <summary>
-/// 3D perspective camera component. Attach to an entity to make <c>MeshRenderSystem</c> upload
-/// a combined view-projection matrix as <c>uViewProj</c>. When no camera entity exists the
-/// system falls back to its own default. The first camera encountered wins if multiple are present.
+/// 3D perspective camera component. Attach to an entity to provide a view + projection matrix
+/// pair for 3D rendering. The first camera entity encountered wins if multiple are present.
 /// </summary>
 public record struct Camera3D(
     Vector3 Position,
@@ -16,6 +15,9 @@ public record struct Camera3D(
     float Far
 )
 {
+    public Camera3D()
+        : this(new Vector3(0, 2, 5), Vector3.Zero, Vector3.UnitY, MathF.PI / 4, 0.1f, 1000f) { }
+
     public static Camera3D Default =>
         new(new Vector3(0, 2, 5), Vector3.Zero, Vector3.UnitY, MathF.PI / 4, 0.1f, 1000f);
 

--- a/src/Engine/Yaeger/Graphics/Camera3D.cs
+++ b/src/Engine/Yaeger/Graphics/Camera3D.cs
@@ -4,7 +4,7 @@ namespace Yaeger.Graphics;
 
 /// <summary>
 /// 3D perspective camera component. Attach to an entity to provide a view + projection matrix
-/// pair for 3D rendering. The first camera entity encountered wins if multiple are present.
+/// pair for 3D rendering.
 /// </summary>
 public record struct Camera3D(
     Vector3 Position,
@@ -25,8 +25,11 @@ public record struct Camera3D(
     {
         get
         {
-            // Guard against default(Camera3D): Position == Target or zero Up produces NaN.
+            // Guard against default(Camera3D): degenerate inputs produce NaN.
             if (Position == Target || Up == Vector3.Zero)
+                return Matrix4x4.Identity;
+            var forward = Vector3.Normalize(Target - Position);
+            if (MathF.Abs(Vector3.Dot(Vector3.Normalize(Up), forward)) > 1f - 1e-6f)
                 return Matrix4x4.Identity;
             return Matrix4x4.CreateLookAt(Position, Target, Up);
         }
@@ -39,7 +42,8 @@ public record struct Camera3D(
         var fov = Fov > 0f ? Fov : MathF.PI / 4;
         var near = Near > 0f ? Near : 0.1f;
         var far = Far > near ? Far : near + 1000f;
-        return Matrix4x4.CreatePerspectiveFieldOfView(fov, aspectRatio, near, far);
+        var aspect = aspectRatio > 0f && float.IsFinite(aspectRatio) ? aspectRatio : 1f;
+        return Matrix4x4.CreatePerspectiveFieldOfView(fov, aspect, near, far);
     }
 
     public Matrix4x4 ViewProjection(float aspectRatio) =>

--- a/src/Engine/Yaeger/Graphics/Camera3D.cs
+++ b/src/Engine/Yaeger/Graphics/Camera3D.cs
@@ -1,0 +1,29 @@
+using System.Numerics;
+
+namespace Yaeger.Graphics;
+
+/// <summary>
+/// 3D perspective camera component. Attach to an entity to make <c>MeshRenderSystem</c> upload
+/// a combined view-projection matrix as <c>uViewProj</c>. When no camera entity exists the
+/// system falls back to its own default. The first camera encountered wins if multiple are present.
+/// </summary>
+public record struct Camera3D(
+    Vector3 Position,
+    Vector3 Target,
+    Vector3 Up,
+    float Fov,
+    float Near,
+    float Far
+)
+{
+    public static Camera3D Default =>
+        new(new Vector3(0, 2, 5), Vector3.Zero, Vector3.UnitY, MathF.PI / 4, 0.1f, 1000f);
+
+    public Matrix4x4 ViewMatrix => Matrix4x4.CreateLookAt(Position, Target, Up);
+
+    public Matrix4x4 ProjectionMatrix(float aspectRatio) =>
+        Matrix4x4.CreatePerspectiveFieldOfView(Fov, aspectRatio, Near, Far);
+
+    public Matrix4x4 ViewProjection(float aspectRatio) =>
+        ViewMatrix * ProjectionMatrix(aspectRatio);
+}

--- a/src/Engine/Yaeger/Graphics/Camera3D.cs
+++ b/src/Engine/Yaeger/Graphics/Camera3D.cs
@@ -21,10 +21,26 @@ public record struct Camera3D(
     public static Camera3D Default =>
         new(new Vector3(0, 2, 5), Vector3.Zero, Vector3.UnitY, MathF.PI / 4, 0.1f, 1000f);
 
-    public Matrix4x4 ViewMatrix => Matrix4x4.CreateLookAt(Position, Target, Up);
+    public Matrix4x4 ViewMatrix
+    {
+        get
+        {
+            // Guard against default(Camera3D): Position == Target or zero Up produces NaN.
+            if (Position == Target || Up == Vector3.Zero)
+                return Matrix4x4.Identity;
+            return Matrix4x4.CreateLookAt(Position, Target, Up);
+        }
+    }
 
-    public Matrix4x4 ProjectionMatrix(float aspectRatio) =>
-        Matrix4x4.CreatePerspectiveFieldOfView(Fov, aspectRatio, Near, Far);
+    public Matrix4x4 ProjectionMatrix(float aspectRatio)
+    {
+        // Guard against default(Camera3D): zero Fov/Near/Far throw inside
+        // CreatePerspectiveFieldOfView.
+        var fov = Fov > 0f ? Fov : MathF.PI / 4;
+        var near = Near > 0f ? Near : 0.1f;
+        var far = Far > near ? Far : near + 1000f;
+        return Matrix4x4.CreatePerspectiveFieldOfView(fov, aspectRatio, near, far);
+    }
 
     public Matrix4x4 ViewProjection(float aspectRatio) =>
         ViewMatrix * ProjectionMatrix(aspectRatio);

--- a/src/Engine/Yaeger/TypeForwarders.cs
+++ b/src/Engine/Yaeger/TypeForwarders.cs
@@ -29,6 +29,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.AnimationFrame))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.AnimationState))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Camera2D))]
+[assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Camera3D))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Color))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.RenderLayer))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Sprite))]

--- a/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
@@ -1,0 +1,102 @@
+using System.Numerics;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Graphics;
+
+public class Camera3DTests
+{
+    private const float Tolerance = 1e-5f;
+    private const float AspectRatio = 16f / 9f;
+
+    [Fact]
+    public void ParameterlessCtor_ProducesSafeDefaults()
+    {
+        // Arrange / Act
+        var camera = new Camera3D();
+
+        // Assert — FOV and Near must be > 0 for CreatePerspectiveFieldOfView to succeed
+        Assert.True(camera.Fov > 0f);
+        Assert.True(camera.Near > 0f);
+        Assert.True(camera.Far > camera.Near);
+    }
+
+    [Fact]
+    public void ParameterlessCtor_MatchesDefault()
+    {
+        var a = new Camera3D();
+        var b = Camera3D.Default;
+
+        Assert.Equal(b.Position, a.Position);
+        Assert.Equal(b.Target, a.Target);
+        Assert.Equal(b.Up, a.Up);
+        Assert.Equal(b.Fov, a.Fov);
+        Assert.Equal(b.Near, a.Near);
+        Assert.Equal(b.Far, a.Far);
+    }
+
+    [Fact]
+    public void ViewMatrix_TargetOnNegativeZ_LooksDownNegativeZ()
+    {
+        // Camera at origin looking at (0,0,-1): forward is -Z, so the view matrix maps
+        // a point at (0,0,-1) world to (0,0,positive) in view space.
+        var camera = new Camera3D(Vector3.Zero, new Vector3(0, 0, -1), Vector3.UnitY,
+            MathF.PI / 2, 0.1f, 100f);
+
+        var viewPoint = Vector4.Transform(new Vector4(0, 0, -1, 1), camera.ViewMatrix);
+
+        Assert.Equal(0f, viewPoint.X, Tolerance);
+        Assert.Equal(0f, viewPoint.Y, Tolerance);
+        Assert.True(viewPoint.Z > 0f); // in front of camera (OpenGL convention: +Z is behind viewer)
+    }
+
+    [Fact]
+    public void ProjectionMatrix_DoesNotThrow_WithDefaultValues()
+    {
+        var camera = Camera3D.Default;
+        var exception = Record.Exception(() => camera.ProjectionMatrix(AspectRatio));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ViewProjection_ProjectsTargetToNdcOriginXY()
+    {
+        // The camera target, projected through view+projection, should land at NDC (0, 0).
+        var camera = Camera3D.Default;
+        var clip = Vector4.Transform(new Vector4(camera.Target, 1f), camera.ViewProjection(AspectRatio));
+        var ndcX = clip.X / clip.W;
+        var ndcY = clip.Y / clip.W;
+
+        Assert.Equal(0f, ndcX, Tolerance);
+        Assert.Equal(0f, ndcY, Tolerance);
+    }
+
+    [Fact]
+    public void ViewProjection_MatchesManualMultiplication()
+    {
+        // ViewProjection(a) must equal ViewMatrix * ProjectionMatrix(a).
+        var camera = Camera3D.Default;
+        var combined = camera.ViewProjection(AspectRatio);
+        var manual = camera.ViewMatrix * camera.ProjectionMatrix(AspectRatio);
+
+        // Sample a handful of elements to confirm identical computation.
+        Assert.Equal(manual.M11, combined.M11, Tolerance);
+        Assert.Equal(manual.M22, combined.M22, Tolerance);
+        Assert.Equal(manual.M33, combined.M33, Tolerance);
+        Assert.Equal(manual.M44, combined.M44, Tolerance);
+        Assert.Equal(manual.M34, combined.M34, Tolerance);
+        Assert.Equal(manual.M43, combined.M43, Tolerance);
+    }
+
+    [Fact]
+    public void Default_HasExpectedFieldValues()
+    {
+        var camera = Camera3D.Default;
+
+        Assert.Equal(new Vector3(0, 2, 5), camera.Position);
+        Assert.Equal(Vector3.Zero, camera.Target);
+        Assert.Equal(Vector3.UnitY, camera.Up);
+        Assert.Equal(MathF.PI / 4, camera.Fov, Tolerance);
+        Assert.Equal(0.1f, camera.Near, Tolerance);
+        Assert.Equal(1000f, camera.Far, Tolerance);
+    }
+}

--- a/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
@@ -9,6 +9,19 @@ public class Camera3DTests
     private const float AspectRatio = 16f / 9f;
 
     [Fact]
+    public void StructDefault_ViewProjection_IsFinite()
+    {
+        // default(Camera3D) has all-zero fields; the guards must prevent NaN/throws.
+        var camera = default(Camera3D);
+        var m = camera.ViewProjection(AspectRatio);
+
+        Assert.True(float.IsFinite(m.M11));
+        Assert.True(float.IsFinite(m.M22));
+        Assert.True(float.IsFinite(m.M33));
+        Assert.True(float.IsFinite(m.M44));
+    }
+
+    [Fact]
     public void ParameterlessCtor_ProducesSafeDefaults()
     {
         // Arrange / Act
@@ -37,8 +50,8 @@ public class Camera3DTests
     [Fact]
     public void ViewMatrix_TargetOnNegativeZ_LooksDownNegativeZ()
     {
-        // Camera at origin looking at (0,0,-1): forward is -Z, so the view matrix maps
-        // a point at (0,0,-1) world to (0,0,positive) in view space.
+        // Camera at origin looking toward (0,0,-1): in right-handed view space the
+        // target is in front of the camera, so its view-space Z is negative.
         var camera = new Camera3D(
             Vector3.Zero,
             new Vector3(0, 0, -1),

--- a/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
@@ -39,8 +39,14 @@ public class Camera3DTests
     {
         // Camera at origin looking at (0,0,-1): forward is -Z, so the view matrix maps
         // a point at (0,0,-1) world to (0,0,positive) in view space.
-        var camera = new Camera3D(Vector3.Zero, new Vector3(0, 0, -1), Vector3.UnitY,
-            MathF.PI / 2, 0.1f, 100f);
+        var camera = new Camera3D(
+            Vector3.Zero,
+            new Vector3(0, 0, -1),
+            Vector3.UnitY,
+            MathF.PI / 2,
+            0.1f,
+            100f
+        );
 
         var viewPoint = Vector4.Transform(new Vector4(0, 0, -1, 1), camera.ViewMatrix);
 

--- a/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
@@ -52,7 +52,8 @@ public class Camera3DTests
 
         Assert.Equal(0f, viewPoint.X, Tolerance);
         Assert.Equal(0f, viewPoint.Y, Tolerance);
-        Assert.True(viewPoint.Z > 0f); // in front of camera (+Z is behind viewer in OpenGL)
+        // Right-handed: view-space +Z points behind the camera, so forward targets have negative Z.
+        Assert.True(viewPoint.Z < 0f);
     }
 
     [Fact]

--- a/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Camera3DTests.cs
@@ -52,7 +52,7 @@ public class Camera3DTests
 
         Assert.Equal(0f, viewPoint.X, Tolerance);
         Assert.Equal(0f, viewPoint.Y, Tolerance);
-        Assert.True(viewPoint.Z > 0f); // in front of camera (OpenGL convention: +Z is behind viewer)
+        Assert.True(viewPoint.Z > 0f); // in front of camera (+Z is behind viewer in OpenGL)
     }
 
     [Fact]
@@ -68,7 +68,10 @@ public class Camera3DTests
     {
         // The camera target, projected through view+projection, should land at NDC (0, 0).
         var camera = Camera3D.Default;
-        var clip = Vector4.Transform(new Vector4(camera.Target, 1f), camera.ViewProjection(AspectRatio));
+        var clip = Vector4.Transform(
+            new Vector4(camera.Target, 1f),
+            camera.ViewProjection(AspectRatio)
+        );
         var ndcX = clip.X / clip.W;
         var ndcY = clip.Y / clip.W;
 


### PR DESCRIPTION
Implements issue #73. Adds a `Camera3D` record struct to
`src/Engine/Yaeger/Graphics/` with Position, Target, Up, Fov, Near,
and Far fields plus ViewMatrix, ProjectionMatrix, ViewProjection
computed properties and a Default factory property.

https://claude.ai/code/session_01SSD1puzczcrjKjnkZkkpaH