### PR TITLE
Add Sponza sample: FreeFlySystem, asset fetch target, CI exclusion

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,12 +21,12 @@ jobs:
       with:
         dotnet-version: 10.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore yaeger.slnf
     - name: Restore tools
       run: dotnet tool restore
     - name: Check formatting
       run: dotnet csharpier check .
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build yaeger.slnf --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test yaeger.slnf --no-build --verbosity normal

--- a/.gitignore
+++ b/.gitignore
@@ -507,3 +507,7 @@ fabric.properties
 
 # Custom additions to .gitignore
 .idea/
+
+# Sponza sample — fetched at build time, not committed
+Samples/Sponza/Assets/Sponza/
+Samples/Sponza/_sponza-fetch/

--- a/Samples/Sponza/FreeFlySystem.cs
+++ b/Samples/Sponza/FreeFlySystem.cs
@@ -16,33 +16,6 @@ internal sealed class FreeFlySystem(World world, Entity cameraEntity) : IUpdateS
         if (!world.TryGetComponent<Camera3D>(cameraEntity, out var camera))
             return;
 
-        var forward = Vector3.Normalize(camera.Target - camera.Position);
-        var right = Vector3.Normalize(Vector3.Cross(forward, camera.Up));
-
-        var move = Vector3.Zero;
-        if (Keyboard.IsKeyPressed(Keys.W))
-            move += forward;
-        if (Keyboard.IsKeyPressed(Keys.S))
-            move -= forward;
-        if (Keyboard.IsKeyPressed(Keys.A))
-            move -= right;
-        if (Keyboard.IsKeyPressed(Keys.D))
-            move += right;
-        if (Keyboard.IsKeyPressed(Keys.E))
-            move += Vector3.UnitY;
-        if (Keyboard.IsKeyPressed(Keys.Q))
-            move -= Vector3.UnitY;
-
-        if (move != Vector3.Zero)
-        {
-            var displacement = Vector3.Normalize(move) * MoveSpeed * deltaTime;
-            camera = camera with
-            {
-                Position = camera.Position + displacement,
-                Target = camera.Target + displacement,
-            };
-        }
-
         if (Mouse.IsButtonPressed(MouseButton.Right))
         {
             var delta = Mouse.PositionDelta;
@@ -70,6 +43,33 @@ internal sealed class FreeFlySystem(World world, Entity cameraEntity) : IUpdateS
 
                 camera = camera with { Target = camera.Position + fwd };
             }
+        }
+
+        var forward = Vector3.Normalize(camera.Target - camera.Position);
+        var right = Vector3.Normalize(Vector3.Cross(forward, camera.Up));
+
+        var move = Vector3.Zero;
+        if (Keyboard.IsKeyPressed(Keys.W))
+            move += forward;
+        if (Keyboard.IsKeyPressed(Keys.S))
+            move -= forward;
+        if (Keyboard.IsKeyPressed(Keys.A))
+            move -= right;
+        if (Keyboard.IsKeyPressed(Keys.D))
+            move += right;
+        if (Keyboard.IsKeyPressed(Keys.E))
+            move += Vector3.UnitY;
+        if (Keyboard.IsKeyPressed(Keys.Q))
+            move -= Vector3.UnitY;
+
+        if (move != Vector3.Zero)
+        {
+            var displacement = Vector3.Normalize(move) * MoveSpeed * deltaTime;
+            camera = camera with
+            {
+                Position = camera.Position + displacement,
+                Target = camera.Target + displacement,
+            };
         }
 
         world.AddComponent(cameraEntity, camera);

