### PR TITLE
Add Blinn-Phong lighting with DirectionalLight component (#78)

### DIFF
--- a/src/Engine/Yaeger/Graphics/DirectionalLight.cs
+++ b/src/Engine/Yaeger/Graphics/DirectionalLight.cs
@@ -4,7 +4,7 @@ namespace Yaeger.Graphics;
 
 public record struct DirectionalLight
 {
-    public Vector3 Direction; // normalised; points *toward* the light (not from surface)
+    public Vector3 Direction; // normalised; points from the fragment toward the light source
     public Color Color;
     public float Intensity;
 }

--- a/src/Engine/Yaeger/Graphics/DirectionalLight.cs
+++ b/src/Engine/Yaeger/Graphics/DirectionalLight.cs
@@ -4,7 +4,7 @@ namespace Yaeger.Graphics;
 
 public record struct DirectionalLight
 {
-    public Vector3 Direction; // normalised; points from the fragment toward the light source
+    public Vector3 Direction; // points from the fragment toward the light source; need not be pre-normalised
     public Color Color;
     public float Intensity;
 }

--- a/src/Engine/Yaeger/Graphics/DirectionalLight.cs
+++ b/src/Engine/Yaeger/Graphics/DirectionalLight.cs
@@ -7,4 +7,12 @@ public record struct DirectionalLight
     public Vector3 Direction; // points from the fragment toward the light source; need not be pre-normalised
     public Color Color;
     public float Intensity;
+
+    public static DirectionalLight Default =>
+        new()
+        {
+            Direction = Vector3.UnitY,
+            Color = Color.White,
+            Intensity = 1f,
+        };
 }

--- a/src/Engine/Yaeger/Graphics/DirectionalLight.cs
+++ b/src/Engine/Yaeger/Graphics/DirectionalLight.cs
@@ -1,0 +1,10 @@
+using System.Numerics;
+
+namespace Yaeger.Graphics;
+
+public record struct DirectionalLight
+{
+    public Vector3 Direction; // normalised; points *toward* the light (not from surface)
+    public Color Color;
+    public float Intensity;
+}

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -81,15 +81,7 @@ public sealed class Renderer3D : IDisposable
         _gl = gl;
         _shader = new Shader(gl, VertexShaderSource, FragmentShaderSource);
         _defaultTexture = CreateWhiteTexture();
-        SetSceneLighting(
-            new DirectionalLight
-            {
-                Direction = Vector3.UnitY,
-                Color = Color.White,
-                Intensity = 1f,
-            },
-            Vector3.Zero
-        );
+        SetSceneLighting(DirectionalLight.Default, Vector3.Zero);
     }
 
     /// <summary>
