### PR TITLE
Implement normal map support for 3D rendering (issue #80)

### DIFF
--- a/src/Engine/Yaeger/Assets/MtlLoader.cs
+++ b/src/Engine/Yaeger/Assets/MtlLoader.cs
@@ -19,6 +19,7 @@ public static class MtlLoader
 
         string? currentName = null;
         string? diffuseTexturePath = null;
+        string? normalTexturePath = null;
         Color ambientColor = Color.Black;
         Color diffuseColor = Color.White;
         Color specularColor = Color.Black;
@@ -31,6 +32,7 @@ public static class MtlLoader
             materials[currentName] = new MtlMaterial(
                 currentName,
                 diffuseTexturePath,
+                normalTexturePath,
                 ambientColor,
                 diffuseColor,
                 specularColor,
@@ -64,6 +66,7 @@ public static class MtlLoader
                         );
                     currentName = rest;
                     diffuseTexturePath = null;
+                    normalTexturePath = null;
                     ambientColor = Color.Black;
                     diffuseColor = Color.White;
                     specularColor = Color.Black;
@@ -103,6 +106,15 @@ public static class MtlLoader
                             "MTL 'map_Kd' directive appears before any 'newmtl'."
                         );
                     diffuseTexturePath = rest;
+                    break;
+                case "map_bump":
+                case "bump":
+                case "norm":
+                    if (currentName is null)
+                        throw new FormatException(
+                            $"MTL '{keyword}' directive appears before any 'newmtl'."
+                        );
+                    normalTexturePath = rest;
                     break;
             }
         }

--- a/src/Engine/Yaeger/Assets/MtlMaterial.cs
+++ b/src/Engine/Yaeger/Assets/MtlMaterial.cs
@@ -5,6 +5,7 @@ namespace Yaeger.Assets;
 public record MtlMaterial(
     string Name,
     string? DiffuseTexturePath,
+    string? NormalTexturePath,
     Color AmbientColor,
     Color DiffuseColor,
     Color SpecularColor,

--- a/src/Engine/Yaeger/Assets/ObjLoader.cs
+++ b/src/Engine/Yaeger/Assets/ObjLoader.cs
@@ -44,7 +44,7 @@ public static class ObjLoader
                 return;
             var meshData = new MeshData(
                 currentName,
-                currentVertices.ToArray(),
+                ComputeTangents(currentVertices, currentIndices),
                 currentIndices.ToArray()
             );
             meshes.Add(new ObjMesh(currentName, meshData, currentMaterial));
@@ -201,6 +201,51 @@ public static class ObjLoader
             meshes.AsReadOnly(),
             new ReadOnlyDictionary<string, MtlMaterial>(materials)
         );
+    }
+
+    private static Vertex3D[] ComputeTangents(List<Vertex3D> vertices, List<uint> indices)
+    {
+        var tangents = new Vector3[vertices.Count];
+
+        for (var i = 0; i < indices.Count; i += 3)
+        {
+            var i0 = (int)indices[i];
+            var i1 = (int)indices[i + 1];
+            var i2 = (int)indices[i + 2];
+
+            var v0 = vertices[i0];
+            var v1 = vertices[i1];
+            var v2 = vertices[i2];
+
+            var edge1 = v1.Position - v0.Position;
+            var edge2 = v2.Position - v0.Position;
+            var deltaUv1 = v1.TexCoord - v0.TexCoord;
+            var deltaUv2 = v2.TexCoord - v0.TexCoord;
+
+            var denom = deltaUv1.X * deltaUv2.Y - deltaUv2.X * deltaUv1.Y;
+            var f = MathF.Abs(denom) > 1e-7f ? 1.0f / denom : 0f;
+
+            var tangent = new Vector3(
+                f * (deltaUv2.Y * edge1.X - deltaUv1.Y * edge2.X),
+                f * (deltaUv2.Y * edge1.Y - deltaUv1.Y * edge2.Y),
+                f * (deltaUv2.Y * edge1.Z - deltaUv1.Y * edge2.Z)
+            );
+
+            tangents[i0] += tangent;
+            tangents[i1] += tangent;
+            tangents[i2] += tangent;
+        }
+
+        var result = new Vertex3D[vertices.Count];
+        for (var i = 0; i < vertices.Count; i++)
+        {
+            var t = tangents[i];
+            var normalized = t.LengthSquared() > 1e-7f ? Vector3.Normalize(t) : Vector3.UnitX;
+            var v = vertices[i];
+            result[i] = new Vertex3D(v.Position, v.Normal, v.TexCoord, normalized);
+        }
+
+        return result;
     }
 
     private static readonly char[] s_whitespace = [' ', '\t'];

