### PR TITLE
Add OBJ/MTL file loader (closes #75)

### DIFF
--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Globalization;
 using Yaeger.Graphics;
 
@@ -5,7 +6,7 @@ namespace Yaeger.Assets;
 
 public static class MtlLoader
 {
-    public static Dictionary<string, MtlMaterial> Load(string path)
+    public static IReadOnlyDictionary<string, MtlMaterial> Load(string path)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path, nameof(path));
 
@@ -49,9 +50,9 @@ public static class MtlLoader
             if (line.Length == 0)
                 continue;
 
-            var spaceIdx = line.IndexOf(' ');
-            var keyword = spaceIdx < 0 ? line : line[..spaceIdx];
-            var rest = spaceIdx < 0 ? "" : line[(spaceIdx + 1)..].TrimStart();
+            var wsIdx = line.IndexOfAny(s_whitespace);
+            var keyword = wsIdx < 0 ? line : line[..wsIdx];
+            var rest = wsIdx < 0 ? "" : line[(wsIdx + 1)..].TrimStart();
 
             switch (keyword)
             {
@@ -83,12 +84,14 @@ public static class MtlLoader
         }
 
         Flush();
-        return materials;
+        return new ReadOnlyDictionary<string, MtlMaterial>(materials);
     }
+
+    private static readonly char[] s_whitespace = [' ', '\t'];
 
     private static Color ParseColor(string value)
     {
-        var parts = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var parts = value.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
         return new Color(
             ToChannel(float.Parse(parts[0], CultureInfo.InvariantCulture)),
             ToChannel(float.Parse(parts[1], CultureInfo.InvariantCulture)),

--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -7,6 +7,8 @@ public static class MtlLoader
 {
     public static Dictionary<string, MtlMaterial> Load(string path)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path, nameof(path));
+
         var resolved = AssetPath.Resolve(path);
 
         if (!File.Exists(resolved))
@@ -39,6 +41,12 @@ public static class MtlLoader
         {
             var line = rawLine.Trim();
             if (line.Length == 0 || line[0] == '#')
+                continue;
+
+            var commentIdx = line.IndexOf('#');
+            if (commentIdx >= 0)
+                line = line[..commentIdx].TrimEnd();
+            if (line.Length == 0)
                 continue;
 
             var spaceIdx = line.IndexOf(' ');

--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -7,6 +7,11 @@ public static class MtlLoader
 {
     public static Dictionary<string, MtlMaterial> Load(string path)
     {
+        var resolved = AssetPath.Resolve(path);
+
+        if (!File.Exists(resolved))
+            throw new FileNotFoundException($"MTL file not found: {path}", resolved);
+
         var materials = new Dictionary<string, MtlMaterial>();
 
         string? currentName = null;
@@ -30,7 +35,7 @@ public static class MtlLoader
             );
         }
 
-        foreach (var rawLine in File.ReadLines(path))
+        foreach (var rawLine in File.ReadLines(resolved))
         {
             var line = rawLine.TrimEnd();
             if (line.Length == 0 || line[0] == '#')

--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -58,6 +58,10 @@ public static class MtlLoader
             {
                 case "newmtl":
                     Flush();
+                    if (rest.Length == 0)
+                        throw new FormatException(
+                            "MTL 'newmtl' directive requires a non-empty material name."
+                        );
                     currentName = rest;
                     diffuseTexturePath = null;
                     ambientColor = Color.Black;

--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -70,18 +70,38 @@ public static class MtlLoader
                     shininess = 0f;
                     break;
                 case "Ka":
+                    if (currentName is null)
+                        throw new FormatException(
+                            "MTL 'Ka' directive appears before any 'newmtl'."
+                        );
                     ambientColor = ParseColor(rest);
                     break;
                 case "Kd":
+                    if (currentName is null)
+                        throw new FormatException(
+                            "MTL 'Kd' directive appears before any 'newmtl'."
+                        );
                     diffuseColor = ParseColor(rest);
                     break;
                 case "Ks":
+                    if (currentName is null)
+                        throw new FormatException(
+                            "MTL 'Ks' directive appears before any 'newmtl'."
+                        );
                     specularColor = ParseColor(rest);
                     break;
                 case "Ns":
+                    if (currentName is null)
+                        throw new FormatException(
+                            "MTL 'Ns' directive appears before any 'newmtl'."
+                        );
                     shininess = float.Parse(rest, CultureInfo.InvariantCulture);
                     break;
                 case "map_Kd":
+                    if (currentName is null)
+                        throw new FormatException(
+                            "MTL 'map_Kd' directive appears before any 'newmtl'."
+                        );
                     diffuseTexturePath = rest;
                     break;
             }

--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -1,0 +1,84 @@
+using System.Globalization;
+using Yaeger.Graphics;
+
+namespace Yaeger.Assets;
+
+public static class MtlLoader
+{
+    public static Dictionary<string, MtlMaterial> Load(string path)
+    {
+        var materials = new Dictionary<string, MtlMaterial>();
+
+        string? currentName = null;
+        string? diffuseTexturePath = null;
+        Color ambientColor = Color.Black;
+        Color diffuseColor = Color.White;
+        Color specularColor = Color.Black;
+        float shininess = 0f;
+
+        void Flush()
+        {
+            if (currentName is null)
+                return;
+            materials[currentName] = new MtlMaterial(
+                currentName,
+                diffuseTexturePath,
+                ambientColor,
+                diffuseColor,
+                specularColor,
+                shininess
+            );
+        }
+
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.TrimEnd();
+            if (line.Length == 0 || line[0] == '#')
+                continue;
+
+            var spaceIdx = line.IndexOf(' ');
+            var keyword = spaceIdx < 0 ? line : line[..spaceIdx];
+            var rest = spaceIdx < 0 ? "" : line[(spaceIdx + 1)..].TrimStart();
+
+            switch (keyword)
+            {
+                case "newmtl":
+                    Flush();
+                    currentName = rest;
+                    diffuseTexturePath = null;
+                    ambientColor = Color.Black;
+                    diffuseColor = Color.White;
+                    specularColor = Color.Black;
+                    shininess = 0f;
+                    break;
+                case "Ka":
+                    ambientColor = ParseColor(rest);
+                    break;
+                case "Kd":
+                    diffuseColor = ParseColor(rest);
+                    break;
+                case "Ks":
+                    specularColor = ParseColor(rest);
+                    break;
+                case "Ns":
+                    shininess = float.Parse(rest, CultureInfo.InvariantCulture);
+                    break;
+                case "map_Kd":
+                    diffuseTexturePath = rest;
+                    break;
+            }
+        }
+
+        Flush();
+        return materials;
+    }
+
+    private static Color ParseColor(string value)
+    {
+        var parts = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var r = (byte)(float.Parse(parts[0], CultureInfo.InvariantCulture) * 255f);
+        var g = (byte)(float.Parse(parts[1], CultureInfo.InvariantCulture) * 255f);
+        var b = (byte)(float.Parse(parts[2], CultureInfo.InvariantCulture) * 255f);
+        return new Color(r, g, b);
+    }
+}

--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -37,7 +37,7 @@ public static class MtlLoader
 
         foreach (var rawLine in File.ReadLines(resolved))
         {
-            var line = rawLine.TrimEnd();
+            var line = rawLine.Trim();
             if (line.Length == 0 || line[0] == '#')
                 continue;
 
@@ -81,9 +81,12 @@ public static class MtlLoader
     private static Color ParseColor(string value)
     {
         var parts = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        var r = (byte)(float.Parse(parts[0], CultureInfo.InvariantCulture) * 255f);
-        var g = (byte)(float.Parse(parts[1], CultureInfo.InvariantCulture) * 255f);
-        var b = (byte)(float.Parse(parts[2], CultureInfo.InvariantCulture) * 255f);
-        return new Color(r, g, b);
+        return new Color(
+            ToChannel(float.Parse(parts[0], CultureInfo.InvariantCulture)),
+            ToChannel(float.Parse(parts[1], CultureInfo.InvariantCulture)),
+            ToChannel(float.Parse(parts[2], CultureInfo.InvariantCulture))
+        );
     }
+
+    private static byte ToChannel(float f) => (byte)Math.Clamp((int)(f * 255f), 0, 255);
 }

--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -92,6 +92,8 @@ public static class MtlLoader
     private static Color ParseColor(string value)
     {
         var parts = value.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 3)
+            throw new FormatException($"MTL color requires 3 components; got {parts.Length}.");
         return new Color(
             ToChannel(float.Parse(parts[0], CultureInfo.InvariantCulture)),
             ToChannel(float.Parse(parts[1], CultureInfo.InvariantCulture)),

--- a/src/Engine/Yaeger/Assets/MtlMaterial.cs
+++ b/src/Engine/Yaeger/Assets/MtlMaterial.cs
@@ -1,0 +1,12 @@
+using Yaeger.Graphics;
+
+namespace Yaeger.Assets;
+
+public record MtlMaterial(
+    string Name,
+    string? DiffuseTexturePath,
+    Color AmbientColor,
+    Color DiffuseColor,
+    Color SpecularColor,
+    float Shininess
+);

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -6,19 +6,30 @@ namespace Yaeger.Assets;
 
 public static class ObjLoader
 {
-    public static IReadOnlyList<ObjMesh> Load(string objPath, string? mtlBasePath = null)
+    public static ObjScene Load(string objPath, string? mtlBasePath = null)
     {
+        var resolved = AssetPath.Resolve(objPath);
+
+        if (!File.Exists(resolved))
+            throw new FileNotFoundException($"OBJ file not found: {objPath}", resolved);
+
         var positions = new List<Vector3>();
         var normals = new List<Vector3>();
         var texCoords = new List<Vector2>();
 
         var meshes = new List<ObjMesh>();
+        var materials = new Dictionary<string, MtlMaterial>();
 
         string currentName = "default";
         string currentMaterial = "";
         var currentVertices = new List<Vertex3D>();
         var currentIndices = new List<uint>();
         var vertexCache = new Dictionary<(int posIdx, int texIdx, int normIdx), uint>();
+
+        string mtlDir =
+            mtlBasePath
+            ?? Path.GetDirectoryName(resolved)
+            ?? AppContext.BaseDirectory;
 
         void FlushGroup()
         {
@@ -35,7 +46,7 @@ public static class ObjLoader
             vertexCache.Clear();
         }
 
-        foreach (var rawLine in File.ReadLines(objPath))
+        foreach (var rawLine in File.ReadLines(resolved))
         {
             var line = rawLine.TrimEnd();
             if (line.Length == 0 || line[0] == '#')
@@ -88,11 +99,19 @@ public static class ObjLoader
                     currentName = rest;
                     break;
                 case "usemtl":
+                    FlushGroup();
                     currentMaterial = rest;
                     break;
                 case "mtllib":
-                    // Directive is recognized; callers use MtlLoader.Load() to retrieve material data.
+                {
+                    var mtlPath = Path.Combine(mtlDir, rest);
+                    if (File.Exists(mtlPath))
+                    {
+                        foreach (var (name, mat) in MtlLoader.Load(mtlPath))
+                            materials[name] = mat;
+                    }
                     break;
+                }
                 case "f":
                 {
                     var tokens = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
@@ -125,7 +144,7 @@ public static class ObjLoader
         }
 
         FlushGroup();
-        return meshes.AsReadOnly();
+        return new ObjScene(meshes.AsReadOnly(), materials);
     }
 
     private static (int posIdx, int texIdx, int normIdx) ParseFaceVertex(string token)

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -24,7 +24,11 @@ public static class ObjLoader
         {
             if (currentIndices.Count == 0)
                 return;
-            var meshData = new MeshData(currentName, currentVertices.ToArray(), currentIndices.ToArray());
+            var meshData = new MeshData(
+                currentName,
+                currentVertices.ToArray(),
+                currentIndices.ToArray()
+            );
             meshes.Add(new ObjMesh(currentName, meshData, currentMaterial));
             currentVertices.Clear();
             currentIndices.Clear();

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -26,10 +26,7 @@ public static class ObjLoader
         var currentIndices = new List<uint>();
         var vertexCache = new Dictionary<(int posIdx, int texIdx, int normIdx), uint>();
 
-        string mtlDir =
-            mtlBasePath
-            ?? Path.GetDirectoryName(resolved)
-            ?? AppContext.BaseDirectory;
+        string mtlDir = mtlBasePath ?? Path.GetDirectoryName(resolved) ?? AppContext.BaseDirectory;
 
         void FlushGroup()
         {

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Numerics;
 using Yaeger.Rendering;
@@ -6,7 +7,10 @@ namespace Yaeger.Assets;
 
 public static class ObjLoader
 {
-    public static ObjScene Load(string objPath, string? mtlBasePath = null)
+    public static IReadOnlyList<ObjMesh> Load(string objPath, string? mtlBasePath = null) =>
+        LoadScene(objPath, mtlBasePath).Meshes;
+
+    public static ObjScene LoadScene(string objPath, string? mtlBasePath = null)
     {
         var resolved = AssetPath.Resolve(objPath);
 
@@ -45,7 +49,7 @@ public static class ObjLoader
 
         foreach (var rawLine in File.ReadLines(resolved))
         {
-            var line = rawLine.TrimEnd();
+            var line = rawLine.Trim();
             if (line.Length == 0 || line[0] == '#')
                 continue;
 
@@ -141,7 +145,10 @@ public static class ObjLoader
         }
 
         FlushGroup();
-        return new ObjScene(meshes.AsReadOnly(), materials);
+        return new ObjScene(
+            meshes.AsReadOnly(),
+            new ReadOnlyDictionary<string, MtlMaterial>(materials)
+        );
     }
 
     private static (int posIdx, int texIdx, int normIdx) ParseFaceVertex(string token)

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -34,10 +34,9 @@ public static class ObjLoader
         var currentIndices = new List<uint>();
         var vertexCache = new Dictionary<(int posIdx, int texIdx, int normIdx), uint>();
 
-        string mtlDir =
-            mtlBasePath is not null
-                ? AssetPath.Resolve(mtlBasePath)
-                : Path.GetDirectoryName(resolved) ?? AppContext.BaseDirectory;
+        string mtlDir = mtlBasePath is not null
+            ? AssetPath.Resolve(mtlBasePath)
+            : Path.GetDirectoryName(resolved) ?? AppContext.BaseDirectory;
 
         void FlushGroup()
         {

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -29,7 +29,7 @@ public static class ObjLoader
         var materials = new Dictionary<string, MtlMaterial>();
 
         string currentName = "default";
-        string? currentMaterial = null;
+        string currentMaterial = "";
         var currentVertices = new List<Vertex3D>();
         var currentIndices = new List<uint>();
         var vertexCache = new Dictionary<(int posIdx, int texIdx, int normIdx), uint>();
@@ -65,15 +65,15 @@ public static class ObjLoader
             if (line.Length == 0)
                 continue;
 
-            var spaceIdx = line.IndexOf(' ');
-            var keyword = spaceIdx < 0 ? line : line[..spaceIdx];
-            var rest = spaceIdx < 0 ? "" : line[(spaceIdx + 1)..].TrimStart();
+            var wsIdx = line.IndexOfAny(s_whitespace);
+            var keyword = wsIdx < 0 ? line : line[..wsIdx];
+            var rest = wsIdx < 0 ? "" : line[(wsIdx + 1)..].TrimStart();
 
             switch (keyword)
             {
                 case "v":
                 {
-                    var p = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    var p = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
                     positions.Add(
                         new Vector3(
                             float.Parse(p[0], CultureInfo.InvariantCulture),
@@ -85,7 +85,7 @@ public static class ObjLoader
                 }
                 case "vn":
                 {
-                    var p = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    var p = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
                     normals.Add(
                         new Vector3(
                             float.Parse(p[0], CultureInfo.InvariantCulture),
@@ -97,7 +97,7 @@ public static class ObjLoader
                 }
                 case "vt":
                 {
-                    var p = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    var p = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
                     texCoords.Add(
                         new Vector2(
                             float.Parse(p[0], CultureInfo.InvariantCulture),
@@ -127,7 +127,7 @@ public static class ObjLoader
                 }
                 case "f":
                 {
-                    var tokens = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    var tokens = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
                     var faceVerts = new uint[tokens.Length];
                     for (var i = 0; i < tokens.Length; i++)
                     {
@@ -168,6 +168,8 @@ public static class ObjLoader
         );
     }
 
+    private static readonly char[] s_whitespace = [' ', '\t'];
+
     private static (int posIdx, int texIdx, int normIdx) ParseFaceVertex(
         string token,
         int posCount,
@@ -188,6 +190,15 @@ public static class ObjLoader
         return (posIdx, texIdx, normIdx);
     }
 
-    private static int Resolve(int oneBasedOrNegative, int poolCount) =>
-        oneBasedOrNegative > 0 ? oneBasedOrNegative - 1 : poolCount + oneBasedOrNegative;
+    private static int Resolve(int raw, int poolCount)
+    {
+        if (raw == 0)
+            throw new FormatException("OBJ index 0 is invalid; indices are 1-based.");
+        var idx = raw > 0 ? raw - 1 : poolCount + raw;
+        if (idx < 0 || idx >= poolCount)
+            throw new FormatException(
+                $"OBJ index {raw} is out of range for pool of size {poolCount}."
+            );
+        return idx;
+    }
 }

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -131,11 +131,11 @@ public static class ObjLoader
                 {
                     var filenames = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
                     var mtlDirFull = Path.GetFullPath(mtlDir);
-                    var safePrefix = mtlDirFull + Path.DirectorySeparatorChar;
                     foreach (var filename in filenames)
                     {
                         var mtlPath = Path.GetFullPath(Path.Combine(mtlDirFull, filename));
-                        if (!mtlPath.StartsWith(safePrefix, StringComparison.Ordinal))
+                        var relative = Path.GetRelativePath(mtlDirFull, mtlPath);
+                        if (Path.IsPathRooted(relative) || relative.StartsWith("..", StringComparison.Ordinal))
                             throw new InvalidOperationException(
                                 $"MTL filename '{filename}' resolves outside the MTL directory."
                             );

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -74,6 +74,10 @@ public static class ObjLoader
                 case "v":
                 {
                     var p = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
+                    if (p.Length < 3)
+                        throw new FormatException(
+                            $"OBJ 'v' requires 3 components; got {p.Length}."
+                        );
                     positions.Add(
                         new Vector3(
                             float.Parse(p[0], CultureInfo.InvariantCulture),
@@ -86,6 +90,10 @@ public static class ObjLoader
                 case "vn":
                 {
                     var p = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
+                    if (p.Length < 3)
+                        throw new FormatException(
+                            $"OBJ 'vn' requires 3 components; got {p.Length}."
+                        );
                     normals.Add(
                         new Vector3(
                             float.Parse(p[0], CultureInfo.InvariantCulture),
@@ -98,6 +106,10 @@ public static class ObjLoader
                 case "vt":
                 {
                     var p = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
+                    if (p.Length < 2)
+                        throw new FormatException(
+                            $"OBJ 'vt' requires at least 2 components; got {p.Length}."
+                        );
                     texCoords.Add(
                         new Vector2(
                             float.Parse(p[0], CultureInfo.InvariantCulture),
@@ -128,6 +140,10 @@ public static class ObjLoader
                 case "f":
                 {
                     var tokens = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
+                    if (tokens.Length < 3)
+                        throw new FormatException(
+                            $"OBJ face 'f' requires at least 3 vertices; got {tokens.Length}."
+                        );
                     var faceVerts = new uint[tokens.Length];
                     for (var i = 0; i < tokens.Length; i++)
                     {
@@ -178,6 +194,10 @@ public static class ObjLoader
     )
     {
         var parts = token.Split('/');
+        if (parts.Length > 3)
+            throw new FormatException(
+                $"OBJ face vertex '{token}' has {parts.Length} components; expected v, v/vt, or v/vt/vn."
+            );
         var posIdx = Resolve(int.Parse(parts[0], CultureInfo.InvariantCulture), posCount);
         var texIdx =
             parts.Length > 1 && parts[1].Length > 0

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -132,12 +132,14 @@ public static class ObjLoader
     {
         var parts = token.Split('/');
         var posIdx = int.Parse(parts[0], CultureInfo.InvariantCulture) - 1;
-        var texIdx = parts.Length > 1 && parts[1].Length > 0
-            ? int.Parse(parts[1], CultureInfo.InvariantCulture) - 1
-            : -1;
-        var normIdx = parts.Length > 2 && parts[2].Length > 0
-            ? int.Parse(parts[2], CultureInfo.InvariantCulture) - 1
-            : -1;
+        var texIdx =
+            parts.Length > 1 && parts[1].Length > 0
+                ? int.Parse(parts[1], CultureInfo.InvariantCulture) - 1
+                : -1;
+        var normIdx =
+            parts.Length > 2 && parts[2].Length > 0
+                ? int.Parse(parts[2], CultureInfo.InvariantCulture) - 1
+                : -1;
         return (posIdx, texIdx, normIdx);
     }
 }

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -121,7 +121,7 @@ public static class ObjLoader
                 case "o":
                 case "g":
                     FlushGroup();
-                    currentName = rest;
+                    currentName = rest.Length > 0 ? rest : "default";
                     break;
                 case "usemtl":
                     FlushGroup();
@@ -130,9 +130,15 @@ public static class ObjLoader
                 case "mtllib":
                 {
                     var filenames = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
+                    var mtlDirFull = Path.GetFullPath(mtlDir);
+                    var safePrefix = mtlDirFull + Path.DirectorySeparatorChar;
                     foreach (var filename in filenames)
                     {
-                        var mtlPath = Path.Combine(mtlDir, filename);
+                        var mtlPath = Path.GetFullPath(Path.Combine(mtlDirFull, filename));
+                        if (!mtlPath.StartsWith(safePrefix, StringComparison.Ordinal))
+                            throw new InvalidOperationException(
+                                $"MTL filename '{filename}' resolves outside the MTL directory."
+                            );
                         if (!File.Exists(mtlPath))
                             throw new FileNotFoundException(
                                 $"MTL file '{filename}' referenced by OBJ not found.",
@@ -202,7 +208,7 @@ public static class ObjLoader
         var parts = token.Split('/');
         if (parts.Length > 3)
             throw new FormatException(
-                $"OBJ face vertex '{token}' has {parts.Length} components; expected v, v/vt, or v/vt/vn."
+                $"OBJ face vertex '{token}' has {parts.Length} components; expected v, v/vt, v//vn, or v/vt/vn."
             );
         var posIdx = Resolve(int.Parse(parts[0], CultureInfo.InvariantCulture), posCount);
         var texIdx =

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -135,7 +135,10 @@ public static class ObjLoader
                     {
                         var mtlPath = Path.GetFullPath(Path.Combine(mtlDirFull, filename));
                         var relative = Path.GetRelativePath(mtlDirFull, mtlPath);
-                        if (Path.IsPathRooted(relative) || relative.StartsWith("..", StringComparison.Ordinal))
+                        if (
+                            Path.IsPathRooted(relative)
+                            || relative.StartsWith("..", StringComparison.Ordinal)
+                        )
                             throw new InvalidOperationException(
                                 $"MTL filename '{filename}' resolves outside the MTL directory."
                             );

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -1,0 +1,139 @@
+using System.Globalization;
+using System.Numerics;
+using Yaeger.Rendering;
+
+namespace Yaeger.Assets;
+
+public static class ObjLoader
+{
+    public static IReadOnlyList<ObjMesh> Load(string objPath, string? mtlBasePath = null)
+    {
+        var positions = new List<Vector3>();
+        var normals = new List<Vector3>();
+        var texCoords = new List<Vector2>();
+
+        var meshes = new List<ObjMesh>();
+
+        string currentName = "default";
+        string currentMaterial = "";
+        var currentVertices = new List<Vertex3D>();
+        var currentIndices = new List<uint>();
+        var vertexCache = new Dictionary<(int posIdx, int texIdx, int normIdx), uint>();
+
+        void FlushGroup()
+        {
+            if (currentIndices.Count == 0)
+                return;
+            var meshData = new MeshData(currentName, currentVertices.ToArray(), currentIndices.ToArray());
+            meshes.Add(new ObjMesh(currentName, meshData, currentMaterial));
+            currentVertices.Clear();
+            currentIndices.Clear();
+            vertexCache.Clear();
+        }
+
+        foreach (var rawLine in File.ReadLines(objPath))
+        {
+            var line = rawLine.TrimEnd();
+            if (line.Length == 0 || line[0] == '#')
+                continue;
+
+            var spaceIdx = line.IndexOf(' ');
+            var keyword = spaceIdx < 0 ? line : line[..spaceIdx];
+            var rest = spaceIdx < 0 ? "" : line[(spaceIdx + 1)..].TrimStart();
+
+            switch (keyword)
+            {
+                case "v":
+                {
+                    var p = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    positions.Add(
+                        new Vector3(
+                            float.Parse(p[0], CultureInfo.InvariantCulture),
+                            float.Parse(p[1], CultureInfo.InvariantCulture),
+                            float.Parse(p[2], CultureInfo.InvariantCulture)
+                        )
+                    );
+                    break;
+                }
+                case "vn":
+                {
+                    var p = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    normals.Add(
+                        new Vector3(
+                            float.Parse(p[0], CultureInfo.InvariantCulture),
+                            float.Parse(p[1], CultureInfo.InvariantCulture),
+                            float.Parse(p[2], CultureInfo.InvariantCulture)
+                        )
+                    );
+                    break;
+                }
+                case "vt":
+                {
+                    var p = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    texCoords.Add(
+                        new Vector2(
+                            float.Parse(p[0], CultureInfo.InvariantCulture),
+                            float.Parse(p[1], CultureInfo.InvariantCulture)
+                        )
+                    );
+                    break;
+                }
+                case "o":
+                case "g":
+                    FlushGroup();
+                    currentName = rest;
+                    break;
+                case "usemtl":
+                    currentMaterial = rest;
+                    break;
+                case "mtllib":
+                    // Directive is recognized; callers use MtlLoader.Load() to retrieve material data.
+                    break;
+                case "f":
+                {
+                    var tokens = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    var faceVerts = new uint[tokens.Length];
+                    for (var i = 0; i < tokens.Length; i++)
+                    {
+                        var (posIdx, texIdx, normIdx) = ParseFaceVertex(tokens[i]);
+                        var key = (posIdx, texIdx, normIdx);
+                        if (!vertexCache.TryGetValue(key, out var vertIdx))
+                        {
+                            var pos = positions[posIdx];
+                            var norm = normIdx >= 0 ? normals[normIdx] : Vector3.UnitY;
+                            var tex = texIdx >= 0 ? texCoords[texIdx] : Vector2.Zero;
+                            vertIdx = (uint)currentVertices.Count;
+                            currentVertices.Add(new Vertex3D(pos, norm, tex));
+                            vertexCache[key] = vertIdx;
+                        }
+                        faceVerts[i] = vertIdx;
+                    }
+                    // Fan-triangulate: for n vertices emit (n-2) triangles
+                    for (var i = 1; i < faceVerts.Length - 1; i++)
+                    {
+                        currentIndices.Add(faceVerts[0]);
+                        currentIndices.Add(faceVerts[i]);
+                        currentIndices.Add(faceVerts[i + 1]);
+                    }
+                    break;
+                }
+            }
+        }
+
+        FlushGroup();
+        return meshes.AsReadOnly();
+    }
+
+    private static (int posIdx, int texIdx, int normIdx) ParseFaceVertex(string token)
+    {
+        var parts = token.Split('/');
+        var posIdx = int.Parse(parts[0], CultureInfo.InvariantCulture) - 1;
+        var texIdx = parts.Length > 1 && parts[1].Length > 0
+            ? int.Parse(parts[1], CultureInfo.InvariantCulture) - 1
+            : -1;
+        var normIdx = parts.Length > 2 && parts[2].Length > 0
+            ? int.Parse(parts[2], CultureInfo.InvariantCulture) - 1
+            : -1;
+        return (posIdx, texIdx, normIdx);
+    }
+}

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -130,6 +130,10 @@ public static class ObjLoader
                 case "mtllib":
                 {
                     var filenames = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
+                    if (filenames.Length == 0)
+                        throw new FormatException(
+                            "OBJ 'mtllib' directive requires at least one filename."
+                        );
                     var mtlDirFull = Path.GetFullPath(mtlDir);
                     foreach (var filename in filenames)
                     {
@@ -139,7 +143,7 @@ public static class ObjLoader
                             Path.IsPathRooted(relative)
                             || relative.StartsWith("..", StringComparison.Ordinal)
                         )
-                            throw new InvalidOperationException(
+                            throw new FormatException(
                                 $"MTL filename '{filename}' resolves outside the MTL directory."
                             );
                         if (!File.Exists(mtlPath))

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -12,6 +12,10 @@ public static class ObjLoader
 
     public static ObjScene LoadScene(string objPath, string? mtlBasePath = null)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(objPath, nameof(objPath));
+        if (mtlBasePath is not null)
+            ArgumentException.ThrowIfNullOrWhiteSpace(mtlBasePath, nameof(mtlBasePath));
+
         var resolved = AssetPath.Resolve(objPath);
 
         if (!File.Exists(resolved))
@@ -25,12 +29,15 @@ public static class ObjLoader
         var materials = new Dictionary<string, MtlMaterial>();
 
         string currentName = "default";
-        string currentMaterial = "";
+        string? currentMaterial = null;
         var currentVertices = new List<Vertex3D>();
         var currentIndices = new List<uint>();
         var vertexCache = new Dictionary<(int posIdx, int texIdx, int normIdx), uint>();
 
-        string mtlDir = mtlBasePath ?? Path.GetDirectoryName(resolved) ?? AppContext.BaseDirectory;
+        string mtlDir =
+            mtlBasePath is not null
+                ? AssetPath.Resolve(mtlBasePath)
+                : Path.GetDirectoryName(resolved) ?? AppContext.BaseDirectory;
 
         void FlushGroup()
         {
@@ -51,6 +58,12 @@ public static class ObjLoader
         {
             var line = rawLine.Trim();
             if (line.Length == 0 || line[0] == '#')
+                continue;
+
+            var commentIdx = line.IndexOf('#');
+            if (commentIdx >= 0)
+                line = line[..commentIdx].TrimEnd();
+            if (line.Length == 0)
                 continue;
 
             var spaceIdx = line.IndexOf(' ');
@@ -119,7 +132,12 @@ public static class ObjLoader
                     var faceVerts = new uint[tokens.Length];
                     for (var i = 0; i < tokens.Length; i++)
                     {
-                        var (posIdx, texIdx, normIdx) = ParseFaceVertex(tokens[i]);
+                        var (posIdx, texIdx, normIdx) = ParseFaceVertex(
+                            tokens[i],
+                            positions.Count,
+                            texCoords.Count,
+                            normals.Count
+                        );
                         var key = (posIdx, texIdx, normIdx);
                         if (!vertexCache.TryGetValue(key, out var vertIdx))
                         {
@@ -151,18 +169,26 @@ public static class ObjLoader
         );
     }
 
-    private static (int posIdx, int texIdx, int normIdx) ParseFaceVertex(string token)
+    private static (int posIdx, int texIdx, int normIdx) ParseFaceVertex(
+        string token,
+        int posCount,
+        int texCount,
+        int normCount
+    )
     {
         var parts = token.Split('/');
-        var posIdx = int.Parse(parts[0], CultureInfo.InvariantCulture) - 1;
+        var posIdx = Resolve(int.Parse(parts[0], CultureInfo.InvariantCulture), posCount);
         var texIdx =
             parts.Length > 1 && parts[1].Length > 0
-                ? int.Parse(parts[1], CultureInfo.InvariantCulture) - 1
+                ? Resolve(int.Parse(parts[1], CultureInfo.InvariantCulture), texCount)
                 : -1;
         var normIdx =
             parts.Length > 2 && parts[2].Length > 0
-                ? int.Parse(parts[2], CultureInfo.InvariantCulture) - 1
+                ? Resolve(int.Parse(parts[2], CultureInfo.InvariantCulture), normCount)
                 : -1;
         return (posIdx, texIdx, normIdx);
     }
+
+    private static int Resolve(int oneBasedOrNegative, int poolCount) =>
+        oneBasedOrNegative > 0 ? oneBasedOrNegative - 1 : poolCount + oneBasedOrNegative;
 }

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -129,9 +129,15 @@ public static class ObjLoader
                     break;
                 case "mtllib":
                 {
-                    var mtlPath = Path.Combine(mtlDir, rest);
-                    if (File.Exists(mtlPath))
+                    var filenames = rest.Split(s_whitespace, StringSplitOptions.RemoveEmptyEntries);
+                    foreach (var filename in filenames)
                     {
+                        var mtlPath = Path.Combine(mtlDir, filename);
+                        if (!File.Exists(mtlPath))
+                            throw new FileNotFoundException(
+                                $"MTL file '{filename}' referenced by OBJ not found.",
+                                mtlPath
+                            );
                         foreach (var (name, mat) in MtlLoader.Load(mtlPath))
                             materials[name] = mat;
                     }

--- a/src/Engine/Yaeger/Assets/ObjMesh.cs
+++ b/src/Engine/Yaeger/Assets/ObjMesh.cs
@@ -2,4 +2,4 @@ using Yaeger.Rendering;
 
 namespace Yaeger.Assets;
 
-public record ObjMesh(string Name, MeshData Mesh, string? MaterialName);
+public record ObjMesh(string Name, MeshData Mesh, string MaterialName);

--- a/src/Engine/Yaeger/Assets/ObjMesh.cs
+++ b/src/Engine/Yaeger/Assets/ObjMesh.cs
@@ -1,0 +1,5 @@
+using Yaeger.Rendering;
+
+namespace Yaeger.Assets;
+
+public record ObjMesh(string Name, MeshData Mesh, string MaterialName);

--- a/src/Engine/Yaeger/Assets/ObjMesh.cs
+++ b/src/Engine/Yaeger/Assets/ObjMesh.cs
@@ -2,4 +2,4 @@ using Yaeger.Rendering;
 
 namespace Yaeger.Assets;
 
-public record ObjMesh(string Name, MeshData Mesh, string MaterialName);
+public record ObjMesh(string Name, MeshData Mesh, string? MaterialName);

--- a/src/Engine/Yaeger/Assets/ObjScene.cs
+++ b/src/Engine/Yaeger/Assets/ObjScene.cs
@@ -1,0 +1,6 @@
+namespace Yaeger.Assets;
+
+public record ObjScene(
+    IReadOnlyList<ObjMesh> Meshes,
+    IReadOnlyDictionary<string, MtlMaterial> Materials
+);

--- a/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
@@ -130,6 +130,36 @@ public class MtlLoaderTests
     }
 
     [Fact]
+    public void Load_NullOrWhiteSpacePath_ShouldThrowArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => MtlLoader.Load("   "));
+    }
+
+    [Fact]
+    public void Load_InlineComments_ShouldBeStripped()
+    {
+        var mtl = """
+            newmtl inline_test # material name comment
+            Kd 1.0 0.0 0.0 # red diffuse
+            Ns 10.0 # shininess
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Single(materials);
+            Assert.Equal("inline_test", materials["inline_test"].Name);
+            Assert.Equal((byte)255, materials["inline_test"].DiffuseColor.R);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Load_DefaultColors_AmbientIsBlackDiffuseIsWhite()
     {
         var mtl = """

--- a/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
@@ -124,6 +124,12 @@ public class MtlLoaderTests
     }
 
     [Fact]
+    public void Load_FileNotFound_ShouldThrowFileNotFoundException()
+    {
+        Assert.Throws<FileNotFoundException>(() => MtlLoader.Load("nonexistent.mtl"));
+    }
+
+    [Fact]
     public void Load_DefaultColors_AmbientIsBlackDiffuseIsWhite()
     {
         var mtl = """

--- a/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
@@ -160,6 +160,25 @@ public class MtlLoaderTests
     }
 
     [Fact]
+    public void Load_MalformedColor_ShouldThrowFormatException()
+    {
+        var mtl = """
+            newmtl bad
+            Kd 1.0 0.5
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            Assert.Throws<FormatException>(() => MtlLoader.Load(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Load_DefaultColors_AmbientIsBlackDiffuseIsWhite()
     {
         var mtl = """

--- a/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
@@ -124,6 +124,25 @@ public class MtlLoaderTests
     }
 
     [Fact]
+    public void Load_EmptyNewmtlName_ShouldThrowFormatException()
+    {
+        var mtl = """
+            newmtl
+            Kd 1.0 0.0 0.0
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            Assert.Throws<FormatException>(() => MtlLoader.Load(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Load_FileNotFound_ShouldThrowFileNotFoundException()
     {
         Assert.Throws<FileNotFoundException>(() => MtlLoader.Load("nonexistent.mtl"));

--- a/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
@@ -1,0 +1,149 @@
+using Yaeger.Assets;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Assets;
+
+public class MtlLoaderTests
+{
+    private static string WriteTempFile(string content)
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void Load_SingleMaterial_ShouldReturnCorrectTexturePathAndColors()
+    {
+        var mtl = """
+            newmtl stone_wall
+            Ka 0.2 0.2 0.2
+            Kd 0.8 0.6 0.4
+            Ks 1.0 1.0 1.0
+            Ns 32.0
+            map_Kd textures/stone.png
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Single(materials);
+            var mat = materials["stone_wall"];
+            Assert.Equal("stone_wall", mat.Name);
+            Assert.Equal("textures/stone.png", mat.DiffuseTexturePath);
+            Assert.Equal((byte)(0.2f * 255f), mat.AmbientColor.R);
+            Assert.Equal((byte)(0.8f * 255f), mat.DiffuseColor.R);
+            Assert.Equal((byte)(0.6f * 255f), mat.DiffuseColor.G);
+            Assert.Equal((byte)(0.4f * 255f), mat.DiffuseColor.B);
+            Assert.Equal((byte)255, mat.SpecularColor.R);
+            Assert.Equal(32.0f, mat.Shininess);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_MultipleMaterials_ShouldReturnAllMaterials()
+    {
+        var mtl = """
+            newmtl mat_a
+            Kd 1.0 0.0 0.0
+            Ns 10.0
+
+            newmtl mat_b
+            Kd 0.0 1.0 0.0
+            Ns 20.0
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Equal(2, materials.Count);
+            Assert.True(materials.ContainsKey("mat_a"));
+            Assert.True(materials.ContainsKey("mat_b"));
+            Assert.Equal(10.0f, materials["mat_a"].Shininess);
+            Assert.Equal(20.0f, materials["mat_b"].Shininess);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_NoTexture_ShouldHaveNullDiffuseTexturePath()
+    {
+        var mtl = """
+            newmtl plain
+            Kd 0.5 0.5 0.5
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Null(materials["plain"].DiffuseTexturePath);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_CommentsAndBlankLines_ShouldBeIgnored()
+    {
+        var mtl = """
+            # This is a comment
+
+            newmtl test_mat
+            # Another comment
+            Ka 0.1 0.1 0.1
+            Kd 0.5 0.5 0.5
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Single(materials);
+            Assert.Equal("test_mat", materials["test_mat"].Name);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_DefaultColors_AmbientIsBlackDiffuseIsWhite()
+    {
+        var mtl = """
+            newmtl defaults
+            Ns 0.0
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            var mat = materials["defaults"];
+            Assert.Equal(Color.Black, mat.AmbientColor);
+            Assert.Equal(Color.White, mat.DiffuseColor);
+            Assert.Equal(Color.Black, mat.SpecularColor);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
@@ -27,10 +27,10 @@ public class ObjLoaderTests
 
         try
         {
-            var scene = ObjLoader.Load(path);
+            var meshes = ObjLoader.Load(path);
 
-            Assert.Single(scene.Meshes);
-            var mesh = scene.Meshes[0].Mesh;
+            Assert.Single(meshes);
+            var mesh = meshes[0].Mesh;
             Assert.Equal(3, mesh.Vertices.Length);
             Assert.Equal(3, mesh.Indices.Length);
             Assert.Equal(new Vector3(0f, 0f, 0f), mesh.Vertices[0].Position);
@@ -60,10 +60,10 @@ public class ObjLoaderTests
 
         try
         {
-            var scene = ObjLoader.Load(path);
+            var meshes = ObjLoader.Load(path);
 
-            Assert.Single(scene.Meshes);
-            var mesh = scene.Meshes[0].Mesh;
+            Assert.Single(meshes);
+            var mesh = meshes[0].Mesh;
             Assert.Equal(4, mesh.Vertices.Length);
             Assert.Equal(6, mesh.Indices.Length);
             Assert.Equal<uint>(0, mesh.Indices[0]);
@@ -99,11 +99,11 @@ public class ObjLoaderTests
 
         try
         {
-            var scene = ObjLoader.Load(path);
+            var meshes = ObjLoader.Load(path);
 
-            Assert.Equal(2, scene.Meshes.Count);
-            Assert.Equal("groupA", scene.Meshes[0].Name);
-            Assert.Equal("groupB", scene.Meshes[1].Name);
+            Assert.Equal(2, meshes.Count);
+            Assert.Equal("groupA", meshes[0].Name);
+            Assert.Equal("groupB", meshes[1].Name);
         }
         finally
         {
@@ -127,10 +127,10 @@ public class ObjLoaderTests
 
         try
         {
-            var scene = ObjLoader.Load(path);
+            var meshes = ObjLoader.Load(path);
 
-            Assert.Single(scene.Meshes);
-            Assert.Equal("myMaterial", scene.Meshes[0].MaterialName);
+            Assert.Single(meshes);
+            Assert.Equal("myMaterial", meshes[0].MaterialName);
         }
         finally
         {
@@ -159,11 +159,11 @@ public class ObjLoaderTests
 
         try
         {
-            var scene = ObjLoader.Load(path);
+            var meshes = ObjLoader.Load(path);
 
-            Assert.Equal(2, scene.Meshes.Count);
-            Assert.Equal("mat1", scene.Meshes[0].MaterialName);
-            Assert.Equal("mat2", scene.Meshes[1].MaterialName);
+            Assert.Equal(2, meshes.Count);
+            Assert.Equal("mat1", meshes[0].MaterialName);
+            Assert.Equal("mat2", meshes[1].MaterialName);
         }
         finally
         {
@@ -189,10 +189,10 @@ public class ObjLoaderTests
 
         try
         {
-            var scene = ObjLoader.Load(path);
+            var meshes = ObjLoader.Load(path);
 
-            Assert.Single(scene.Meshes);
-            var vertices = scene.Meshes[0].Mesh.Vertices;
+            Assert.Single(meshes);
+            var vertices = meshes[0].Mesh.Vertices;
             Assert.Equal(new Vector2(0f, 0f), vertices[0].TexCoord);
             Assert.Equal(new Vector2(1f, 0f), vertices[1].TexCoord);
             Assert.Equal(new Vector2(0f, 1f), vertices[2].TexCoord);
@@ -220,10 +220,10 @@ public class ObjLoaderTests
 
         try
         {
-            var scene = ObjLoader.Load(path);
+            var meshes = ObjLoader.Load(path);
 
-            Assert.Single(scene.Meshes);
-            var mesh = scene.Meshes[0].Mesh;
+            Assert.Single(meshes);
+            var mesh = meshes[0].Mesh;
             Assert.Equal(4, mesh.Vertices.Length);
             Assert.Equal(6, mesh.Indices.Length);
         }
@@ -234,7 +234,7 @@ public class ObjLoaderTests
     }
 
     [Fact]
-    public void Load_MtllibDirective_ShouldPopulateMaterials()
+    public void LoadScene_MtllibDirective_ShouldPopulateMaterials()
     {
         var tempDir = Path.GetTempPath();
         var mtlPath = Path.Combine(tempDir, $"{Guid.NewGuid()}.mtl");
@@ -261,7 +261,7 @@ public class ObjLoaderTests
 
         try
         {
-            var scene = ObjLoader.Load(objPath);
+            var scene = ObjLoader.LoadScene(objPath);
 
             Assert.True(scene.Materials.ContainsKey("stone"));
             Assert.Equal(10.0f, scene.Materials["stone"].Shininess);

--- a/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
@@ -304,7 +304,7 @@ public class ObjLoaderTests
     }
 
     [Fact]
-    public void Load_NoUsemtl_ShouldHaveNullMaterialName()
+    public void Load_NoUsemtl_ShouldHaveEmptyMaterialName()
     {
         var obj = """
             v 0.0 0.0 0.0
@@ -321,7 +321,7 @@ public class ObjLoaderTests
             var meshes = ObjLoader.Load(path);
 
             Assert.Single(meshes);
-            Assert.Null(meshes[0].MaterialName);
+            Assert.Equal("", meshes[0].MaterialName);
         }
         finally
         {
@@ -365,5 +365,26 @@ public class ObjLoaderTests
     public void Load_NullOrWhiteSpacePath_ShouldThrowArgumentException()
     {
         Assert.Throws<ArgumentException>(() => ObjLoader.Load("   "));
+    }
+
+    [Fact]
+    public void Load_OutOfRangeIndex_ShouldThrowFormatException()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 99//1 100//1 101//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            Assert.Throws<FormatException>(() => ObjLoader.Load(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 }

--- a/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
@@ -274,8 +274,96 @@ public class ObjLoaderTests
     }
 
     [Fact]
+    public void Load_NegativeIndices_ShouldResolveRelativeToPoolEnd()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            f -3//-1 -2//-1 -1//-1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Single(meshes);
+            var mesh = meshes[0].Mesh;
+            Assert.Equal(3, mesh.Vertices.Length);
+            Assert.Equal(new Vector3(0f, 0f, 0f), mesh.Vertices[0].Position);
+            Assert.Equal(new Vector3(1f, 0f, 0f), mesh.Vertices[1].Position);
+            Assert.Equal(new Vector3(0f, 1f, 0f), mesh.Vertices[2].Position);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_NoUsemtl_ShouldHaveNullMaterialName()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 1//1 2//1 3//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Single(meshes);
+            Assert.Null(meshes[0].MaterialName);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_InlineComments_ShouldBeStripped()
+    {
+        var obj = """
+            v 0.0 0.0 0.0 # origin
+            v 1.0 0.0 0.0 # x-axis
+            v 0.0 1.0 0.0 # y-axis
+            vn 0.0 0.0 1.0 # front
+            g tri # group name comment
+            f 1//1 2//1 3//1 # face
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Single(meshes);
+            Assert.Equal(3, meshes[0].Mesh.Vertices.Length);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Load_FileNotFound_ShouldThrowFileNotFoundException()
     {
         Assert.Throws<FileNotFoundException>(() => ObjLoader.Load("nonexistent.obj"));
+    }
+
+    [Fact]
+    public void Load_NullOrWhiteSpacePath_ShouldThrowArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => ObjLoader.Load("   "));
     }
 }

--- a/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
@@ -356,6 +356,30 @@ public class ObjLoaderTests
     }
 
     [Fact]
+    public void LoadScene_MtllibMissingFile_ShouldThrowFileNotFoundException()
+    {
+        var obj = """
+            mtllib doesnotexist.mtl
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 1//1 2//1 3//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            Assert.Throws<FileNotFoundException>(() => ObjLoader.LoadScene(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Load_FileNotFound_ShouldThrowFileNotFoundException()
     {
         Assert.Throws<FileNotFoundException>(() => ObjLoader.Load("nonexistent.obj"));

--- a/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
@@ -27,10 +27,10 @@ public class ObjLoaderTests
 
         try
         {
-            var meshes = ObjLoader.Load(path);
+            var scene = ObjLoader.Load(path);
 
-            Assert.Single(meshes);
-            var mesh = meshes[0].Mesh;
+            Assert.Single(scene.Meshes);
+            var mesh = scene.Meshes[0].Mesh;
             Assert.Equal(3, mesh.Vertices.Length);
             Assert.Equal(3, mesh.Indices.Length);
             Assert.Equal(new Vector3(0f, 0f, 0f), mesh.Vertices[0].Position);
@@ -60,18 +60,15 @@ public class ObjLoaderTests
 
         try
         {
-            var meshes = ObjLoader.Load(path);
+            var scene = ObjLoader.Load(path);
 
-            Assert.Single(meshes);
-            var mesh = meshes[0].Mesh;
+            Assert.Single(scene.Meshes);
+            var mesh = scene.Meshes[0].Mesh;
             Assert.Equal(4, mesh.Vertices.Length);
-            // Two triangles = 6 indices
             Assert.Equal(6, mesh.Indices.Length);
-            // First triangle: v0, v1, v2
             Assert.Equal<uint>(0, mesh.Indices[0]);
             Assert.Equal<uint>(1, mesh.Indices[1]);
             Assert.Equal<uint>(2, mesh.Indices[2]);
-            // Second triangle: v0, v2, v3
             Assert.Equal<uint>(0, mesh.Indices[3]);
             Assert.Equal<uint>(2, mesh.Indices[4]);
             Assert.Equal<uint>(3, mesh.Indices[5]);
@@ -102,11 +99,11 @@ public class ObjLoaderTests
 
         try
         {
-            var meshes = ObjLoader.Load(path);
+            var scene = ObjLoader.Load(path);
 
-            Assert.Equal(2, meshes.Count);
-            Assert.Equal("groupA", meshes[0].Name);
-            Assert.Equal("groupB", meshes[1].Name);
+            Assert.Equal(2, scene.Meshes.Count);
+            Assert.Equal("groupA", scene.Meshes[0].Name);
+            Assert.Equal("groupB", scene.Meshes[1].Name);
         }
         finally
         {
@@ -130,10 +127,43 @@ public class ObjLoaderTests
 
         try
         {
-            var meshes = ObjLoader.Load(path);
+            var scene = ObjLoader.Load(path);
 
-            Assert.Single(meshes);
-            Assert.Equal("myMaterial", meshes[0].MaterialName);
+            Assert.Single(scene.Meshes);
+            Assert.Equal("myMaterial", scene.Meshes[0].MaterialName);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_UsemtlMidGroup_ShouldFlushAndCreateSeparateMeshes()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            v 0.0 0.0 1.0
+            v 1.0 0.0 1.0
+            v 0.0 1.0 1.0
+            vn 0.0 0.0 1.0
+            g section
+            usemtl mat1
+            f 1//1 2//1 3//1
+            usemtl mat2
+            f 4//1 5//1 6//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var scene = ObjLoader.Load(path);
+
+            Assert.Equal(2, scene.Meshes.Count);
+            Assert.Equal("mat1", scene.Meshes[0].MaterialName);
+            Assert.Equal("mat2", scene.Meshes[1].MaterialName);
         }
         finally
         {
@@ -159,10 +189,10 @@ public class ObjLoaderTests
 
         try
         {
-            var meshes = ObjLoader.Load(path);
+            var scene = ObjLoader.Load(path);
 
-            Assert.Single(meshes);
-            var vertices = meshes[0].Mesh.Vertices;
+            Assert.Single(scene.Meshes);
+            var vertices = scene.Meshes[0].Mesh.Vertices;
             Assert.Equal(new Vector2(0f, 0f), vertices[0].TexCoord);
             Assert.Equal(new Vector2(1f, 0f), vertices[1].TexCoord);
             Assert.Equal(new Vector2(0f, 1f), vertices[2].TexCoord);
@@ -176,7 +206,6 @@ public class ObjLoaderTests
     [Fact]
     public void Load_SharedVertices_ShouldDeduplicateViaCache()
     {
-        // Two triangles sharing two vertices (a square split into triangles)
         var obj = """
             v 0.0 0.0 0.0
             v 1.0 0.0 0.0
@@ -191,11 +220,10 @@ public class ObjLoaderTests
 
         try
         {
-            var meshes = ObjLoader.Load(path);
+            var scene = ObjLoader.Load(path);
 
-            Assert.Single(meshes);
-            var mesh = meshes[0].Mesh;
-            // 4 unique (pos, norm) combinations → 4 vertices
+            Assert.Single(scene.Meshes);
+            var mesh = scene.Meshes[0].Mesh;
             Assert.Equal(4, mesh.Vertices.Length);
             Assert.Equal(6, mesh.Indices.Length);
         }
@@ -203,5 +231,51 @@ public class ObjLoaderTests
         {
             File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void Load_MtllibDirective_ShouldPopulateMaterials()
+    {
+        var tempDir = Path.GetTempPath();
+        var mtlPath = Path.Combine(tempDir, $"{Guid.NewGuid()}.mtl");
+        var objPath = Path.Combine(tempDir, $"{Guid.NewGuid()}.obj");
+
+        var mtl = """
+            newmtl stone
+            Kd 1.0 0.0 0.0
+            Ns 10.0
+            """;
+        File.WriteAllText(mtlPath, mtl);
+
+        var obj = $"""
+            mtllib {Path.GetFileName(mtlPath)}
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            usemtl stone
+            f 1//1 2//1 3//1
+            """;
+        File.WriteAllText(objPath, obj);
+
+        try
+        {
+            var scene = ObjLoader.Load(objPath);
+
+            Assert.True(scene.Materials.ContainsKey("stone"));
+            Assert.Equal(10.0f, scene.Materials["stone"].Shininess);
+        }
+        finally
+        {
+            File.Delete(objPath);
+            File.Delete(mtlPath);
+        }
+    }
+
+    [Fact]
+    public void Load_FileNotFound_ShouldThrowFileNotFoundException()
+    {
+        Assert.Throws<FileNotFoundException>(() => ObjLoader.Load("nonexistent.obj"));
     }
 }

--- a/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
@@ -1,0 +1,207 @@
+using System.Numerics;
+using Yaeger.Assets;
+
+namespace Yaeger.Tests.Assets;
+
+public class ObjLoaderTests
+{
+    private static string WriteTempFile(string content)
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void Load_SingleTriangle_ShouldReturnCorrectVertexPositionsAndIndices()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 1//1 2//1 3//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Single(meshes);
+            var mesh = meshes[0].Mesh;
+            Assert.Equal(3, mesh.Vertices.Length);
+            Assert.Equal(3, mesh.Indices.Length);
+            Assert.Equal(new Vector3(0f, 0f, 0f), mesh.Vertices[0].Position);
+            Assert.Equal(new Vector3(1f, 0f, 0f), mesh.Vertices[1].Position);
+            Assert.Equal(new Vector3(0f, 1f, 0f), mesh.Vertices[2].Position);
+            Assert.Equal<uint>([0, 1, 2], mesh.Indices);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_QuadFace_ShouldFanTriangulateIntoTwoTriangles()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 1.0 1.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g quad
+            f 1//1 2//1 3//1 4//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Single(meshes);
+            var mesh = meshes[0].Mesh;
+            Assert.Equal(4, mesh.Vertices.Length);
+            // Two triangles = 6 indices
+            Assert.Equal(6, mesh.Indices.Length);
+            // First triangle: v0, v1, v2
+            Assert.Equal<uint>(0, mesh.Indices[0]);
+            Assert.Equal<uint>(1, mesh.Indices[1]);
+            Assert.Equal<uint>(2, mesh.Indices[2]);
+            // Second triangle: v0, v2, v3
+            Assert.Equal<uint>(0, mesh.Indices[3]);
+            Assert.Equal<uint>(2, mesh.Indices[4]);
+            Assert.Equal<uint>(3, mesh.Indices[5]);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_MultiGroupObj_ShouldReturnCorrectNumberOfMeshes()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            v 0.0 0.0 1.0
+            v 1.0 0.0 1.0
+            v 0.0 1.0 1.0
+            vn 0.0 0.0 1.0
+            g groupA
+            f 1//1 2//1 3//1
+            g groupB
+            f 4//1 5//1 6//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Equal(2, meshes.Count);
+            Assert.Equal("groupA", meshes[0].Name);
+            Assert.Equal("groupB", meshes[1].Name);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_UsemtlDirective_ShouldAssociateMaterialWithMesh()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g mesh1
+            usemtl myMaterial
+            f 1//1 2//1 3//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Single(meshes);
+            Assert.Equal("myMaterial", meshes[0].MaterialName);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_WithTextureCoordinates_ShouldSetTexCoords()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vt 0.0 0.0
+            vt 1.0 0.0
+            vt 0.0 1.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 1/1/1 2/2/1 3/3/1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Single(meshes);
+            var vertices = meshes[0].Mesh.Vertices;
+            Assert.Equal(new Vector2(0f, 0f), vertices[0].TexCoord);
+            Assert.Equal(new Vector2(1f, 0f), vertices[1].TexCoord);
+            Assert.Equal(new Vector2(0f, 1f), vertices[2].TexCoord);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_SharedVertices_ShouldDeduplicateViaCache()
+    {
+        // Two triangles sharing two vertices (a square split into triangles)
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 1.0 1.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g shared
+            f 1//1 2//1 3//1
+            f 1//1 3//1 4//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            Assert.Single(meshes);
+            var mesh = meshes[0].Mesh;
+            // 4 unique (pos, norm) combinations → 4 vertices
+            Assert.Equal(4, mesh.Vertices.Length);
+            Assert.Equal(6, mesh.Indices.Length);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
@@ -368,6 +368,49 @@ public class ObjLoaderTests
     }
 
     [Fact]
+    public void Load_FaceWithFewerThanThreeVertices_ShouldThrowFormatException()
+    {
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 1//1 2//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            Assert.Throws<FormatException>(() => ObjLoader.Load(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_MalformedVertex_ShouldThrowFormatException()
+    {
+        var obj = """
+            v 0.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 1//1 2//1 3//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            Assert.Throws<FormatException>(() => ObjLoader.Load(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Load_OutOfRangeIndex_ShouldThrowFormatException()
     {
         var obj = """


### PR DESCRIPTION
Implements `ObjLoader` and `MtlLoader` under `src/Engine/Yaeger/Assets/`:
- `MtlMaterial` record with ambient/diffuse/specular colors, shininess, and optional diffuse texture path
- `MtlLoader.Load()` parses `.mtl` files into a name-keyed dictionary
- `ObjMesh` record wrapping a `MeshData` with its associated material name
- `ObjLoader.Load()` parses `.obj` files into one `ObjMesh` per named group/object, handling v/vn/vt pools, fan-triangulated faces, usemtl, and the mtllib directive

Adds unit tests covering triangle parsing, quad fan-triangulation, multi-group files, UV coordinates, vertex deduplication, and MTL color/texture parsing.

https://claude.ai/code/session_01UfwRfV2JyG8wCAScttUt8M