@@ -120,14 +112,13 @@ public sealed class Renderer3D : IDisposable
     /// </summary>
     public void SetSceneLighting(DirectionalLight light, Vector3 cameraPos)
     {
-        var dir =
-            light.Direction.LengthSquared() > 0f
-                ? Vector3.Normalize(light.Direction)
-                : Vector3.UnitY;
+        var lenSq = light.Direction.LengthSquared();
+        var dir = float.IsFinite(lenSq) && lenSq > 0f ? Vector3.Normalize(light.Direction) : Vector3.UnitY;
+        var intensity = float.IsFinite(light.Intensity) ? MathF.Max(light.Intensity, 0f) : 0f;
         _shader.Bind();
         _shader.SetUniformVec3("uLightDir", dir);
         _shader.SetUniformVec4("uLightColor", light.Color.ToVector4());
-        _shader.SetUniformFloat("uLightIntensity", light.Intensity);
+        _shader.SetUniformFloat("uLightIntensity", intensity);
         _shader.SetUniformVec3("uCameraPos", cameraPos);
         _shader.Unbind();
     }

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -54,8 +54,10 @@ public sealed class Renderer3D : IDisposable
         void main() {
             vec3 N = normalize(vNormal);
             vec3 L = normalize(uLightDir);
-            vec3 V = normalize(uCameraPos - vFragPos);
-            vec3 H = normalize(L + V);
+            vec3 viewDir = uCameraPos - vFragPos;
+            vec3 V = viewDir * inversesqrt(max(dot(viewDir, viewDir), 1e-10));
+            vec3 halfDir = L + V;
+            vec3 H = halfDir * inversesqrt(max(dot(halfDir, halfDir), 1e-10));
 
             vec4 texColor = texture(uDiffuse, vTexCoord) * uDiffuseColor;
 
@@ -118,6 +120,7 @@ public sealed class Renderer3D : IDisposable
         _shader.SetUniformVec4("uLightColor", light.Color.ToVector4());
         _shader.SetUniformFloat("uLightIntensity", light.Intensity);
         _shader.SetUniformVec3("uCameraPos", cameraPos);
+        _shader.Unbind();
     }
 
     /// <summary>Draws a single mesh with the supplied transform and material.</summary>

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -109,8 +109,12 @@ public sealed class Renderer3D : IDisposable
     /// </summary>
     public void SetSceneLighting(DirectionalLight light, Vector3 cameraPos)
     {
+        var dir =
+            light.Direction.LengthSquared() > 0f
+                ? Vector3.Normalize(light.Direction)
+                : Vector3.UnitY;
         _shader.Bind();
-        _shader.SetUniformVec3("uLightDir", light.Direction);
+        _shader.SetUniformVec3("uLightDir", dir);
         _shader.SetUniformVec4("uLightColor", light.Color.ToVector4());
         _shader.SetUniformFloat("uLightIntensity", light.Intensity);
         _shader.SetUniformVec3("uCameraPos", cameraPos);

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -59,12 +59,13 @@ public sealed class Renderer3D : IDisposable
             vec3 halfDir = L + V;
             vec3 H = halfDir * inversesqrt(max(dot(halfDir, halfDir), 1e-10));
 
-            vec4 texColor = texture(uDiffuse, vTexCoord) * uDiffuseColor;
+            vec4 rawTex   = texture(uDiffuse, vTexCoord);
+            vec4 texColor = rawTex * uDiffuseColor;
 
             float diff = max(dot(N, L), 0.0);
             float spec = diff > 0.0 ? pow(max(dot(N, H), 0.0), uShininess) : 0.0;
 
-            vec3 ambient  = (uAmbientColor  * texColor).rgb;
+            vec3 ambient  = (uAmbientColor * rawTex).rgb;
             vec3 diffuse  = texColor.rgb     * diff * uLightColor.rgb * uLightIntensity;
             vec3 specular = uSpecularColor.rgb * spec * uLightColor.rgb * uLightIntensity;
 

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -82,7 +82,12 @@ public sealed class Renderer3D : IDisposable
         _shader = new Shader(gl, VertexShaderSource, FragmentShaderSource);
         _defaultTexture = CreateWhiteTexture();
         SetSceneLighting(
-            new DirectionalLight { Direction = Vector3.UnitY, Color = Color.White, Intensity = 1f },
+            new DirectionalLight
+            {
+                Direction = Vector3.UnitY,
+                Color = Color.White,
+                Intensity = 1f,
+            },
             Vector3.Zero
         );
     }

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -81,6 +81,10 @@ public sealed class Renderer3D : IDisposable
         _gl = gl;
         _shader = new Shader(gl, VertexShaderSource, FragmentShaderSource);
         _defaultTexture = CreateWhiteTexture();
+        SetSceneLighting(
+            new DirectionalLight { Direction = Vector3.UnitY, Color = Color.White, Intensity = 1f },
+            Vector3.Zero
+        );
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -62,11 +62,11 @@ public sealed class Renderer3D : IDisposable
             float diff = max(dot(N, L), 0.0);
             float spec = diff > 0.0 ? pow(max(dot(N, H), 0.0), uShininess) : 0.0;
 
-            vec4 ambient  = uAmbientColor  * texColor;
-            vec4 diffuse  = texColor       * diff     * uLightColor * uLightIntensity;
-            vec4 specular = uSpecularColor * spec     * uLightColor * uLightIntensity;
+            vec3 ambient  = (uAmbientColor  * texColor).rgb;
+            vec3 diffuse  = texColor.rgb     * diff * uLightColor.rgb * uLightIntensity;
+            vec3 specular = uSpecularColor.rgb * spec * uLightColor.rgb * uLightIntensity;
 
