### PR TITLE
Add Vertex3D, MeshData, and GpuMesh for 3D mesh rendering

### DIFF
--- a/src/Engine/Yaeger/Rendering/GpuMesh.cs
+++ b/src/Engine/Yaeger/Rendering/GpuMesh.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Silk.NET.OpenGL;
 
 namespace Yaeger.Rendering;
@@ -10,14 +11,6 @@ public sealed class GpuMesh : IDisposable
     private readonly Buffer<uint> _ebo;
     private readonly uint _indexCount;
 
-    // Vertex layout: Position (3f) | Normal (3f) | TexCoord (2f)
-    private const uint VertexSize = 8;
-    private const int PositionCount = 3;
-    private const int NormalCount = 3;
-    private const int TexCoordCount = 2;
-    private const int NormalOffset = PositionCount;
-    private const int TexCoordOffset = PositionCount + NormalCount;
-
     public unsafe GpuMesh(GL gl, MeshData data)
     {
         _gl = gl;
@@ -27,29 +20,30 @@ public sealed class GpuMesh : IDisposable
         _gl.BindVertexArray(_vao);
 
         _vbo = new Buffer<Vertex3D>(gl, data.Vertices, BufferTargetARB.ArrayBuffer);
+        _vbo.Bind();
         _ebo = new Buffer<uint>(gl, data.Indices, BufferTargetARB.ElementArrayBuffer);
+        _ebo.Bind();
 
-        VertexAttributeFloatPointer(0, PositionCount, VertexSize, 0);
-        VertexAttributeFloatPointer(1, NormalCount, VertexSize, NormalOffset);
-        VertexAttributeFloatPointer(2, TexCoordCount, VertexSize, TexCoordOffset);
+        var stride = (uint)sizeof(Vertex3D);
+        SetupAttrib(0, 3, stride, OffsetOf(nameof(Vertex3D.Position)));
+        SetupAttrib(1, 3, stride, OffsetOf(nameof(Vertex3D.Normal)));
+        SetupAttrib(2, 2, stride, OffsetOf(nameof(Vertex3D.TexCoord)));
 
         _gl.BindVertexArray(0);
     }
 
-    private unsafe void VertexAttributeFloatPointer(
-        uint index,
-        int count,
-        uint vertexSize,
-        int offset
-    )
+    private static uint OffsetOf(string fieldName) =>
+        (uint)(nint)Marshal.OffsetOf<Vertex3D>(fieldName);
+
+    private unsafe void SetupAttrib(uint index, int count, uint stride, uint offset)
     {
         _gl.VertexAttribPointer(
             index,
             count,
             VertexAttribPointerType.Float,
             false,
-            vertexSize * sizeof(float),
-            (void*)(offset * sizeof(float))
+            stride,
+            (void*)offset
         );
         _gl.EnableVertexAttribArray(index);
     }
@@ -63,12 +57,13 @@ public sealed class GpuMesh : IDisposable
             DrawElementsType.UnsignedInt,
             (void*)0
         );
+        _gl.BindVertexArray(0);
     }
 
     public void Dispose()
     {
+        _gl.DeleteVertexArray(_vao);
         _vbo.Dispose();
         _ebo.Dispose();
-        _gl.DeleteVertexArray(_vao);
     }
 }

--- a/src/Engine/Yaeger/Rendering/GpuMesh.cs
+++ b/src/Engine/Yaeger/Rendering/GpuMesh.cs
@@ -1,0 +1,74 @@
+using Silk.NET.OpenGL;
+
+namespace Yaeger.Rendering;
+
+public sealed class GpuMesh : IDisposable
+{
+    private readonly GL _gl;
+    private readonly uint _vao;
+    private readonly Buffer<Vertex3D> _vbo;
+    private readonly Buffer<uint> _ebo;
+    private readonly uint _indexCount;
+
+    // Vertex layout: Position (3f) | Normal (3f) | TexCoord (2f)
+    private const uint VertexSize = 8;
+    private const int PositionCount = 3;
+    private const int NormalCount = 3;
+    private const int TexCoordCount = 2;
+    private const int NormalOffset = PositionCount;
+    private const int TexCoordOffset = PositionCount + NormalCount;
+
+    public unsafe GpuMesh(GL gl, MeshData data)
+    {
+        _gl = gl;
+        _indexCount = (uint)data.Indices.Length;
+
+        _vao = _gl.GenVertexArray();
+        _gl.BindVertexArray(_vao);
+
+        _vbo = new Buffer<Vertex3D>(gl, data.Vertices, BufferTargetARB.ArrayBuffer);
+        _ebo = new Buffer<uint>(gl, data.Indices, BufferTargetARB.ElementArrayBuffer);
+
+        VertexAttributeFloatPointer(0, PositionCount, VertexSize, 0);
+        VertexAttributeFloatPointer(1, NormalCount, VertexSize, NormalOffset);
+        VertexAttributeFloatPointer(2, TexCoordCount, VertexSize, TexCoordOffset);
+
+        _gl.BindVertexArray(0);
+    }
+
+    private unsafe void VertexAttributeFloatPointer(
+        uint index,
+        int count,
+        uint vertexSize,
+        int offset
+    )
+    {
+        _gl.VertexAttribPointer(
+            index,
+            count,
+            VertexAttribPointerType.Float,
+            false,
+            vertexSize * sizeof(float),
+            (void*)(offset * sizeof(float))
+        );
+        _gl.EnableVertexAttribArray(index);
+    }
+
+    public unsafe void Draw()
+    {
+        _gl.BindVertexArray(_vao);
+        _gl.DrawElements(
+            PrimitiveType.Triangles,
+            _indexCount,
+            DrawElementsType.UnsignedInt,
+            (void*)0
+        );
+    }
+
+    public void Dispose()
+    {
+        _vbo.Dispose();
+        _ebo.Dispose();
+        _gl.DeleteVertexArray(_vao);
+    }
+}