--- a/src/Engine/Yaeger/Graphics/Material3D.cs
+++ b/src/Engine/Yaeger/Graphics/Material3D.cs
@@ -5,6 +5,7 @@ namespace Yaeger.Graphics;
 public record struct Material3D
 {
     public string DiffuseTexturePath;
+    public string? NormalTexturePath;
     public Color Ambient;
     public Color Diffuse;
     public Color Specular;
@@ -14,6 +15,7 @@ public record struct Material3D
         new()
         {
             DiffuseTexturePath = mtl.DiffuseTexturePath ?? string.Empty,
+            NormalTexturePath = mtl.NormalTexturePath,
             Ambient = mtl.AmbientColor,
             Diffuse = mtl.DiffuseColor,
             Specular = mtl.SpecularColor,
@@ -24,6 +26,7 @@ public record struct Material3D
         new()
         {
             DiffuseTexturePath = model.DiffuseTexturePath ?? string.Empty,
+            NormalTexturePath = model.NormalTexturePath,
             Ambient = Color.Black,
             Diffuse = model.DiffuseColor,
             Specular = Color.Black,

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -61,12 +61,19 @@ public sealed class Renderer3D : IDisposable
             vec3 N = normalize(vNormal);
 
             if (uHasNormalMap != 0) {
-                vec3 T = normalize(vTangent);
-                T = normalize(T - dot(T, N) * N);
-                vec3 B = cross(N, T);
-                mat3 TBN = mat3(T, B, N);
-                vec3 sampledN = texture(uNormalMap, vTexCoord).rgb * 2.0 - 1.0;
-                N = normalize(TBN * sampledN);
+                float tLenSq = dot(vTangent, vTangent);
+                if (tLenSq > 1e-10) {
+                    vec3 T = vTangent * inversesqrt(tLenSq);
+                    vec3 Tproj = T - dot(T, N) * N;
+                    float projLenSq = dot(Tproj, Tproj);
+                    if (projLenSq > 1e-10) {
+                        vec3 Tn = Tproj * inversesqrt(projLenSq);
+                        vec3 B = cross(N, Tn);
+                        mat3 TBN = mat3(Tn, B, N);
+                        vec3 sampledN = texture(uNormalMap, vTexCoord).rgb * 2.0 - 1.0;
+                        N = normalize(TBN * sampledN);
+                    }
+                }
             }
 
             vec3 L = normalize(uLightDir);

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -15,6 +15,7 @@ public sealed class Renderer3D : IDisposable
         layout(location = 0) in vec3 aPosition;
         layout(location = 1) in vec3 aNormal;
         layout(location = 2) in vec2 aTexCoord;
+        layout(location = 3) in vec3 aTangent;
 
         uniform mat4 uModel;
         uniform mat4 uViewProj;
@@ -23,11 +24,13 @@ public sealed class Renderer3D : IDisposable
         out vec3 vNormal;
         out vec2 vTexCoord;
         out vec3 vFragPos;
+        out vec3 vTangent;
 
         void main() {
             vec4 worldPos = uModel * vec4(aPosition, 1.0);
             vFragPos  = worldPos.xyz;
             vNormal   = uNormalMatrix * aNormal;
+            vTangent  = uNormalMatrix * aTangent;
             vTexCoord = aTexCoord;
             gl_Position = uViewProj * worldPos;
         }
@@ -38,9 +41,12 @@ public sealed class Renderer3D : IDisposable
         in  vec3 vNormal;
         in  vec2 vTexCoord;
         in  vec3 vFragPos;
+        in  vec3 vTangent;
         out vec4 FragColor;
 
         uniform sampler2D uDiffuse;
+        uniform sampler2D uNormalMap;
+        uniform int       uHasNormalMap;
         uniform vec4  uDiffuseColor;
         uniform vec4  uAmbientColor;
         uniform vec4  uSpecularColor;
@@ -53,6 +59,16 @@ public sealed class Renderer3D : IDisposable
 
         void main() {
             vec3 N = normalize(vNormal);
+
+            if (uHasNormalMap != 0) {
+                vec3 T = normalize(vTangent);
+                T = normalize(T - dot(T, N) * N);
+                vec3 B = cross(N, T);
+                mat3 TBN = mat3(T, B, N);
+                vec3 sampledN = texture(uNormalMap, vTexCoord).rgb * 2.0 - 1.0;
+                N = normalize(TBN * sampledN);
+            }
+
             vec3 L = normalize(uLightDir);
             vec3 viewDir = uCameraPos - vFragPos;
             vec3 V = viewDir * inversesqrt(max(dot(viewDir, viewDir), 1e-10));
@@ -76,12 +92,14 @@ public sealed class Renderer3D : IDisposable
     private readonly GL _gl;
     private readonly Shader _shader;
     private readonly uint _defaultTexture;
+    private readonly uint _defaultNormalTexture;
 
     public Renderer3D(GL gl)
     {
         _gl = gl;
         _shader = new Shader(gl, VertexShaderSource, FragmentShaderSource);
         _defaultTexture = CreateWhiteTexture();
+        _defaultNormalTexture = CreateFlatNormalTexture();
         SetSceneLighting(DirectionalLight.Default, Vector3.Zero);
     }
 
@@ -161,6 +179,22 @@ public sealed class Renderer3D : IDisposable
             _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
         }
 
+        _shader.SetUniformInt("uDiffuse", 0);
+
+        if (!string.IsNullOrEmpty(material.NormalTexturePath))
+        {
+            textures.Get(material.NormalTexturePath).Bind(TextureUnit.Texture1);
+            _shader.SetUniformInt("uHasNormalMap", 1);
+        }
+        else
+        {
+            _gl.ActiveTexture(TextureUnit.Texture1);
+            _gl.BindTexture(TextureTarget.Texture2D, _defaultNormalTexture);
+            _shader.SetUniformInt("uHasNormalMap", 0);
+        }
+
+        _shader.SetUniformInt("uNormalMap", 1);
+
         mesh.Draw();
 
         _shader.Unbind();
@@ -199,9 +233,44 @@ public sealed class Renderer3D : IDisposable
         return handle;
     }
 
+    // Flat normal map: (0.5, 0.5, 1.0) encodes tangent-space normal pointing straight up.
+    private unsafe uint CreateFlatNormalTexture()
+    {
+        var handle = _gl.GenTexture();
+        _gl.BindTexture(TextureTarget.Texture2D, handle);
+        byte[] flatNormal = [128, 128, 255, 255];
+        fixed (byte* ptr = flatNormal)
+        {
+            _gl.TexImage2D(
+                TextureTarget.Texture2D,
+                0,
+                (int)InternalFormat.Rgba,
+                1,
+                1,
+                0,
+                PixelFormat.Rgba,
+                PixelType.UnsignedByte,
+                ptr
+            );
+        }
+        _gl.TexParameter(
+            TextureTarget.Texture2D,
+            TextureParameterName.TextureMinFilter,
+            (int)TextureMinFilter.Nearest
+        );
+        _gl.TexParameter(
+            TextureTarget.Texture2D,
+            TextureParameterName.TextureMagFilter,
+            (int)TextureMagFilter.Nearest
+        );
+        _gl.BindTexture(TextureTarget.Texture2D, 0);
+        return handle;
+    }
+
     public void Dispose()
     {
         _shader.Dispose();
         _gl.DeleteTexture(_defaultTexture);
+        _gl.DeleteTexture(_defaultNormalTexture);
     }
 }

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -30,7 +30,7 @@ public sealed class Renderer3D : IDisposable
             vec4 worldPos = uModel * vec4(aPosition, 1.0);
             vFragPos  = worldPos.xyz;
             vNormal   = uNormalMatrix * aNormal;
-            vTangent  = uNormalMatrix * aTangent;
+            vTangent  = mat3(uModel) * aTangent;
             vTexCoord = aTexCoord;
             gl_Position = uViewProj * worldPos;
         }