-            FragColor = ambient + diffuse + specular;
+            FragColor = vec4(ambient + diffuse + specular, texColor.a);
         }
         """;
 

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -114,7 +114,9 @@ public sealed class Renderer3D : IDisposable
     {
         var lenSq = light.Direction.LengthSquared();
         var dir =
-            float.IsFinite(lenSq) && lenSq > 0f ? Vector3.Normalize(light.Direction) : Vector3.UnitY;
+            float.IsFinite(lenSq) && lenSq > 0f
+                ? Vector3.Normalize(light.Direction)
+                : Vector3.UnitY;
         var intensity = float.IsFinite(light.Intensity) ? MathF.Max(light.Intensity, 0f) : 0f;
         _shader.Bind();
         _shader.SetUniformVec3("uLightDir", dir);

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -113,7 +113,8 @@ public sealed class Renderer3D : IDisposable
     public void SetSceneLighting(DirectionalLight light, Vector3 cameraPos)
     {
         var lenSq = light.Direction.LengthSquared();
-        var dir = float.IsFinite(lenSq) && lenSq > 0f ? Vector3.Normalize(light.Direction) : Vector3.UnitY;
+        var dir =
+            float.IsFinite(lenSq) && lenSq > 0f ? Vector3.Normalize(light.Direction) : Vector3.UnitY;
         var intensity = float.IsFinite(light.Intensity) ? MathF.Max(light.Intensity, 0f) : 0f;
         _shader.Bind();
         _shader.SetUniformVec3("uLightDir", dir);

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -148,7 +148,10 @@ public sealed class Renderer3D : IDisposable
         _shader.SetUniformVec4("uDiffuseColor", material.Diffuse.ToVector4());
         _shader.SetUniformVec4("uAmbientColor", material.Ambient.ToVector4());
         _shader.SetUniformVec4("uSpecularColor", material.Specular.ToVector4());
-        _shader.SetUniformFloat("uShininess", MathF.Max(material.Shininess, 1f));
+        _shader.SetUniformFloat(
+            "uShininess",
+            float.IsFinite(material.Shininess) ? MathF.Max(material.Shininess, 1f) : 1f
+        );
 
         if (!string.IsNullOrEmpty(material.DiffuseTexturePath))
             textures.Get(material.DiffuseTexturePath).Bind(TextureUnit.Texture0);

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -41,15 +41,32 @@ public sealed class Renderer3D : IDisposable
         out vec4 FragColor;
 
         uniform sampler2D uDiffuse;
-        uniform vec4      uDiffuseColor;
+        uniform vec4  uDiffuseColor;
+        uniform vec4  uAmbientColor;
+        uniform vec4  uSpecularColor;
+        uniform float uShininess;
+
+        uniform vec3  uLightDir;
+        uniform vec4  uLightColor;
+        uniform float uLightIntensity;
+        uniform vec3  uCameraPos;
 
         void main() {
-            // sign(dot(v,v)+1) == 1.0 for all finite inputs, so the multiply is a
-            // no-op on output but references vNormal/vFragPos, keeping uNormalMatrix
-            // active without discard (which would disable early-Z). Lighting in #78.
-            float n = sign(dot(vNormal, vNormal) + 1.0);
-            float f = sign(dot(vFragPos, vFragPos) + 1.0);
-            FragColor = texture(uDiffuse, vTexCoord) * uDiffuseColor * n * f;
+            vec3 N = normalize(vNormal);
+            vec3 L = normalize(uLightDir);
+            vec3 V = normalize(uCameraPos - vFragPos);
+            vec3 H = normalize(L + V);
+
+            vec4 texColor = texture(uDiffuse, vTexCoord) * uDiffuseColor;
+
+            float diff = max(dot(N, L), 0.0);
+            float spec = pow(max(dot(N, H), 0.0), uShininess);
+
+            vec4 ambient  = uAmbientColor  * texColor;
+            vec4 diffuse  = uDiffuseColor  * texColor  * diff * uLightColor * uLightIntensity;
+            vec4 specular = uSpecularColor             * spec * uLightColor * uLightIntensity;
+
+            FragColor = ambient + diffuse + specular;
         }
         """;
 
@@ -87,6 +104,18 @@ public sealed class Renderer3D : IDisposable
         _gl.Disable(EnableCap.CullFace);
     }
 