--- a/src/Engine/Yaeger/Rendering/MeshData.cs
+++ b/src/Engine/Yaeger/Rendering/MeshData.cs
@@ -1,0 +1,3 @@
+namespace Yaeger.Rendering;
+
+public record MeshData(string Name, Vertex3D[] Vertices, uint[] Indices);

--- a/src/Engine/Yaeger/Rendering/Vertex3D.cs
+++ b/src/Engine/Yaeger/Rendering/Vertex3D.cs
@@ -1,0 +1,10 @@
+using System.Numerics;
+
+namespace Yaeger.Rendering;
+
+public struct Vertex3D
+{
+    public Vector3 Position;
+    public Vector3 Normal;
+    public Vector2 TexCoord;
+}

--- a/src/Engine/Yaeger/Rendering/Vertex3D.cs
+++ b/src/Engine/Yaeger/Rendering/Vertex3D.cs
@@ -2,9 +2,16 @@ using System.Numerics;
 
 namespace Yaeger.Rendering;
 
-public struct Vertex3D
+public readonly struct Vertex3D
 {
-    public Vector3 Position;
-    public Vector3 Normal;
-    public Vector2 TexCoord;
+    public readonly Vector3 Position;
+    public readonly Vector3 Normal;
+    public readonly Vector2 TexCoord;
+
+    public Vertex3D(Vector3 position, Vector3 normal, Vector2 texCoord)
+    {
+        Position = position;
+        Normal = normal;
+        TexCoord = texCoord;
+    }
 }

