### PR TITLE
Add 3D rendering pipeline: Renderer3D, MeshRenderSystem, GpuMeshRegistry

### DIFF
--- a/src/Engine/Yaeger/Graphics/MeshHandle.cs
+++ b/src/Engine/Yaeger/Graphics/MeshHandle.cs
@@ -1,0 +1,6 @@
+namespace Yaeger.Graphics;
+
+/// <summary>
+/// ECS component that references a mesh registered in <see cref="Yaeger.Rendering.GpuMeshRegistry"/>.
+/// </summary>
+public readonly record struct MeshHandle(int Id);

--- a/src/Engine/Yaeger/Graphics/MeshHandle.cs
+++ b/src/Engine/Yaeger/Graphics/MeshHandle.cs
@@ -1,6 +1,8 @@
 namespace Yaeger.Graphics;
 
 /// <summary>
-/// ECS component that references a mesh registered in <see cref="Yaeger.Rendering.GpuMeshRegistry"/>.
+/// ECS component that holds an opaque integer key into a mesh registry.
+/// Attach to an entity alongside <see cref="Transform3D"/> and <see cref="Material3D"/>
+/// to participate in 3D rendering.
 /// </summary>
 public readonly record struct MeshHandle(int Id);

--- a/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
+++ b/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
@@ -10,7 +10,7 @@ namespace Yaeger.Rendering;
 public sealed class GpuMeshRegistry(GL gl) : IDisposable
 {
     private readonly Dictionary<int, GpuMesh> _meshes = new();
-    private int _nextId;
+    private int _nextId = 1; // 0 is reserved so default(MeshHandle) is always invalid
 
     /// <summary>Uploads <paramref name="data"/> to the GPU and returns a typed handle.</summary>
     public MeshHandle Register(MeshData data)

--- a/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
+++ b/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
@@ -1,0 +1,31 @@
+using Silk.NET.OpenGL;
+
+namespace Yaeger.Rendering;
+
+/// <summary>
+/// Manages GPU-side mesh lifetimes and provides integer-keyed lookups for use with
+/// the <see cref="Yaeger.Graphics.MeshHandle"/> ECS component.
+/// </summary>
+public sealed class GpuMeshRegistry(GL gl) : IDisposable
+{
+    private readonly Dictionary<int, GpuMesh> _meshes = new();
+    private int _nextId;
+
+    /// <summary>Uploads <paramref name="data"/> to the GPU and returns an opaque handle ID.</summary>
+    public int Register(MeshData data)
+    {
+        var id = _nextId++;
+        _meshes[id] = new GpuMesh(gl, data);
+        return id;
+    }
+
+    /// <summary>Looks up the mesh for the given handle ID.</summary>
+    public bool TryGet(int id, out GpuMesh mesh) => _meshes.TryGetValue(id, out mesh!);
+
+    public void Dispose()
+    {
+        foreach (var mesh in _meshes.Values)
+            mesh.Dispose();
+        _meshes.Clear();
+    }
+}

--- a/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
+++ b/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
@@ -1,4 +1,5 @@
 using Silk.NET.OpenGL;
+using Yaeger.Graphics;
 
 namespace Yaeger.Rendering;
 

--- a/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
+++ b/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
@@ -11,16 +11,17 @@ public sealed class GpuMeshRegistry(GL gl) : IDisposable
     private readonly Dictionary<int, GpuMesh> _meshes = new();
     private int _nextId;
 
-    /// <summary>Uploads <paramref name="data"/> to the GPU and returns an opaque handle ID.</summary>
-    public int Register(MeshData data)
+    /// <summary>Uploads <paramref name="data"/> to the GPU and returns a typed handle.</summary>
+    public MeshHandle Register(MeshData data)
     {
-        var id = _nextId++;
-        _meshes[id] = new GpuMesh(gl, data);
-        return id;
+        var handle = new MeshHandle(_nextId++);
+        _meshes[handle.Id] = new GpuMesh(gl, data);
+        return handle;
     }
 
-    /// <summary>Looks up the mesh for the given handle ID.</summary>
-    public bool TryGet(int id, out GpuMesh mesh) => _meshes.TryGetValue(id, out mesh!);
+    /// <summary>Looks up the mesh for the given handle.</summary>
+    public bool TryGet(MeshHandle handle, out GpuMesh mesh) =>
+        _meshes.TryGetValue(handle.Id, out mesh!);
 
     public void Dispose()
     {

--- a/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
+++ b/src/Engine/Yaeger/Rendering/GpuMeshRegistry.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Silk.NET.OpenGL;
 using Yaeger.Graphics;
 
@@ -21,8 +22,8 @@ public sealed class GpuMeshRegistry(GL gl) : IDisposable
     }
 
     /// <summary>Looks up the mesh for the given handle.</summary>
-    public bool TryGet(MeshHandle handle, out GpuMesh mesh) =>
-        _meshes.TryGetValue(handle.Id, out mesh!);
+    public bool TryGet(MeshHandle handle, [NotNullWhen(true)] out GpuMesh? mesh) =>
+        _meshes.TryGetValue(handle.Id, out mesh);
 
     public void Dispose()
     {

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -10,9 +10,6 @@ namespace Yaeger.Rendering;
 /// </summary>
 public sealed class Renderer3D : IDisposable
 {
-    // uNormalMatrix and the normal/fragpos varyings are intentionally omitted until
-    // lighting is added in the follow-up issue; keeping them here would cause drivers
-    // to optimise them away, making uNormalMatrix inactive and throwing at runtime.
     private const string VertexShaderSource = """
         #version 330 core
         layout(location = 0) in vec3 aPosition;
@@ -21,18 +18,26 @@ public sealed class Renderer3D : IDisposable
 
         uniform mat4 uModel;
         uniform mat4 uViewProj;
+        uniform mat3 uNormalMatrix;
 
+        out vec3 vNormal;
         out vec2 vTexCoord;
+        out vec3 vFragPos;
 
         void main() {
-            vTexCoord   = aTexCoord;
-            gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+            vec4 worldPos = uModel * vec4(aPosition, 1.0);
+            vFragPos  = worldPos.xyz;
+            vNormal   = uNormalMatrix * aNormal;
+            vTexCoord = aTexCoord;
+            gl_Position = uViewProj * worldPos;
         }
         """;
 
     private const string FragmentShaderSource = """
         #version 330 core
+        in  vec3 vNormal;
         in  vec2 vTexCoord;
+        in  vec3 vFragPos;
         out vec4 FragColor;
 
         uniform sampler2D uDiffuse;
@@ -40,6 +45,10 @@ public sealed class Renderer3D : IDisposable
 
         void main() {
             FragColor = texture(uDiffuse, vTexCoord) * uDiffuseColor;
+            // vNormal and vFragPos are read here so the driver keeps uNormalMatrix
+            // active; the contribution is sub-precision and invisible at 8-bit display.
+            // Full lighting is wired in issue #78.
+            FragColor.rgb += (vNormal + vFragPos) * 0.000001;
         }
         """;
 
@@ -90,6 +99,11 @@ public sealed class Renderer3D : IDisposable
 
         _shader.SetUniformMatrix4("uModel", model);
         _shader.SetUniformMatrix4("uViewProj", viewProj);
+
+        if (!Matrix4x4.Invert(model, out var invModel))
+            invModel = Matrix4x4.Identity;
+        _shader.SetUniformMatrix3("uNormalMatrix", Matrix4x4.Transpose(invModel));
+
         _shader.SetUniformVec4("uDiffuseColor", material.Diffuse.ToVector4());
 
         if (!string.IsNullOrEmpty(material.DiffuseTexturePath))

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -44,10 +44,12 @@ public sealed class Renderer3D : IDisposable
         uniform vec4      uDiffuseColor;
 
         void main() {
-            // Guard against degenerate inputs; keeps vNormal/vFragPos (and therefore
-            // uNormalMatrix) active without affecting the unlit output. Lighting in #78.
-            if (any(isnan(vNormal)) || any(isnan(vFragPos))) discard;
-            FragColor = texture(uDiffuse, vTexCoord) * uDiffuseColor;
+            // sign(dot(v,v)+1) == 1.0 for all finite inputs, so the multiply is a
+            // no-op on output but references vNormal/vFragPos, keeping uNormalMatrix
+            // active without discard (which would disable early-Z). Lighting in #78.
+            float n = sign(dot(vNormal, vNormal) + 1.0);
+            float f = sign(dot(vFragPos, vFragPos) + 1.0);
+            FragColor = texture(uDiffuse, vTexCoord) * uDiffuseColor * n * f;
         }
         """;
 

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -1,0 +1,157 @@
+using System.Numerics;
+using Silk.NET.OpenGL;
+using Yaeger.Graphics;
+
+namespace Yaeger.Rendering;
+
+/// <summary>
+/// Renders 3D meshes with MVP transforms, depth testing, and back-face culling.
+/// Independent of the 2D <see cref="Renderer"/> pipeline.
+/// </summary>
+public sealed class Renderer3D : IDisposable
+{
+    private const string VertexShaderSource = """
+        #version 330 core
+        layout(location = 0) in vec3 aPosition;
+        layout(location = 1) in vec3 aNormal;
+        layout(location = 2) in vec2 aTexCoord;
+
+        uniform mat4 uModel;
+        uniform mat4 uViewProj;
+        uniform mat3 uNormalMatrix;
+
+        out vec3 vNormal;
+        out vec2 vTexCoord;
+        out vec3 vFragPos;
+
+        void main() {
+            vec4 worldPos = uModel * vec4(aPosition, 1.0);
+            vFragPos  = worldPos.xyz;
+            vNormal   = uNormalMatrix * aNormal;
+            vTexCoord = aTexCoord;
+            gl_Position = uViewProj * worldPos;
+        }
+        """;
+
+    private const string FragmentShaderSource = """
+        #version 330 core
+        in  vec3 vNormal;
+        in  vec2 vTexCoord;
+        in  vec3 vFragPos;
+        out vec4 FragColor;
+
+        uniform sampler2D uDiffuse;
+        uniform vec4      uDiffuseColor;
+
+        void main() {
+            FragColor = texture(uDiffuse, vTexCoord) * uDiffuseColor;
+        }
+        """;
+
+    private readonly GL _gl;
+    private readonly Shader _shader;
+    private readonly uint _defaultTexture;
+
+    public Renderer3D(GL gl)
+    {
+        _gl = gl;
+        _shader = new Shader(gl, VertexShaderSource, FragmentShaderSource);
+        _defaultTexture = CreateWhiteTexture();
+    }
+
+    /// <summary>
+    /// Enables depth testing and back-face culling, and clears the depth buffer.
+    /// Call once at the start of the 3D pass each frame.
+    /// </summary>
+    public void BeginFrame3D()
+    {
+        _gl.Enable(EnableCap.DepthTest);
+        _gl.DepthFunc(DepthFunction.Less);
+        _gl.Enable(EnableCap.CullFace);
+        _gl.CullFace(TriangleFace.Back);
+        _gl.Clear((uint)ClearBufferMask.DepthBufferBit);
+    }
+
+    /// <summary>
+    /// Disables depth testing and back-face culling so the 2D pipeline is unaffected.
+    /// Call once at the end of the 3D pass each frame.
+    /// </summary>
+    public void EndFrame3D()
+    {
+        _gl.Disable(EnableCap.DepthTest);
+        _gl.Disable(EnableCap.CullFace);
+    }
+
+    /// <summary>Draws a single mesh with the supplied transform and material.</summary>
+    public void Draw(
+        GpuMesh mesh,
+        Matrix4x4 model,
+        Matrix4x4 viewProj,
+        Material3D material,
+        TextureManager textures
+    )
+    {
+        _shader.Bind();
+
+        _shader.SetUniformMatrix4("uModel", model);
+        _shader.SetUniformMatrix4("uViewProj", viewProj);
+
+        // Normal matrix = transpose(inverse(model)), uploaded as upper-left mat3.
+        if (!Matrix4x4.Invert(model, out var invModel))
+            invModel = Matrix4x4.Identity;
+        _shader.SetUniformMatrix3("uNormalMatrix", Matrix4x4.Transpose(invModel));
+
+        _shader.SetUniformVec4("uDiffuseColor", material.Diffuse.ToVector4());
+
+        if (!string.IsNullOrEmpty(material.DiffuseTexturePath))
+            textures.Get(material.DiffuseTexturePath).Bind(TextureUnit.Texture0);
+        else
+        {
+            _gl.ActiveTexture(TextureUnit.Texture0);
+            _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
+        }
+
+        mesh.Draw();
+
+        _shader.Unbind();
+    }
+
+    private unsafe uint CreateWhiteTexture()
+    {
+        var handle = _gl.GenTexture();
+        _gl.BindTexture(TextureTarget.Texture2D, handle);
+        byte[] white = [255, 255, 255, 255];
+        fixed (byte* ptr = white)
+        {
+            _gl.TexImage2D(
+                TextureTarget.Texture2D,
+                0,
+                (int)InternalFormat.Rgba,
+                1,
+                1,
+                0,
+                PixelFormat.Rgba,
+                PixelType.UnsignedByte,
+                ptr
+            );
+        }
+        _gl.TexParameter(
+            TextureTarget.Texture2D,
+            TextureParameterName.TextureMinFilter,
+            (int)TextureMinFilter.Nearest
+        );
+        _gl.TexParameter(
+            TextureTarget.Texture2D,
+            TextureParameterName.TextureMagFilter,
+            (int)TextureMagFilter.Nearest
+        );
+        _gl.BindTexture(TextureTarget.Texture2D, 0);
+        return handle;
+    }
+
+    public void Dispose()
+    {
+        _shader.Dispose();
+        _gl.DeleteTexture(_defaultTexture);
+    }
+}

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -10,6 +10,9 @@ namespace Yaeger.Rendering;
 /// </summary>
 public sealed class Renderer3D : IDisposable
 {
+    // uNormalMatrix and the normal/fragpos varyings are intentionally omitted until
+    // lighting is added in the follow-up issue; keeping them here would cause drivers
+    // to optimise them away, making uNormalMatrix inactive and throwing at runtime.
     private const string VertexShaderSource = """
         #version 330 core
         layout(location = 0) in vec3 aPosition;
@@ -18,26 +21,18 @@ public sealed class Renderer3D : IDisposable
 
         uniform mat4 uModel;
         uniform mat4 uViewProj;
-        uniform mat3 uNormalMatrix;
 
-        out vec3 vNormal;
         out vec2 vTexCoord;
-        out vec3 vFragPos;
 
         void main() {
-            vec4 worldPos = uModel * vec4(aPosition, 1.0);
-            vFragPos  = worldPos.xyz;
-            vNormal   = uNormalMatrix * aNormal;
-            vTexCoord = aTexCoord;
-            gl_Position = uViewProj * worldPos;
+            vTexCoord   = aTexCoord;
+            gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
         }
         """;
 
     private const string FragmentShaderSource = """
         #version 330 core
-        in  vec3 vNormal;
         in  vec2 vTexCoord;
-        in  vec3 vFragPos;
         out vec4 FragColor;
 
         uniform sampler2D uDiffuse;
@@ -95,12 +90,6 @@ public sealed class Renderer3D : IDisposable
 
         _shader.SetUniformMatrix4("uModel", model);
         _shader.SetUniformMatrix4("uViewProj", viewProj);
-
-        // Normal matrix = transpose(inverse(model)), uploaded as upper-left mat3.
-        if (!Matrix4x4.Invert(model, out var invModel))
-            invModel = Matrix4x4.Identity;
-        _shader.SetUniformMatrix3("uNormalMatrix", Matrix4x4.Transpose(invModel));
-
         _shader.SetUniformVec4("uDiffuseColor", material.Diffuse.ToVector4());
 
         if (!string.IsNullOrEmpty(material.DiffuseTexturePath))

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -44,11 +44,10 @@ public sealed class Renderer3D : IDisposable
         uniform vec4      uDiffuseColor;
 
         void main() {
+            // Guard against degenerate inputs; keeps vNormal/vFragPos (and therefore
+            // uNormalMatrix) active without affecting the unlit output. Lighting in #78.
+            if (any(isnan(vNormal)) || any(isnan(vFragPos))) discard;
             FragColor = texture(uDiffuse, vTexCoord) * uDiffuseColor;
-            // vNormal and vFragPos are read here so the driver keeps uNormalMatrix
-            // active; the contribution is sub-precision and invisible at 8-bit display.
-            // Full lighting is wired in issue #78.
-            FragColor.rgb += (vNormal + vFragPos) * 0.000001;
         }
         """;
 

--- a/src/Engine/Yaeger/Rendering/Shader.cs
+++ b/src/Engine/Yaeger/Rendering/Shader.cs
@@ -90,9 +90,19 @@ public class Shader : IDisposable
     public unsafe void SetUniformMatrix3(string name, Matrix4x4 m)
     {
         var location = GetUniformLocation(name);
-        float[] mat3 = [m.M11, m.M12, m.M13, m.M21, m.M22, m.M23, m.M31, m.M32, m.M33];
-        fixed (float* ptr = mat3)
-            _gl.UniformMatrix3(location, 1, false, ptr);
+        float* mat3 = stackalloc float[]
+        {
+            m.M11,
+            m.M12,
+            m.M13,
+            m.M21,
+            m.M22,
+            m.M23,
+            m.M31,
+            m.M32,
+            m.M33,
+        };
+        _gl.UniformMatrix3(location, 1, false, mat3);
     }
 
     public void Dispose() => _gl.DeleteProgram(_program);

--- a/src/Engine/Yaeger/Rendering/Shader.cs
+++ b/src/Engine/Yaeger/Rendering/Shader.cs
@@ -90,18 +90,7 @@ public class Shader : IDisposable
     public unsafe void SetUniformMatrix3(string name, Matrix4x4 m)
     {
         var location = GetUniformLocation(name);
-        float[] mat3 =
-        [
-            m.M11,
-            m.M12,
-            m.M13,
-            m.M21,
-            m.M22,
-            m.M23,
-            m.M31,
-            m.M32,
-            m.M33,
-        ];
+        float[] mat3 = [m.M11, m.M12, m.M13, m.M21, m.M22, m.M23, m.M31, m.M32, m.M33];
         fixed (float* ptr = mat3)
             _gl.UniformMatrix3(location, 1, false, ptr);
     }

--- a/src/Engine/Yaeger/Rendering/Shader.cs
+++ b/src/Engine/Yaeger/Rendering/Shader.cs
@@ -87,20 +87,20 @@ public class Shader : IDisposable
         _gl.Uniform1(location, value);
     }
 
-    public unsafe void SetUniformMatrix3(string name, Matrix4x4 m)
+    public unsafe void SetUniformMatrix3(string name, Matrix4x4 matrix)
     {
         var location = GetUniformLocation(name);
         float* mat3 = stackalloc float[]
         {
-            m.M11,
-            m.M12,
-            m.M13,
-            m.M21,
-            m.M22,
-            m.M23,
-            m.M31,
-            m.M32,
-            m.M33,
+            matrix.M11,
+            matrix.M12,
+            matrix.M13,
+            matrix.M21,
+            matrix.M22,
+            matrix.M23,
+            matrix.M31,
+            matrix.M32,
+            matrix.M33,
         };
         _gl.UniformMatrix3(location, 1, false, mat3);
     }

--- a/src/Engine/Yaeger/Rendering/Shader.cs
+++ b/src/Engine/Yaeger/Rendering/Shader.cs
@@ -75,5 +75,36 @@ public class Shader : IDisposable
         _gl.Uniform4(location, value.X, value.Y, value.Z, value.W);
     }
 
+    public void SetUniformVec3(string name, Vector3 value)
+    {
+        var location = GetUniformLocation(name);
+        _gl.Uniform3(location, value.X, value.Y, value.Z);
+    }
+
+    public void SetUniformFloat(string name, float value)
+    {
+        var location = GetUniformLocation(name);
+        _gl.Uniform1(location, value);
+    }
+
+    public unsafe void SetUniformMatrix3(string name, Matrix4x4 m)
+    {
+        var location = GetUniformLocation(name);
+        float[] mat3 =
+        [
+            m.M11,
+            m.M12,
+            m.M13,
+            m.M21,
+            m.M22,
+            m.M23,
+            m.M31,
+            m.M32,
+            m.M33,
+        ];
+        fixed (float* ptr = mat3)
+            _gl.UniformMatrix3(location, 1, false, ptr);
+    }
+
     public void Dispose() => _gl.DeleteProgram(_program);
 }

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -26,7 +26,7 @@ public class MeshRenderSystem(
 
         foreach (
             (
-                Entity entity,
+                _,
                 MeshHandle handle,
                 Transform3D transform,
                 Material3D material

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -25,12 +25,11 @@ public class MeshRenderSystem(
         renderer.BeginFrame3D();
 
         foreach (
-            (
-                _,
-                MeshHandle handle,
-                Transform3D transform,
-                Material3D material
-            ) in world.Query<MeshHandle, Transform3D, Material3D>()
+            (_, MeshHandle handle, Transform3D transform, Material3D material) in world.Query<
+                MeshHandle,
+                Transform3D,
+                Material3D
+            >()
         )
         {
             if (!meshRegistry.TryGet(handle, out var mesh))

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -9,6 +9,7 @@ namespace Yaeger.Systems;
 /// <summary>
 /// Queries ECS entities with <see cref="MeshHandle"/>, <see cref="Transform3D"/>, and
 /// <see cref="Material3D"/> components and issues draw calls via <see cref="Renderer3D"/>.
+/// Wire this to <see cref="Window.OnRender"/>, not <see cref="Window.OnUpdate"/>.
 /// </summary>
 public class MeshRenderSystem(
     Renderer3D renderer,
@@ -16,9 +17,9 @@ public class MeshRenderSystem(
     TextureManager textureManager,
     World world,
     Window window
-) : IUpdateSystem
+)
 {
-    public void Update(float deltaTime)
+    public void Render()
     {
         var viewProj = GetViewProjection();
 

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -32,7 +32,7 @@ public class MeshRenderSystem(
             >()
         )
         {
-            if (!meshRegistry.TryGet(handle.Id, out var mesh))
+            if (!meshRegistry.TryGet(handle, out var mesh))
                 continue;
 
             renderer.Draw(mesh, transform.ModelMatrix, viewProj, material, textureManager);

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -25,11 +25,12 @@ public class MeshRenderSystem(
         renderer.BeginFrame3D();
 
         foreach (
-            (Entity entity, MeshHandle handle, Transform3D transform, Material3D material) in world.Query<
-                MeshHandle,
-                Transform3D,
-                Material3D
-            >()
+            (
+                Entity entity,
+                MeshHandle handle,
+                Transform3D transform,
+                Material3D material
+            ) in world.Query<MeshHandle, Transform3D, Material3D>()
         )
         {
             if (!meshRegistry.TryGet(handle, out var mesh))

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -1,0 +1,55 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Rendering;
+using Yaeger.Windowing;
+
+namespace Yaeger.Systems;
+
+/// <summary>
+/// Queries ECS entities with <see cref="MeshHandle"/>, <see cref="Transform3D"/>, and
+/// <see cref="Material3D"/> components and issues draw calls via <see cref="Renderer3D"/>.
+/// </summary>
+public class MeshRenderSystem(
+    Renderer3D renderer,
+    GpuMeshRegistry meshRegistry,
+    TextureManager textureManager,
+    World world,
+    Window window
+) : IUpdateSystem
+{
+    public void Update(float deltaTime)
+    {
+        var viewProj = GetViewProjection();
+
+        renderer.BeginFrame3D();
+
+        foreach (
+            (Entity entity, MeshHandle handle, Transform3D transform, Material3D material) in world.Query<
+                MeshHandle,
+                Transform3D,
+                Material3D
+            >()
+        )
+        {
+            if (!meshRegistry.TryGet(handle.Id, out var mesh))
+                continue;
+
+            renderer.Draw(mesh, transform.ModelMatrix, viewProj, material, textureManager);
+        }
+
+        renderer.EndFrame3D();
+    }
+
+    private Matrix4x4 GetViewProjection()
+    {
+        foreach (var (_, camera) in world.GetStore<Camera3D>().All())
+        {
+            var size = window.Size;
+            var aspectRatio = size.Y > 0f ? size.X / size.Y : 1f;
+            return camera.ViewProjection(aspectRatio);
+        }
+
+        return Matrix4x4.Identity;
+    }
+}

--- a/src/Engine/Yaeger/TypeForwarders.cs
+++ b/src/Engine/Yaeger/TypeForwarders.cs
@@ -33,6 +33,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Camera3D))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Color))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Material3D))]
+[assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.MeshHandle))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.RenderLayer))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Sprite))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.SpriteSheet))]

--- a/tests/Yaeger.Tests/Graphics/MeshHandleTests.cs
+++ b/tests/Yaeger.Tests/Graphics/MeshHandleTests.cs
@@ -1,0 +1,57 @@
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Graphics;
+
+public class MeshHandleTests
+{
+    [Fact]
+    public void IsStruct_SatisfiesEcsConstraint()
+    {
+        Assert.True(typeof(MeshHandle).IsValueType);
+    }
+
+    [Fact]
+    public void Constructor_SetsId()
+    {
+        var handle = new MeshHandle(42);
+
+        Assert.Equal(42, handle.Id);
+    }
+
+    [Fact]
+    public void Default_HasIdZero()
+    {
+        var handle = default(MeshHandle);
+
+        Assert.Equal(0, handle.Id);
+    }
+
+    [Fact]
+    public void Equality_SameId_AreEqual()
+    {
+        var a = new MeshHandle(7);
+        var b = new MeshHandle(7);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Equality_DifferentId_AreNotEqual()
+    {
+        var a = new MeshHandle(1);
+        var b = new MeshHandle(2);
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void With_ProducesNewHandleWithUpdatedId()
+    {
+        var original = new MeshHandle(3);
+
+        var updated = original with { Id = 99 };
+
+        Assert.Equal(99, updated.Id);
+        Assert.Equal(3, original.Id);
+    }
+}


### PR DESCRIPTION
Implements GitHub issue #77:

- Extend Shader with SetUniformVec3, SetUniformFloat, SetUniformMatrix3
  (mat3 uploaded as upper-left 3×3 of a Matrix4x4)
- Add MeshHandle struct ECS component (int Id key into GpuMeshRegistry)
- Add GpuMeshRegistry: maps int handles to GpuMesh lifetimes
- Add Renderer3D: owns the 3D GLSL shader, manages depth test / back-face
  cull state via BeginFrame3D/EndFrame3D, computes normal matrix on CPU
  (transpose(inverse(model))) and issues draw calls
- Add MeshRenderSystem (IUpdateSystem): queries (MeshHandle, Transform3D,
  Material3D), finds the active Camera3D for view-projection, calls
  Renderer3D.Draw per entity
- 2D pipeline (UnifiedRenderSystem / Renderer) is untouched; depth test
  is scoped to the 3D pass via explicit GL state transitions
- Forward MeshHandle via TypeForwarders.cs for Yaeger.Core compatibility

https://claude.ai/code/session_01R2pi5v9EvR5UdmrLrpYDnp