+    /// <summary>
+    /// Uploads scene-wide lighting uniforms. Call once per frame before the draw loop.
+    /// </summary>
+    public void SetSceneLighting(DirectionalLight light, Vector3 cameraPos)
+    {
+        _shader.Bind();
+        _shader.SetUniformVec3("uLightDir", light.Direction);
+        _shader.SetUniformVec4("uLightColor", light.Color.ToVector4());
+        _shader.SetUniformFloat("uLightIntensity", light.Intensity);
+        _shader.SetUniformVec3("uCameraPos", cameraPos);
+    }
+
     /// <summary>Draws a single mesh with the supplied transform and material.</summary>
     public void Draw(
         GpuMesh mesh,
@@ -106,6 +135,9 @@ public sealed class Renderer3D : IDisposable
         _shader.SetUniformMatrix3("uNormalMatrix", Matrix4x4.Transpose(invModel));
 
         _shader.SetUniformVec4("uDiffuseColor", material.Diffuse.ToVector4());
+        _shader.SetUniformVec4("uAmbientColor", material.Ambient.ToVector4());
+        _shader.SetUniformVec4("uSpecularColor", material.Specular.ToVector4());
+        _shader.SetUniformFloat("uShininess", MathF.Max(material.Shininess, 1f));
 
         if (!string.IsNullOrEmpty(material.DiffuseTexturePath))
             textures.Get(material.DiffuseTexturePath).Bind(TextureUnit.Texture0);

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -60,11 +60,11 @@ public sealed class Renderer3D : IDisposable
             vec4 texColor = texture(uDiffuse, vTexCoord) * uDiffuseColor;
 
             float diff = max(dot(N, L), 0.0);
-            float spec = pow(max(dot(N, H), 0.0), uShininess);
+            float spec = diff > 0.0 ? pow(max(dot(N, H), 0.0), uShininess) : 0.0;
 
             vec4 ambient  = uAmbientColor  * texColor;
-            vec4 diffuse  = uDiffuseColor  * texColor  * diff * uLightColor * uLightIntensity;
-            vec4 specular = uSpecularColor             * spec * uLightColor * uLightIntensity;
+            vec4 diffuse  = texColor       * diff     * uLightColor * uLightIntensity;
+            vec4 specular = uSpecularColor * spec     * uLightColor * uLightIntensity;
 
             FragColor = ambient + diffuse + specular;
         }

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -59,7 +59,7 @@ public class MeshRenderSystem(
     private static readonly DirectionalLight DefaultLight = new()
     {
         Direction = Vector3.UnitY,
-        Color = new Color(255, 255, 255),
+        Color = Color.White,
         Intensity = 1f,
     };
 

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -21,9 +21,11 @@ public class MeshRenderSystem(
 {
     public void Render()
     {
-        var viewProj = GetViewProjection();
+        var (viewProj, cameraPos) = GetViewProjectionAndPosition();
+        var light = GetDirectionalLight();
 
         renderer.BeginFrame3D();
+        renderer.SetSceneLighting(light, cameraPos);
 
         foreach (
             (_, MeshHandle handle, Transform3D transform, Material3D material) in world.Query<
@@ -42,15 +44,30 @@ public class MeshRenderSystem(
         renderer.EndFrame3D();
     }
 
-    private Matrix4x4 GetViewProjection()
+    private (Matrix4x4 ViewProj, Vector3 CameraPos) GetViewProjectionAndPosition()
     {
         foreach (var (_, camera) in world.GetStore<Camera3D>().All())
         {
             var size = window.Size;
             var aspectRatio = size.Y > 0f ? size.X / size.Y : 1f;
-            return camera.ViewProjection(aspectRatio);
+            return (camera.ViewProjection(aspectRatio), camera.Position);
         }
 
-        return Matrix4x4.Identity;
+        return (Matrix4x4.Identity, Vector3.Zero);
+    }
+
+    private static readonly DirectionalLight DefaultLight = new()
+    {
+        Direction = Vector3.UnitY,
+        Color = new Color(255, 255, 255),
+        Intensity = 1f,
+    };
+
+    private DirectionalLight GetDirectionalLight()
+    {
+        foreach (var (_, light) in world.GetStore<DirectionalLight>().All())
+            return light;
+
+        return DefaultLight;
     }
 }

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -56,12 +56,7 @@ public class MeshRenderSystem(
         return (Matrix4x4.Identity, Vector3.Zero);
     }
 
-    private static readonly DirectionalLight DefaultLight = new()
-    {
-        Direction = Vector3.UnitY,
-        Color = Color.White,
-        Intensity = 1f,
-    };
+    private static readonly DirectionalLight DefaultLight = DirectionalLight.Default;
 
     private DirectionalLight GetDirectionalLight()
     {

--- a/src/Engine/Yaeger/TypeForwarders.cs
+++ b/src/Engine/Yaeger/TypeForwarders.cs
@@ -32,6 +32,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Camera2D))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Camera3D))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Color))]
+[assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.DirectionalLight))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Material3D))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.MeshHandle))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.RenderLayer))]

