### PR TITLE
Fix sky artifact in 3D renderer by clearing the colour buffer each frame

### DIFF
--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -111,7 +111,7 @@ public sealed class Renderer3D : IDisposable
     }
 
     /// <summary>
-    /// Enables depth testing and back-face culling, and clears the depth buffer.
+    /// Enables depth testing and back-face culling, and clears the colour and depth buffers.
     /// Call once at the start of the 3D pass each frame.
     /// </summary>
     public void BeginFrame3D()
@@ -120,7 +120,8 @@ public sealed class Renderer3D : IDisposable
         _gl.DepthFunc(DepthFunction.Less);
         _gl.Enable(EnableCap.CullFace);
         _gl.CullFace(TriangleFace.Back);
-        _gl.Clear((uint)ClearBufferMask.DepthBufferBit);
+        _gl.ClearColor(0f, 0f, 0f, 1f);
+        _gl.Clear((uint)(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit));
     }
 
     /// <summary>


### PR DESCRIPTION
BeginFrame3D only cleared DepthBufferBit, leaving the colour buffer intact.
Any screen region covered by no geometry (e.g. looking up in Sponza) showed
stale pixels from the previous frame instead of the intended black background.

https://claude.ai/code/session_01XTGEkFjywGQ4J5cY2LoNqZ