--- a/Samples/Sponza/FreeFlySystem.cs
+++ b/Samples/Sponza/FreeFlySystem.cs
@@ -1,0 +1,75 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Input;
+using Yaeger.Systems;
+
+namespace Sponza;
+
+internal sealed class FreeFlySystem(World world, Entity cameraEntity) : IUpdateSystem
+{
+    private const float MoveSpeed = 10f;
+    private const float LookSensitivity = 0.003f;
+
+    public void Update(float deltaTime)
+    {
+        if (!world.TryGetComponent<Camera3D>(cameraEntity, out var camera))
+            return;
+
+        var forward = Vector3.Normalize(camera.Target - camera.Position);
+        var right = Vector3.Normalize(Vector3.Cross(forward, camera.Up));
+
+        var move = Vector3.Zero;
+        if (Keyboard.IsKeyPressed(Keys.W))
+            move += forward;
+        if (Keyboard.IsKeyPressed(Keys.S))
+            move -= forward;
+        if (Keyboard.IsKeyPressed(Keys.A))
+            move -= right;
+        if (Keyboard.IsKeyPressed(Keys.D))
+            move += right;
+        if (Keyboard.IsKeyPressed(Keys.E))
+            move += Vector3.UnitY;
+        if (Keyboard.IsKeyPressed(Keys.Q))
+            move -= Vector3.UnitY;
+
+        if (move != Vector3.Zero)
+        {
+            var displacement = Vector3.Normalize(move) * MoveSpeed * deltaTime;
+            camera = camera with
+            {
+                Position = camera.Position + displacement,
+                Target = camera.Target + displacement,
+            };
+        }
+
+        if (Mouse.IsButtonPressed(MouseButton.Right))
+        {
+            var delta = Mouse.PositionDelta;
+            if (delta.LengthSquared() > 0f)
+            {
+                var yaw = -delta.X * LookSensitivity;
+                var pitch = -delta.Y * LookSensitivity;
+
+                var fwd = Vector3.Normalize(camera.Target - camera.Position);
+                var r = Vector3.Normalize(Vector3.Cross(fwd, camera.Up));
+
+                // Yaw around world Y axis
+                fwd = Vector3.Normalize(
+                    Vector3.TransformNormal(fwd, Matrix4x4.CreateFromAxisAngle(Vector3.UnitY, yaw))
+                );
+
+                // Pitch around local right axis; reject if result points nearly straight up/down
+                var pitched = Vector3.Normalize(
+                    Vector3.TransformNormal(fwd, Matrix4x4.CreateFromAxisAngle(r, pitch))
+                );
+                if (MathF.Abs(pitched.Y) < 0.999f)
+                    fwd = pitched;
+
+                camera = camera with { Target = camera.Position + fwd };
+            }
+        }
+
+        world.AddComponent(cameraEntity, camera);
+    }
+}

--- a/Samples/Sponza/FreeFlySystem.cs
+++ b/Samples/Sponza/FreeFlySystem.cs
@@ -52,12 +52,14 @@ internal sealed class FreeFlySystem(World world, Entity cameraEntity) : IUpdateS
                 var pitch = -delta.Y * LookSensitivity;
 
                 var fwd = Vector3.Normalize(camera.Target - camera.Position);
-                var r = Vector3.Normalize(Vector3.Cross(fwd, camera.Up));
 
                 // Yaw around world Y axis
                 fwd = Vector3.Normalize(
                     Vector3.TransformNormal(fwd, Matrix4x4.CreateFromAxisAngle(Vector3.UnitY, yaw))
                 );