--- a/tests/Yaeger.Tests/Graphics/DirectionalLightTests.cs
+++ b/tests/Yaeger.Tests/Graphics/DirectionalLightTests.cs
@@ -53,4 +53,14 @@ public class DirectionalLightTests
 
         Assert.NotEqual(a, b);
     }
+
+    [Fact]
+    public void Default_HasSafeValues()
+    {
+        var light = DirectionalLight.Default;
+
+        Assert.Equal(Vector3.UnitY, light.Direction);
+        Assert.Equal(Color.White, light.Color);
+        Assert.Equal(1f, light.Intensity);
+    }
 }

--- a/tests/Yaeger.Tests/Graphics/DirectionalLightTests.cs
+++ b/tests/Yaeger.Tests/Graphics/DirectionalLightTests.cs
@@ -1,0 +1,56 @@
+using System.Numerics;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Graphics;
+
+public class DirectionalLightTests
+{
+    [Fact]
+    public void IsStruct_SatisfiesEcsConstraint()
+    {
+        Assert.True(typeof(DirectionalLight).IsValueType);
+    }
+
+    [Fact]
+    public void Default_HasZeroFields()
+    {
+        var light = default(DirectionalLight);
+
+        Assert.Equal(Vector3.Zero, light.Direction);
+        Assert.Equal(default(Color), light.Color);
+        Assert.Equal(0f, light.Intensity);
+    }
+
+    [Fact]
+    public void RecordStruct_EqualityByValue()
+    {
+        var a = new DirectionalLight
+        {
+            Direction = new Vector3(0f, -1f, 0f),
+            Color = new Color(255, 255, 255),
+            Intensity = 1f,
+        };
+        var b = new DirectionalLight
+        {
+            Direction = new Vector3(0f, -1f, 0f),
+            Color = new Color(255, 255, 255),
+            Intensity = 1f,
+        };
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void DifferentIntensity_NotEqual()
+    {
+        var a = new DirectionalLight
+        {
+            Direction = Vector3.UnitY,
+            Color = Color.White,
+            Intensity = 1f,
+        };
+        var b = a with { Intensity = 0.5f };
+
+        Assert.NotEqual(a, b);
+    }
+}

--- a/tests/Yaeger.Tests/Graphics/DirectionalLightTests.cs
+++ b/tests/Yaeger.Tests/Graphics/DirectionalLightTests.cs
@@ -12,7 +12,7 @@ public class DirectionalLightTests
     }
 
     [Fact]
-    public void Default_HasZeroFields()
+    public void StructDefault_HasZeroFields()
     {
         var light = default(DirectionalLight);
 


### PR DESCRIPTION
- Add `DirectionalLight` record struct (Direction, Color, Intensity) to Graphics/
- Replace unlit fragment shader in Renderer3D with Blinn-Phong (ambient + diffuse + specular)
- Add `Renderer3D.SetSceneLighting()` to upload scene-wide uniforms (uLightDir, uLightColor, uLightIntensity, uCameraPos) once per frame
- Update `Draw()` to upload per-material uniforms (uAmbientColor, uSpecularColor, uShininess clamped to ≥1)
- Update `MeshRenderSystem` to query the first DirectionalLight entity, fall back to a default white overhead light, and expose camera position for specular highlights
- Add DirectionalLightTests covering ECS struct constraint, defaults, and value equality

https://claude.ai/code/session_01P7HziRrg5dAZqv2YMWHmwT