### PR TITLE
Add Material3D ECS component with FromMtl factory helper

### DIFF
--- a/src/Engine/Yaeger.Core/Yaeger.Core.csproj
+++ b/src/Engine/Yaeger.Core/Yaeger.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="..\Yaeger\AssetPath.cs" Link="AssetPath.cs" />
+    <Compile Include="..\Yaeger\Assets\MtlMaterial.cs" Link="Assets\MtlMaterial.cs" />
     <Compile Include="..\Yaeger\ECS\**\*.cs" Link="ECS\%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile
       Include="..\Yaeger\Graphics\**\*.cs"

--- a/src/Engine/Yaeger/Graphics/Material3D.cs
+++ b/src/Engine/Yaeger/Graphics/Material3D.cs
@@ -1,0 +1,22 @@
+using Yaeger.Assets;
+
+namespace Yaeger.Graphics;
+
+public record struct Material3D
+{
+    public string DiffuseTexturePath;
+    public Color Ambient;
+    public Color Diffuse;
+    public Color Specular;
+    public float Shininess;
+
+    public static Material3D FromMtl(MtlMaterial mtl) =>
+        new()
+        {
+            DiffuseTexturePath = mtl.DiffuseTexturePath ?? string.Empty,
+            Ambient = mtl.AmbientColor,
+            Diffuse = mtl.DiffuseColor,
+            Specular = mtl.SpecularColor,
+            Shininess = mtl.Shininess,
+        };
+}

--- a/src/Engine/Yaeger/TypeForwarders.cs
+++ b/src/Engine/Yaeger/TypeForwarders.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(global::Yaeger.AssetPath))]
+[assembly: TypeForwardedTo(typeof(global::Yaeger.Assets.MtlMaterial))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.ECS.ComponentRegistry))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.ECS.ComponentStorage<>))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.ECS.Entity))]
@@ -31,6 +32,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Camera2D))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Camera3D))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Color))]
+[assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Material3D))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.RenderLayer))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Sprite))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.SpriteSheet))]

--- a/src/Engine/Yaeger/Yaeger.csproj
+++ b/src/Engine/Yaeger/Yaeger.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <Compile Remove="AssetPath.cs" />
+    <Compile Remove="Assets\MtlMaterial.cs" />
     <Compile Remove="ECS\**\*.cs" />
     <Compile Remove="Graphics\**\*.cs" />
     <Compile Remove="Physics\**\*.cs" />

--- a/tests/Yaeger.Tests/Graphics/Material3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Material3DTests.cs
@@ -1,0 +1,82 @@
+using Yaeger.Assets;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Graphics;
+
+public class Material3DTests
+{
+    [Fact]
+    public void IsStruct_SatisfiesEcsConstraint()
+    {
+        Assert.True(typeof(Material3D).IsValueType);
+    }
+
+    [Fact]
+    public void Default_HasEmptyTexturePath()
+    {
+        var material = default(Material3D);
+
+        Assert.Null(material.DiffuseTexturePath);
+    }
+
+    [Fact]
+    public void FromMtl_MapsAllFields()
+    {
+        var mtl = new MtlMaterial(
+            Name: "TestMat",
+            DiffuseTexturePath: "textures/wall.png",
+            AmbientColor: new Color(10, 20, 30),
+            DiffuseColor: new Color(100, 150, 200),
+            SpecularColor: new Color(255, 255, 255),
+            Shininess: 32f
+        );
+
+        var material = Material3D.FromMtl(mtl);
+
+        Assert.Equal("textures/wall.png", material.DiffuseTexturePath);
+        Assert.Equal(new Color(10, 20, 30), material.Ambient);
+        Assert.Equal(new Color(100, 150, 200), material.Diffuse);
+        Assert.Equal(new Color(255, 255, 255), material.Specular);
+        Assert.Equal(32f, material.Shininess);
+    }
+
+    [Fact]
+    public void FromMtl_NullTexturePath_BecomesEmptyString()
+    {
+        var mtl = new MtlMaterial(
+            Name: "NoTex",
+            DiffuseTexturePath: null,
+            AmbientColor: new Color(0, 0, 0),
+            DiffuseColor: new Color(0, 0, 0),
+            SpecularColor: new Color(0, 0, 0),
+            Shininess: 0f
+        );
+
+        var material = Material3D.FromMtl(mtl);
+
+        Assert.Equal(string.Empty, material.DiffuseTexturePath);
+    }
+
+    [Fact]
+    public void RecordStruct_EqualityByValue()
+    {
+        var a = new Material3D
+        {
+            DiffuseTexturePath = "tex.png",
+            Ambient = new Color(1, 2, 3),
+            Diffuse = new Color(4, 5, 6),
+            Specular = new Color(7, 8, 9),
+            Shininess = 16f,
+        };
+        var b = new Material3D
+        {
+            DiffuseTexturePath = "tex.png",
+            Ambient = new Color(1, 2, 3),
+            Diffuse = new Color(4, 5, 6),
+            Specular = new Color(7, 8, 9),
+            Shininess = 16f,
+        };
+
+        Assert.Equal(a, b);
+    }
+}

--- a/tests/Yaeger.Tests/Graphics/Material3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Material3DTests.cs
@@ -12,7 +12,7 @@ public class Material3DTests
     }
 
     [Fact]
-    public void Default_HasEmptyTexturePath()
+    public void Default_HasNullTexturePath()
     {
         var material = default(Material3D);
 


### PR DESCRIPTION
Implements #76. Adds a `record struct Material3D` to `Yaeger.Graphics`
carrying per-entity material data (diffuse texture path, ambient/diffuse/
specular colors, shininess) and a `FromMtl` factory that converts from the
`MtlMaterial` loader record. Includes unit tests covering field mapping,
null-texture-path fallback, value equality, and the struct constraint.

https://claude.ai/code/session_01P8AUPwLLwNH3Gv84Zu5fsK