--- a/tests/Yaeger.Tests/Rendering/MeshDataTests.cs
+++ b/tests/Yaeger.Tests/Rendering/MeshDataTests.cs
@@ -9,7 +9,7 @@ public class MeshDataTests
     public void Constructor_SetsAllProperties()
     {
         var vertices = new[] { new Vertex3D(Vector3.UnitX, Vector3.UnitY, Vector2.Zero) };
-        var indices = new uint[] { 0, 1, 2 };
+        var indices = new uint[] { 0 };
 
         var mesh = new MeshData("cube", vertices, indices);
 

--- a/tests/Yaeger.Tests/Rendering/MeshDataTests.cs
+++ b/tests/Yaeger.Tests/Rendering/MeshDataTests.cs
@@ -1,0 +1,57 @@
+using System.Numerics;
+using Yaeger.Rendering;
+
+namespace Yaeger.Tests.Rendering;
+
+public class MeshDataTests
+{
+    [Fact]
+    public void Constructor_SetsAllProperties()
+    {
+        var vertices = new[] { new Vertex3D { Position = Vector3.UnitX } };
+        var indices = new uint[] { 0, 1, 2 };
+
+        var mesh = new MeshData("cube", vertices, indices);
+
+        Assert.Equal("cube", mesh.Name);
+        Assert.Same(vertices, mesh.Vertices);
+        Assert.Same(indices, mesh.Indices);
+    }
+
+    [Fact]
+    public void RecordEquality_SameReferences_AreEqual()
+    {
+        var vertices = new[] { new Vertex3D { Position = Vector3.Zero } };
+        var indices = new uint[] { 0 };
+
+        var a = new MeshData("mesh", vertices, indices);
+        var b = new MeshData("mesh", vertices, indices);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void RecordEquality_DifferentArrayInstances_AreNotEqual()
+    {
+        // Arrays do not override Equals, so different instances are not equal
+        // even when the contents match.
+        var a = new MeshData("mesh", Array.Empty<Vertex3D>(), new uint[] { 0 });
+        var b = new MeshData("mesh", Array.Empty<Vertex3D>(), new uint[] { 0 });
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void With_ProducesUpdatedRecord()
+    {
+        var vertices = new Vertex3D[3];
+        var indices = new uint[] { 0, 1, 2 };
+        var original = new MeshData("original", vertices, indices);
+
+        var renamed = original with { Name = "renamed" };
+
+        Assert.Equal("renamed", renamed.Name);
+        Assert.Same(vertices, renamed.Vertices);
+        Assert.Same(indices, renamed.Indices);
+    }
+}

--- a/tests/Yaeger.Tests/Rendering/MeshDataTests.cs
+++ b/tests/Yaeger.Tests/Rendering/MeshDataTests.cs
@@ -8,7 +8,7 @@ public class MeshDataTests
     [Fact]
     public void Constructor_SetsAllProperties()
     {
-        var vertices = new[] { new Vertex3D { Position = Vector3.UnitX } };
+        var vertices = new[] { new Vertex3D(Vector3.UnitX, Vector3.UnitY, Vector2.Zero) };
         var indices = new uint[] { 0, 1, 2 };
 
         var mesh = new MeshData("cube", vertices, indices);
@@ -21,7 +21,7 @@ public class MeshDataTests
     [Fact]
     public void RecordEquality_SameReferences_AreEqual()
     {
-        var vertices = new[] { new Vertex3D { Position = Vector3.Zero } };
+        var vertices = new[] { new Vertex3D(Vector3.Zero, Vector3.Zero, Vector2.Zero) };
         var indices = new uint[] { 0 };
 
         var a = new MeshData("mesh", vertices, indices);
@@ -35,8 +35,8 @@ public class MeshDataTests
     {
         // Arrays do not override Equals, so different instances are not equal
         // even when the contents match.
-        var a = new MeshData("mesh", Array.Empty<Vertex3D>(), new uint[] { 0 });
-        var b = new MeshData("mesh", Array.Empty<Vertex3D>(), new uint[] { 0 });
+        var a = new MeshData("mesh", new Vertex3D[0], new uint[] { 0 });
+        var b = new MeshData("mesh", new Vertex3D[0], new uint[] { 0 });
 
         Assert.NotEqual(a, b);
     }

--- a/tests/Yaeger.Tests/Rendering/Vertex3DTests.cs
+++ b/tests/Yaeger.Tests/Rendering/Vertex3DTests.cs
@@ -1,0 +1,36 @@
+using System.Numerics;
+using Yaeger.Rendering;
+
+namespace Yaeger.Tests.Rendering;
+
+public class Vertex3DTests
+{
+    [Fact]
+    public void ObjectInitializer_SetsAllFields()
+    {
+        var position = new Vector3(1f, 2f, 3f);
+        var normal = new Vector3(0f, 1f, 0f);
+        var texCoord = new Vector2(0.5f, 0.25f);
+
+        var vertex = new Vertex3D
+        {
+            Position = position,
+            Normal = normal,
+            TexCoord = texCoord,
+        };
+
+        Assert.Equal(position, vertex.Position);
+        Assert.Equal(normal, vertex.Normal);
+        Assert.Equal(texCoord, vertex.TexCoord);
+    }
+
+    [Fact]
+    public void Default_HasZeroValues()
+    {
+        var vertex = default(Vertex3D);
+
+        Assert.Equal(Vector3.Zero, vertex.Position);
+        Assert.Equal(Vector3.Zero, vertex.Normal);
+        Assert.Equal(Vector2.Zero, vertex.TexCoord);
+    }
+}

--- a/tests/Yaeger.Tests/Rendering/Vertex3DTests.cs
+++ b/tests/Yaeger.Tests/Rendering/Vertex3DTests.cs
@@ -6,18 +6,13 @@ namespace Yaeger.Tests.Rendering;
 public class Vertex3DTests
 {
     [Fact]
-    public void ObjectInitializer_SetsAllFields()
+    public void Constructor_SetsAllFields()
     {
         var position = new Vector3(1f, 2f, 3f);
         var normal = new Vector3(0f, 1f, 0f);
         var texCoord = new Vector2(0.5f, 0.25f);
 
-        var vertex = new Vertex3D
-        {
-            Position = position,
-            Normal = normal,
-            TexCoord = texCoord,
-        };
+        var vertex = new Vertex3D(position, normal, texCoord);
 
         Assert.Equal(position, vertex.Position);
         Assert.Equal(normal, vertex.Normal);


### PR DESCRIPTION
Implements the three types required for arbitrary 3D geometry as part
of the 3D rendering milestone (issue #74):

- Vertex3D: unmanaged struct with Position/Normal/TexCoord fields for
  direct VBO upload via Buffer<T>.
- MeshData: CPU-side record holding Name, Vertex3D[] and uint[] indices;
  produced by the OBJ loader and consumed once to create a GpuMesh.
- GpuMesh: manages VAO/VBO/EBO lifecycle, configures attrib layout
  (loc 0 position, 1 normal, 2 texcoord), exposes Draw() via
  glDrawElements, and implements IDisposable.

Tests cover Vertex3D field initialisation and MeshData record semantics.

Closes #74