--- a/src/Engine/Yaeger/Rendering/Shader.cs
+++ b/src/Engine/Yaeger/Rendering/Shader.cs
@@ -87,6 +87,12 @@ public class Shader : IDisposable
         _gl.Uniform1(location, value);
     }
 
+    public void SetUniformInt(string name, int value)
+    {
+        var location = GetUniformLocation(name);
+        _gl.Uniform1(location, value);
+    }
+
     public unsafe void SetUniformMatrix3(string name, Matrix4x4 matrix)
     {
         var location = GetUniformLocation(name);

--- a/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/MtlLoaderTests.cs
@@ -220,4 +220,114 @@ public class MtlLoaderTests
             File.Delete(path);
         }
     }
+
+    [Fact]
+    public void Load_NoNormalMap_ShouldHaveNullNormalTexturePath()
+    {
+        var mtl = """
+            newmtl plain
+            Kd 0.5 0.5 0.5
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Null(materials["plain"].NormalTexturePath);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_MapBump_ShouldSetNormalTexturePath()
+    {
+        var mtl = """
+            newmtl bumped
+            map_Kd textures/wall.png
+            map_bump textures/wall_normal.png
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Equal("textures/wall_normal.png", materials["bumped"].NormalTexturePath);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_BumpDirective_ShouldSetNormalTexturePath()
+    {
+        var mtl = """
+            newmtl bumped
+            bump textures/wall_normal.png
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Equal("textures/wall_normal.png", materials["bumped"].NormalTexturePath);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_NormDirective_ShouldSetNormalTexturePath()
+    {
+        var mtl = """
+            newmtl bumped
+            norm textures/wall_normal.png
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Equal("textures/wall_normal.png", materials["bumped"].NormalTexturePath);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_NormalMapResetBetweenMaterials()
+    {
+        var mtl = """
+            newmtl mat_with_normal
+            map_bump textures/normal.png
+
+            newmtl mat_without_normal
+            Kd 1.0 0.0 0.0
+            """;
+        var path = WriteTempFile(mtl);
+
+        try
+        {
+            var materials = MtlLoader.Load(path);
+
+            Assert.Equal("textures/normal.png", materials["mat_with_normal"].NormalTexturePath);
+            Assert.Null(materials["mat_without_normal"].NormalTexturePath);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }

--- a/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/ObjLoaderTests.cs
@@ -392,6 +392,65 @@ public class ObjLoaderTests
     }
 
     [Fact]
+    public void Load_TriangleWithTexCoords_ShouldComputeNonZeroTangents()
+    {
+        // Triangle in the XY plane with UV coords — tangents should align with U direction
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vt 0.0 0.0
+            vt 1.0 0.0
+            vt 0.0 1.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 1/1/1 2/2/1 3/3/1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            var vertices = meshes[0].Mesh.Vertices;
+            foreach (var v in vertices)
+                Assert.NotEqual(Vector3.Zero, v.Tangent);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_NoTexCoords_ShouldFallbackToUnitXTangent()
+    {
+        // When UV coords are all zero, denom is zero and tangent falls back to UnitX
+        var obj = """
+            v 0.0 0.0 0.0
+            v 1.0 0.0 0.0
+            v 0.0 1.0 0.0
+            vn 0.0 0.0 1.0
+            g tri
+            f 1//1 2//1 3//1
+            """;
+        var path = WriteTempFile(obj);
+
+        try
+        {
+            var meshes = ObjLoader.Load(path);
+
+            var vertices = meshes[0].Mesh.Vertices;
+            foreach (var v in vertices)
+                Assert.Equal(Vector3.UnitX, v.Tangent);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Load_FaceWithFewerThanThreeVertices_ShouldThrowFormatException()
     {
         var obj = """

--- a/tests/Yaeger.Tests/Graphics/Material3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Material3DTests.cs
@@ -20,11 +20,20 @@ public class Material3DTests
     }
 
     [Fact]
+    public void Default_NormalTexturePathIsNull()
+    {
+        var material = default(Material3D);
+
+        Assert.Null(material.NormalTexturePath);
+    }
+
+    [Fact]
     public void FromMtl_MapsAllFields()
     {
         var mtl = new MtlMaterial(
             Name: "TestMat",
             DiffuseTexturePath: "textures/wall.png",
+            NormalTexturePath: null,
             AmbientColor: new Color(10, 20, 30),
             DiffuseColor: new Color(100, 150, 200),
             SpecularColor: new Color(255, 255, 255),
@@ -41,11 +50,30 @@ public class Material3DTests
     }
 
     [Fact]
+    public void FromMtl_NormalTexturePath_MapsCorrectly()
+    {
+        var mtl = new MtlMaterial(
+            Name: "BumpedMat",
+            DiffuseTexturePath: "textures/wall.png",
+            NormalTexturePath: "textures/wall_normal.png",
+            AmbientColor: Color.Black,
+            DiffuseColor: Color.White,
+            SpecularColor: Color.Black,
+            Shininess: 0f
+        );
+
+        var material = Material3D.FromMtl(mtl);
+
+        Assert.Equal("textures/wall_normal.png", material.NormalTexturePath);
+    }
+
+    [Fact]
     public void FromMtl_NullTexturePath_BecomesEmptyString()
     {
         var mtl = new MtlMaterial(
             Name: "NoTex",
             DiffuseTexturePath: null,
+            NormalTexturePath: null,
             AmbientColor: new Color(0, 0, 0),
             DiffuseColor: new Color(0, 0, 0),
             SpecularColor: new Color(0, 0, 0),
@@ -55,6 +83,7 @@ public class Material3DTests
         var material = Material3D.FromMtl(mtl);
 
         Assert.Equal(string.Empty, material.DiffuseTexturePath);
+        Assert.Null(material.NormalTexturePath);
     }
 
     [Fact]
@@ -77,6 +106,21 @@ public class Material3DTests
     }
 
     [Fact]
+    public void FromModel_NormalTexturePath_MapsCorrectly()
+    {
+        var model = new ModelMaterial(
+            Name: "stone",
+            DiffuseTexturePath: "textures/stone.png",
+            NormalTexturePath: "textures/stone_normal.png",
+            DiffuseColor: Color.White
+        );
+
+        var material = Material3D.FromModel(model);
+
+        Assert.Equal("textures/stone_normal.png", material.NormalTexturePath);
+    }
+
+    [Fact]
     public void FromModel_NullTexturePath_BecomesEmptyString()
     {
         var model = new ModelMaterial(
@@ -89,6 +133,7 @@ public class Material3DTests
         var material = Material3D.FromModel(model);
 
         Assert.Equal(string.Empty, material.DiffuseTexturePath);
+        Assert.Null(material.NormalTexturePath);
     }
 
     [Fact]
@@ -97,6 +142,7 @@ public class Material3DTests
         var a = new Material3D
         {
             DiffuseTexturePath = "tex.png",
+            NormalTexturePath = null,
             Ambient = new Color(1, 2, 3),
             Diffuse = new Color(4, 5, 6),
             Specular = new Color(7, 8, 9),
@@ -105,6 +151,7 @@ public class Material3DTests
         var b = new Material3D
         {
             DiffuseTexturePath = "tex.png",
+            NormalTexturePath = null,
             Ambient = new Color(1, 2, 3),
             Diffuse = new Color(4, 5, 6),
             Specular = new Color(7, 8, 9),


### PR DESCRIPTION
- Add Shader.SetUniformInt for texture unit and flag uniforms
- Extend MtlMaterial and MtlLoader to parse map_bump/bump/norm directives
- Add NormalTexturePath to Material3D with mapping from MtlMaterial and ModelMaterial
- Compute per-vertex tangents in ObjLoader via UV-differential (Lengyel) method
- Update vertex shader to pass aTangent through as vTangent (transformed by normal matrix)
- Update fragment shader with TBN construction and conditional normal map sampling
- Bind normal map to texture unit 1 in Renderer3D.Draw; fall back to flat normal texture
- Add tests for tangent computation, MTL normal map directives, and Material3D normal path

https://claude.ai/code/session_01WFtdH55ZoGd6vAhpTKs9Ai