+
+                // Recompute right axis after yaw so pitch is applied to post-yaw orientation
+                var r = Vector3.Normalize(Vector3.Cross(fwd, camera.Up));
 
                 // Pitch around local right axis; reject if result points nearly straight up/down
                 var pitched = Vector3.Normalize(

--- a/Samples/Sponza/Program.cs
+++ b/Samples/Sponza/Program.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Sponza;
 using Yaeger;
 using Yaeger.Assets;
 using Yaeger.ECS;
@@ -9,9 +10,9 @@ using Yaeger.Systems;
 using Yaeger.Windowing;
 
 // Sponza demo — loads the Intel/KhronosGroup Sponza glTF via AssimpLoader.
-// Place the model at Assets/Sponza/Sponza.gltf (download from KhronosGroup/glTF-Sample-Assets).
+// Assets are fetched automatically on first build via the FetchSponzaAssets MSBuild target.
 // Requires native libassimp at runtime (e.g. apt install libassimp-dev on Linux).
-// Press ESC to exit.
+// Controls: WASD move, Q/E up/down, right-mouse-drag look, ESC exit.
 
 var modelPath = AssetPath.Resolve("Assets/Sponza/Sponza.gltf");
 
@@ -19,7 +20,7 @@ if (!File.Exists(modelPath))
 {
     Console.Error.WriteLine(
         $"Model not found: {modelPath}\n"
-            + "Download from https://github.com/KhronosGroup/glTF-Sample-Assets and place it at that path."
+            + "Run 'dotnet build' outside CI to fetch assets automatically."
     );
     return;
 }
@@ -62,7 +63,7 @@ world.AddComponent(
     lightEntity,
     new DirectionalLight
     {
-        Direction = Vector3.Normalize(new Vector3(-1f, -1f, -1f)),
+        Direction = Vector3.Normalize(new Vector3(0.4f, -1f, 0.3f)),
         Color = Color.White,
         Intensity = 1f,
     }
@@ -70,9 +71,11 @@ world.AddComponent(
 
 using var renderer3D = new Renderer3D(window.Gl);
 var meshRenderSystem = new MeshRenderSystem(renderer3D, registry, textures, world, window);
+var freeFlySystem = new FreeFlySystem(world, cameraEntity);
 
 Keyboard.AddKeyDown(Keys.Escape, window.Close);
 
+window.OnUpdate += deltaTime => freeFlySystem.Update((float)deltaTime);
 window.OnRender += _ => meshRenderSystem.Render();
 
 window.Run();

--- a/Samples/Sponza/Sponza.csproj
+++ b/Samples/Sponza/Sponza.csproj
@@ -54,6 +54,10 @@
 
     <MakeDir Directories="$(_SponzaDir)" Condition="!Exists('$(_SponzaDir)')" />
     <Copy SourceFiles="@(_SponzaFiles)" DestinationFolder="$(_SponzaDir)/%(RecursiveDir)" />
+    <Copy
+      SourceFiles="@(_SponzaFiles)"
+      DestinationFolder="$(TargetDir)Assets/Sponza/%(RecursiveDir)"
+    />
     <Message Text="Sponza assets ready at $(_SponzaDir)" Importance="high" />
   </Target>
 </Project>

--- a/Samples/Sponza/Sponza.csproj
+++ b/Samples/Sponza/Sponza.csproj
@@ -24,16 +24,21 @@
     Skipped in CI (CI env var is set automatically by GitHub Actions).
     Assets land in Assets/Sponza/ and are copied to the output directory by the rule above.
   -->
-  <Target Name="FetchSponzaAssets" BeforeTargets="Build" Condition="'$(CI)' != 'true'">
+  <Target
+    Name="FetchSponzaAssets"
+    BeforeTargets="Build"
+    Condition="'$(CI)' != 'true' And !Exists('$(MSBuildProjectDirectory)/Assets/Sponza/Sponza.gltf')"
+  >
     <PropertyGroup>
       <_SponzaDir>$(MSBuildProjectDirectory)/Assets/Sponza</_SponzaDir>
       <_SponzaFetchDir>$(MSBuildProjectDirectory)/_sponza-fetch</_SponzaFetchDir>
     </PropertyGroup>
 
-    <!-- Clone with sparse checkout only when the fetch cache does not yet exist -->
+    <!-- Clone with sparse shallow checkout only when the fetch cache does not yet exist -->
     <Exec
-      Command="git clone --filter=blob:none --no-checkout --sparse https://github.com/KhronosGroup/glTF-Sample-Assets.git &quot;$(_SponzaFetchDir)&quot; &amp;&amp; git -C &quot;$(_SponzaFetchDir)&quot; sparse-checkout set Models/Sponza/glTF &amp;&amp; git -C &quot;$(_SponzaFetchDir)&quot; checkout"
-      Condition="!Exists('$(_SponzaFetchDir)')" />
+      Command="git clone --filter=blob:none --no-checkout --sparse --depth=1 https://github.com/KhronosGroup/glTF-Sample-Assets.git &quot;$(_SponzaFetchDir)&quot; &amp;&amp; git -C &quot;$(_SponzaFetchDir)&quot; sparse-checkout set Models/Sponza/glTF &amp;&amp; git -C &quot;$(_SponzaFetchDir)&quot; checkout"
+      Condition="!Exists('$(_SponzaFetchDir)')"
+    />
 
     <!-- Collect files after the clone so the glob finds them -->
     <ItemGroup>
@@ -41,14 +46,7 @@
     </ItemGroup>
 
     <MakeDir Directories="$(_SponzaDir)" Condition="!Exists('$(_SponzaDir)')" />
-    <Copy
-      SourceFiles="@(_SponzaFiles)"
-      DestinationFolder="$(_SponzaDir)/%(RecursiveDir)"
-      Condition="!Exists('$(_SponzaDir)/Sponza.gltf')" />
-
-    <Message
-      Text="Sponza assets ready at $(_SponzaDir)"
-      Importance="high"
-      Condition="Exists('$(_SponzaDir)/Sponza.gltf')" />
+    <Copy SourceFiles="@(_SponzaFiles)" DestinationFolder="$(_SponzaDir)/%(RecursiveDir)" />
+    <Message Text="Sponza assets ready at $(_SponzaDir)" Importance="high" />
   </Target>
 </Project>

--- a/Samples/Sponza/Sponza.csproj
+++ b/Samples/Sponza/Sponza.csproj
@@ -22,7 +22,8 @@
   <!--
     Fetch the KhronosGroup Sponza assets on first build using git sparse-checkout.
     Skipped in CI (CI env var is set automatically by GitHub Actions).
-    Assets land in Assets/Sponza/ and are copied to the output directory by the rule above.
+    On first build the target copies directly to $(TargetDir); on subsequent builds
+    the <None Update="Assets\**"> rule above handles the output copy.
   -->
   <Target
     Name="FetchSponzaAssets"

--- a/Samples/Sponza/Sponza.csproj
+++ b/Samples/Sponza/Sponza.csproj
@@ -32,7 +32,14 @@
     <PropertyGroup>
       <_SponzaDir>$(MSBuildProjectDirectory)/Assets/Sponza</_SponzaDir>
       <_SponzaFetchDir>$(MSBuildProjectDirectory)/_sponza-fetch</_SponzaFetchDir>
+      <_SponzaGltfFetchPath>$(_SponzaFetchDir)/Models/Sponza/glTF/Sponza.gltf</_SponzaGltfFetchPath>
     </PropertyGroup>
+
+    <!-- Remove an incomplete fetch cache so the clone is retried on the next build -->
+    <RemoveDir
+      Directories="$(_SponzaFetchDir)"
+      Condition="Exists('$(_SponzaFetchDir)') And !Exists('$(_SponzaGltfFetchPath)')"
+    />
 
     <!-- Clone with sparse shallow checkout only when the fetch cache does not yet exist -->
     <Exec

--- a/Samples/Sponza/Sponza.csproj
+++ b/Samples/Sponza/Sponza.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RootNamespace>Sponza</RootNamespace>
     <!-- Requires native libassimp at runtime. On Linux: apt install libassimp-dev -->
     <!-- On Windows/macOS: place the native binary alongside the executable. -->
   </PropertyGroup>
@@ -17,4 +18,37 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <!--
+    Fetch the KhronosGroup Sponza assets on first build using git sparse-checkout.
+    Skipped in CI (CI env var is set automatically by GitHub Actions).
+    Assets land in Assets/Sponza/ and are copied to the output directory by the rule above.
+  -->
+  <Target Name="FetchSponzaAssets" BeforeTargets="Build" Condition="'$(CI)' != 'true'">
+    <PropertyGroup>
+      <_SponzaDir>$(MSBuildProjectDirectory)/Assets/Sponza</_SponzaDir>
+      <_SponzaFetchDir>$(MSBuildProjectDirectory)/_sponza-fetch</_SponzaFetchDir>
+    </PropertyGroup>
+
+    <!-- Clone with sparse checkout only when the fetch cache does not yet exist -->
+    <Exec
+      Command="git clone --filter=blob:none --no-checkout --sparse https://github.com/KhronosGroup/glTF-Sample-Assets.git &quot;$(_SponzaFetchDir)&quot; &amp;&amp; git -C &quot;$(_SponzaFetchDir)&quot; sparse-checkout set Models/Sponza/glTF &amp;&amp; git -C &quot;$(_SponzaFetchDir)&quot; checkout"
+      Condition="!Exists('$(_SponzaFetchDir)')" />
+
+    <!-- Collect files after the clone so the glob finds them -->
+    <ItemGroup>
+      <_SponzaFiles Include="$(_SponzaFetchDir)/Models/Sponza/glTF/**/*" />
+    </ItemGroup>
+
+    <MakeDir Directories="$(_SponzaDir)" Condition="!Exists('$(_SponzaDir)')" />
+    <Copy
+      SourceFiles="@(_SponzaFiles)"
+      DestinationFolder="$(_SponzaDir)/%(RecursiveDir)"
+      Condition="!Exists('$(_SponzaDir)/Sponza.gltf')" />
+
+    <Message
+      Text="Sponza assets ready at $(_SponzaDir)"
+      Importance="high"
+      Condition="Exists('$(_SponzaDir)/Sponza.gltf')" />
+  </Target>
 </Project>

--- a/Samples/Sponza/Sponza.csproj
+++ b/Samples/Sponza/Sponza.csproj
@@ -58,6 +58,7 @@
       SourceFiles="@(_SponzaFiles)"
       DestinationFolder="$(TargetDir)Assets/Sponza/%(RecursiveDir)"
     />
+    <RemoveDir Directories="$(_SponzaFetchDir)" />
     <Message Text="Sponza assets ready at $(_SponzaDir)" Importance="high" />
   </Target>
 </Project>

--- a/yaeger.slnf
+++ b/yaeger.slnf
@@ -1,0 +1,20 @@
+{
+  "solution": {
+    "path": "yaeger.sln",
+    "projects": [
+      "src\\Engine\\Yaeger\\Yaeger.csproj",
+      "src\\Engine\\Yaeger.Core\\Yaeger.Core.csproj",
+      "src\\Engine\\Yaeger.Browser\\Yaeger.Browser.csproj",
+      "tests\\Yaeger.Tests\\Yaeger.Tests.csproj",
+      "Samples\\Pong\\Pong.csproj",
+      "Samples\\RenderingStressTest\\RenderingStressTest.csproj",
+      "Samples\\TextRenderingExample\\TextRenderingExample.csproj",
+      "Samples\\BouncingBalls\\BouncingBalls.csproj",
+      "Samples\\Animation2D\\Animation2D.csproj",
+      "Samples\\CameraDemo\\CameraDemo.csproj",
+      "Samples\\MouseDemo\\MouseDemo.csproj",
+      "Samples\\SceneDemo\\SceneDemo.csproj",
+      "Samples\\BrowserDemo\\BrowserDemo.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
- FreeFlySystem: WASD move, Q/E up/down, right-mouse-drag look with
  pitch clamping to prevent gimbal lock at poles
- Sponza.csproj: FetchSponzaAssets MSBuild target clones KhronosGroup/
  glTF-Sample-Assets via git sparse-checkout on first build; skipped when
  CI=true (set automatically by GitHub Actions)
- yaeger.slnf: solution filter that excludes Sponza; CI build/test/restore
  commands now target this filter so assets are never fetched in CI
- Program.cs: wire OnUpdate → FreeFlySystem, fix light direction to
  (0.4, -1, 0.3) as specified in issue
- .gitignore: ignore Samples/Sponza/Assets/Sponza/ and _sponza-fetch/

Closes #79

https://claude.ai/code/session_01AeUokTxwGyUBVR8FVSU1ow