### PR TITLE
Add spatial-hash broadphase to CollisionDetectionSystem (closes #100)

### DIFF
--- a/Samples/BouncingBalls/Program.cs
+++ b/Samples/BouncingBalls/Program.cs
@@ -13,8 +13,9 @@ var world = new World();
 var renderer = new Renderer(window);
 var renderSystem = new UnifiedRenderSystem(renderer, null, world);
 
-// Physics world with downward gravity (positive Y is up in NDC)
-var physics = new PhysicsWorld2D(world, new Vector2(0, -2.0f));
+// Physics world with downward gravity (positive Y is up in NDC).
+// Cell size 0.15 ≈ 2× average ball radius — tuned for this NDC-scale world.
+var physics = new PhysicsWorld2D(world, new Vector2(0, -2.0f), broadphaseCellSize: 0.15f);
 
 // Debug renderer for collider wireframes (toggle with Space)
 using var debugRenderer = new PhysicsDebugRenderer(window, world);

--- a/Samples/BouncingBalls/Program.cs
+++ b/Samples/BouncingBalls/Program.cs
@@ -14,7 +14,7 @@ var renderer = new Renderer(window);
 var renderSystem = new UnifiedRenderSystem(renderer, null, world);
 
 // Physics world with downward gravity (positive Y is up in NDC).
-// Cell size 0.15 ≈ 2× average ball radius — tuned for this NDC-scale world.
+// Cell size 0.15 — tuned for this NDC-scale world (≈ 3× the average ball radius of 0.054).
 var physics = new PhysicsWorld2D(world, new Vector2(0, -2.0f), broadphaseCellSize: 0.15f);
 
 // Debug renderer for collider wireframes (toggle with Space)

--- a/src/Engine/Yaeger/Physics/PhysicsWorld2D.cs
+++ b/src/Engine/Yaeger/Physics/PhysicsWorld2D.cs
@@ -36,14 +36,22 @@ public class PhysicsWorld2D : IUpdateSystem
     public IReadOnlyList<CollisionManifold> Manifolds => _collisionDetectionSystem.Manifolds;
 
     /// <summary>
-    /// Creates a new 2D physics world with the specified gravity.
+    /// Creates a new 2D physics world with the specified gravity and broadphase cell size.
     /// </summary>
-    public PhysicsWorld2D(World world, Vector2? gravity = null)
+    /// <param name="world">The ECS world containing physics entities.</param>
+    /// <param name="gravity">Gravity vector. Defaults to (0, -9.81).</param>
+    /// <param name="broadphaseCellSize">
+    /// Size of each spatial-hash cell in world units. Should be roughly 2× the average
+    /// collider extent for best pruning. Defaults to 1.0 (suitable for unit-scale worlds).
+    /// Use a smaller value (e.g. 0.1) for NDC-scale worlds, or a larger value (e.g. 64)
+    /// for pixel-scale worlds.
+    /// </param>
+    public PhysicsWorld2D(World world, Vector2? gravity = null, float broadphaseCellSize = 1.0f)
     {
         var g = gravity ?? new Vector2(0, -9.81f);
         _gravitySystem = new GravitySystem(world, g);
         _movementSystem = new MovementSystem(world);
-        _collisionDetectionSystem = new CollisionDetectionSystem(world);
+        _collisionDetectionSystem = new CollisionDetectionSystem(world, broadphaseCellSize);
         _collisionResolutionSystem = new CollisionResolutionSystem(world);
     }
 

--- a/src/Engine/Yaeger/Physics/PhysicsWorld2D.cs
+++ b/src/Engine/Yaeger/Physics/PhysicsWorld2D.cs
@@ -48,6 +48,13 @@ public class PhysicsWorld2D : IUpdateSystem
     /// </param>
     public PhysicsWorld2D(World world, Vector2? gravity = null, float broadphaseCellSize = 1.0f)
     {
+        if (broadphaseCellSize <= 0 || !float.IsFinite(broadphaseCellSize))
+            throw new ArgumentOutOfRangeException(
+                nameof(broadphaseCellSize),
+                broadphaseCellSize,
+                "Cell size must be a positive finite value."
+            );
+
         var g = gravity ?? new Vector2(0, -9.81f);
         _gravitySystem = new GravitySystem(world, g);
         _movementSystem = new MovementSystem(world);

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -15,7 +15,7 @@ public class CollisionDetectionSystem(World world, float cellSize = 1.0f)
     private readonly SpatialHash _spatialHash = new(cellSize);
     private readonly List<CollisionManifold> _manifolds = [];
     private readonly List<(Entity Entity, Vector2 Center, BoxCollider2D Collider)> _boxEntities =
-        [];
+    [];
     private readonly List<(
         Entity Entity,
         Vector2 Center,

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -6,20 +6,22 @@ using Yaeger.Physics.Components;
 namespace Yaeger.Physics.Systems;
 
 /// <summary>
-/// Detects collisions between entities using narrowphase checks.
+/// Detects collisions between entities using a spatial-hash broadphase to cull candidate
+/// pairs, followed by exact AABB/circle narrowphase checks.
 /// Supports Box-Box (AABB), Circle-Circle, and Box-Circle collision pairs.
-/// Phase 1 uses brute-force broadphase (O(n^2)).
 /// </summary>
-public class CollisionDetectionSystem(World world)
+public class CollisionDetectionSystem(World world, float cellSize = 0.1f)
 {
+    private readonly SpatialHash _spatialHash = new(cellSize);
     private readonly List<CollisionManifold> _manifolds = [];
     private readonly List<(Entity Entity, Vector2 Center, BoxCollider2D Collider)> _boxEntities =
-    [];
+        [];
     private readonly List<(
         Entity Entity,
         Vector2 Center,
         CircleCollider2D Collider
     )> _circleEntities = [];
+    private readonly HashSet<(int A, int B)> _candidatePairs = [];
 
     /// <summary>
     /// The collision manifolds detected in the last call to <see cref="Detect"/>.
@@ -27,13 +29,15 @@ public class CollisionDetectionSystem(World world)
     public IReadOnlyList<CollisionManifold> Manifolds => _manifolds;
 
     /// <summary>
-    /// Runs collision detection for all collidable entities.
+    /// Runs broadphase spatial partitioning followed by narrowphase collision detection.
     /// </summary>
     public void Detect()
     {
         _manifolds.Clear();
         _boxEntities.Clear();
         _circleEntities.Clear();
+        _candidatePairs.Clear();
+        _spatialHash.Clear();
 
         // Collect all collidable entities with their world positions
         foreach (
@@ -58,43 +62,59 @@ public class CollisionDetectionSystem(World world)
             _circleEntities.Add((entity, center, collider));
         }
 
-        // Box vs Box
+        var boxCount = _boxEntities.Count;
+
+        // Broadphase: insert all collider AABBs into the spatial hash.
+        // Box indices: 0..boxCount-1. Circle indices: boxCount..boxCount+circleCount-1.
         for (var i = 0; i < _boxEntities.Count; i++)
         {
-            for (var j = i + 1; j < _boxEntities.Count; j++)
-            {
-                if (TestBoxBox(_boxEntities[i], _boxEntities[j], out var manifold))
-                {
-                    _manifolds.Add(manifold);
-                }
-            }
+            var (_, center, collider) = _boxEntities[i];
+            _spatialHash.Insert(i, center - collider.HalfSize, center + collider.HalfSize);
         }
 
-        // Circle vs Circle
         for (var i = 0; i < _circleEntities.Count; i++)
         {
-            for (var j = i + 1; j < _circleEntities.Count; j++)
-            {
-                if (TestCircleCircle(_circleEntities[i], _circleEntities[j], out var manifold))
-                {
-                    _manifolds.Add(manifold);
-                }
-            }
+            var (_, center, collider) = _circleEntities[i];
+            var r = new Vector2(collider.Radius);
+            _spatialHash.Insert(boxCount + i, center - r, center + r);
         }
 
-        // Box vs Circle
-        for (var i = 0; i < _boxEntities.Count; i++)
+        _spatialHash.GetCandidatePairs(_candidatePairs);
+
+        // Narrowphase: test only broadphase candidate pairs.
+        foreach (var (ia, ib) in _candidatePairs)
         {
-            for (var j = 0; j < _circleEntities.Count; j++)
+            var aIsBox = ia < boxCount;
+            var bIsBox = ib < boxCount;
+
+            if (aIsBox && bIsBox)
             {
-                // Skip self-collision (entity has both BoxCollider2D and CircleCollider2D)
-                if (_boxEntities[i].Entity == _circleEntities[j].Entity)
+                if (TestBoxBox(_boxEntities[ia], _boxEntities[ib], out var manifold))
+                    _manifolds.Add(manifold);
+            }
+            else if (!aIsBox && !bIsBox)
+            {
+                if (
+                    TestCircleCircle(
+                        _circleEntities[ia - boxCount],
+                        _circleEntities[ib - boxCount],
+                        out var manifold
+                    )
+                )
+                    _manifolds.Add(manifold);
+            }
+            else
+            {
+                // Mixed pair: box indices are always less than circle indices, so ia is
+                // always the box index and ib - boxCount is always the circle index.
+                var box = _boxEntities[ia];
+                var circle = _circleEntities[ib - boxCount];
+
+                if (box.Entity == circle.Entity)
                     continue;
 
-                if (TestBoxCircle(_boxEntities[i], _circleEntities[j], out var manifold))
-                {
+                if (TestBoxCircle(box, circle, out var manifold))
                     _manifolds.Add(manifold);
-                }
             }
         }
     }

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -12,7 +12,14 @@ namespace Yaeger.Physics.Systems;
 /// </summary>
 public class CollisionDetectionSystem(World world, float cellSize = 1.0f)
 {
-    private readonly SpatialHash _spatialHash = new(cellSize);
+    private readonly SpatialHash _spatialHash =
+        cellSize > 0 && float.IsFinite(cellSize)
+            ? new(cellSize)
+            : throw new ArgumentOutOfRangeException(
+                nameof(cellSize),
+                cellSize,
+                "Cell size must be a positive finite value."
+            );
     private readonly List<CollisionManifold> _manifolds = [];
     private readonly List<(Entity Entity, Vector2 Center, BoxCollider2D Collider)> _boxEntities =
     [];

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -29,6 +29,7 @@ public class CollisionDetectionSystem(World world, float cellSize = 1.0f)
         CircleCollider2D Collider
     )> _circleEntities = [];
     private readonly HashSet<(int A, int B)> _candidatePairs = [];
+    private readonly List<(int A, int B)> _sortedPairs = [];
 
     /// <summary>
     /// The collision manifolds detected in the last call to <see cref="Detect"/>.
@@ -88,8 +89,13 @@ public class CollisionDetectionSystem(World world, float cellSize = 1.0f)
 
         _spatialHash.GetCandidatePairs(_candidatePairs);
 
+        // Sort pairs for deterministic narrowphase and manifold order.
+        _sortedPairs.Clear();
+        _sortedPairs.AddRange(_candidatePairs);
+        _sortedPairs.Sort();
+
         // Narrowphase: test only broadphase candidate pairs.
-        foreach (var (ia, ib) in _candidatePairs)
+        foreach (var (ia, ib) in _sortedPairs)
         {
             var aIsBox = ia < boxCount;
             var bIsBox = ib < boxCount;

--- a/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
+++ b/src/Engine/Yaeger/Physics/Systems/CollisionDetectionSystem.cs
@@ -10,7 +10,7 @@ namespace Yaeger.Physics.Systems;
 /// pairs, followed by exact AABB/circle narrowphase checks.
 /// Supports Box-Box (AABB), Circle-Circle, and Box-Circle collision pairs.
 /// </summary>
-public class CollisionDetectionSystem(World world, float cellSize = 0.1f)
+public class CollisionDetectionSystem(World world, float cellSize = 1.0f)
 {
     private readonly SpatialHash _spatialHash = new(cellSize);
     private readonly List<CollisionManifold> _manifolds = [];

--- a/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
+++ b/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
@@ -62,6 +62,17 @@ internal sealed class SpatialHash(float cellSize)
         var maxCx = (int)fMaxCx;
         var maxCy = (int)fMaxCy;
 
+        // Guard against degenerate configurations (e.g. tiny cellSize with large colliders)
+        // that would make the nested loops iterate millions of times in a single frame.
+        var cellCountX = (long)maxCx - minCx + 1;
+        var cellCountY = (long)maxCy - minCy + 1;
+        const long maxCellsPerInsert = 1 << 16; // 65536
+        if (cellCountX * cellCountY > maxCellsPerInsert)
+            throw new InvalidOperationException(
+                $"Collider covers {cellCountX}×{cellCountY} = {cellCountX * cellCountY} broadphase cells, "
+                    + $"exceeding the limit of {maxCellsPerInsert}. Increase the spatial-hash cell size."
+            );
+
         for (var cx = minCx; cx <= maxCx; cx++)
         {
             for (var cy = minCy; cy <= maxCy; cy++)

--- a/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
+++ b/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
@@ -10,15 +10,20 @@ namespace Yaeger.Physics.Systems;
 internal sealed class SpatialHash(float cellSize)
 {
     private readonly Dictionary<(int X, int Y), List<int>> _cells = new();
-
-    // Tracks which cells are occupied this frame so Clear() can reuse their lists
-    // rather than dropping them for GC, and GetCandidatePairs() skips empty cells.
     private readonly List<(int X, int Y)> _activeCells = [];
+
+    // Pool of cleared List<int> objects ready for reuse, avoiding per-frame allocation.
+    private readonly Stack<List<int>> _listPool = new();
 
     internal void Clear()
     {
         foreach (var key in _activeCells)
-            _cells[key].Clear();
+        {
+            var list = _cells[key];
+            list.Clear();
+            _listPool.Push(list);
+            _cells.Remove(key);
+        }
         _activeCells.Clear();
     }
 
@@ -36,7 +41,7 @@ internal sealed class SpatialHash(float cellSize)
                 var key = (cx, cy);
                 if (!_cells.TryGetValue(key, out var list))
                 {
-                    list = [];
+                    list = _listPool.Count > 0 ? _listPool.Pop() : [];
                     _cells[key] = list;
                 }
                 if (list.Count == 0)

--- a/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
+++ b/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
@@ -11,9 +11,15 @@ internal sealed class SpatialHash(float cellSize)
 {
     private readonly Dictionary<(int X, int Y), List<int>> _cells = new();
 
+    // Tracks which cells are occupied this frame so Clear() can reuse their lists
+    // rather than dropping them for GC, and GetCandidatePairs() skips empty cells.
+    private readonly List<(int X, int Y)> _activeCells = [];
+
     internal void Clear()
     {
-        _cells.Clear();
+        foreach (var key in _activeCells)
+            _cells[key].Clear();
+        _activeCells.Clear();
     }
 
     internal void Insert(int id, Vector2 min, Vector2 max)
@@ -33,6 +39,8 @@ internal sealed class SpatialHash(float cellSize)
                     list = [];
                     _cells[key] = list;
                 }
+                if (list.Count == 0)
+                    _activeCells.Add(key);
                 list.Add(id);
             }
         }
@@ -40,8 +48,9 @@ internal sealed class SpatialHash(float cellSize)
 
     internal void GetCandidatePairs(HashSet<(int A, int B)> results)
     {
-        foreach (var list in _cells.Values)
+        foreach (var key in _activeCells)
         {
+            var list = _cells[key];
             for (var i = 0; i < list.Count; i++)
             {
                 for (var j = i + 1; j < list.Count; j++)

--- a/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
+++ b/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
@@ -1,0 +1,60 @@
+using System.Numerics;
+
+namespace Yaeger.Physics.Systems;
+
+/// <summary>
+/// Uniform-grid spatial hash for broadphase collision culling.
+/// Maps world-space AABBs to integer grid cells; pairs that share no cell
+/// cannot be overlapping and are skipped before the narrowphase.
+/// </summary>
+internal sealed class SpatialHash(float cellSize)
+{
+    private readonly Dictionary<(int X, int Y), List<int>> _cells = new();
+
+    internal void Clear()
+    {
+        foreach (var list in _cells.Values)
+            list.Clear();
+    }
+
+    internal void Insert(int id, Vector2 min, Vector2 max)
+    {
+        var minCx = (int)MathF.Floor(min.X / cellSize);
+        var minCy = (int)MathF.Floor(min.Y / cellSize);
+        var maxCx = (int)MathF.Floor(max.X / cellSize);
+        var maxCy = (int)MathF.Floor(max.Y / cellSize);
+
+        for (var cx = minCx; cx <= maxCx; cx++)
+        {
+            for (var cy = minCy; cy <= maxCy; cy++)
+            {
+                var key = (cx, cy);
+                if (!_cells.TryGetValue(key, out var list))
+                {
+                    list = [];
+                    _cells[key] = list;
+                }
+                list.Add(id);
+            }
+        }
+    }
+
+    internal void GetCandidatePairs(HashSet<(int A, int B)> results)
+    {
+        foreach (var list in _cells.Values)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                for (var j = i + 1; j < list.Count; j++)
+                {
+                    var a = list[i];
+                    var b = list[j];
+                    if (a < b)
+                        results.Add((a, b));
+                    else
+                        results.Add((b, a));
+                }
+            }
+        }
+    }
+}

--- a/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
+++ b/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
@@ -29,6 +29,14 @@ internal sealed class SpatialHash(float cellSize)
 
     internal void Insert(int id, Vector2 min, Vector2 max)
     {
+        if (
+            !float.IsFinite(min.X)
+            || !float.IsFinite(min.Y)
+            || !float.IsFinite(max.X)
+            || !float.IsFinite(max.Y)
+        )
+            return;
+
         var minCx = (int)MathF.Floor(min.X / cellSize);
         var minCy = (int)MathF.Floor(min.Y / cellSize);
         var maxCx = (int)MathF.Floor(max.X / cellSize);

--- a/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
+++ b/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
@@ -37,10 +37,30 @@ internal sealed class SpatialHash(float cellSize)
         )
             return;
 
-        var minCx = (int)MathF.Floor(min.X / cellSize);
-        var minCy = (int)MathF.Floor(min.Y / cellSize);
-        var maxCx = (int)MathF.Floor(max.X / cellSize);
-        var maxCy = (int)MathF.Floor(max.Y / cellSize);
+        var fMinCx = MathF.Floor(min.X / cellSize);
+        var fMinCy = MathF.Floor(min.Y / cellSize);
+        var fMaxCx = MathF.Floor(max.X / cellSize);
+        var fMaxCy = MathF.Floor(max.Y / cellSize);
+
+        // Division by a very small cellSize or extreme coordinates can overflow float to
+        // ±Infinity, or produce values outside the int range. Skip rather than cast to a
+        // corrupt index.
+        if (
+            !float.IsFinite(fMinCx)
+            || !float.IsFinite(fMinCy)
+            || !float.IsFinite(fMaxCx)
+            || !float.IsFinite(fMaxCy)
+            || fMinCx < int.MinValue
+            || fMinCy < int.MinValue
+            || fMaxCx > int.MaxValue
+            || fMaxCy > int.MaxValue
+        )
+            return;
+
+        var minCx = (int)fMinCx;
+        var minCy = (int)fMinCy;
+        var maxCx = (int)fMaxCx;
+        var maxCy = (int)fMaxCy;
 
         for (var cx = minCx; cx <= maxCx; cx++)
         {

--- a/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
+++ b/src/Engine/Yaeger/Physics/Systems/SpatialHash.cs
@@ -13,8 +13,7 @@ internal sealed class SpatialHash(float cellSize)
 
     internal void Clear()
     {
-        foreach (var list in _cells.Values)
-            list.Clear();
+        _cells.Clear();
     }
 
     internal void Insert(int id, Vector2 min, Vector2 max)

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -509,7 +509,9 @@ public class CollisionDetectionSystemTests
         var world = new World();
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => new CollisionDetectionSystem(world, cellSize));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new CollisionDetectionSystem(world, cellSize)
+        );
     }
 
     #endregion

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -405,4 +405,93 @@ public class CollisionDetectionSystemTests
         // Assert — should not generate a self-collision manifold
         Assert.Empty(system.Manifolds);
     }
+
+    #region Broadphase
+
+    [Fact]
+    public void Detect_Broadphase_FarApartEntitiesProduceNoManifolds()
+    {
+        // Arrange — 4 boxes in separate regions of a 10x10 world, none touching
+        var world = new World();
+
+        var positions = new[]
+        {
+            new Vector2(-4f, -4f),
+            new Vector2(4f, -4f),
+            new Vector2(-4f, 4f),
+            new Vector2(4f, 4f),
+        };
+
+        foreach (var pos in positions)
+        {
+            var e = world.CreateEntity();
+            world.AddComponent(e, new Transform2D(pos));
+            world.AddComponent(e, new BoxCollider2D(1f, 1f));
+        }
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — none of the four boxes are close enough to collide
+        Assert.Empty(system.Manifolds);
+    }
+
+    [Fact]
+    public void Detect_Broadphase_OnlyAdjacentCirclesCollide()
+    {
+        // Arrange — 3 circles in a row; only the first two overlap
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(0f, 0f)));
+        world.AddComponent(a, new CircleCollider2D(0.1f));
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(0.15f, 0f)));
+        world.AddComponent(b, new CircleCollider2D(0.1f));
+
+        var c = world.CreateEntity();
+        world.AddComponent(c, new Transform2D(new Vector2(5f, 0f)));
+        world.AddComponent(c, new CircleCollider2D(0.1f));
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — only a and b share a spatial cell and overlap; c is pruned
+        Assert.Single(system.Manifolds);
+        var entities = new[] { system.Manifolds[0].EntityA, system.Manifolds[0].EntityB };
+        Assert.Contains(a, entities);
+        Assert.Contains(b, entities);
+    }
+
+    [Fact]
+    public void Detect_Broadphase_ManyNonCollidingEntitiesProduceNoManifolds()
+    {
+        // Arrange — 100 circles spread across a grid, none overlapping
+        var world = new World();
+
+        for (var row = 0; row < 10; row++)
+        {
+            for (var col = 0; col < 10; col++)
+            {
+                var e = world.CreateEntity();
+                world.AddComponent(e, new Transform2D(new Vector2(col * 0.5f, row * 0.5f)));
+                world.AddComponent(e, new CircleCollider2D(0.1f));
+            }
+        }
+
+        var system = new CollisionDetectionSystem(world);
+
+        // Act
+        system.Detect();
+
+        // Assert — circles are spaced 0.5 apart with radius 0.1, so none touch
+        Assert.Empty(system.Manifolds);
+    }
+
+    #endregion
 }

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -493,6 +493,31 @@ public class CollisionDetectionSystemTests
         Assert.Empty(system.Manifolds);
     }
 
+    [Fact]
+    public void Detect_Broadphase_CollidersStraddlingCellBoundary_ShouldDetect()
+    {
+        // Arrange — with cellSize=2, the boundary between cell 0 and cell 1 is at x=2.
+        // A's center (1.9) is in cell 0; B's center (2.5) is in cell 1. Both AABBs
+        // straddle x=2 and overlap, so the broadphase must surface this pair.
+        var world = new World();
+
+        var a = world.CreateEntity();
+        world.AddComponent(a, new Transform2D(new Vector2(1.9f, 0f)));
+        world.AddComponent(a, new BoxCollider2D(1.2f, 1.2f)); // half=0.6; AABB x=[1.3..2.5]
+
+        var b = world.CreateEntity();
+        world.AddComponent(b, new Transform2D(new Vector2(2.5f, 0f)));
+        world.AddComponent(b, new BoxCollider2D(1.2f, 1.2f)); // half=0.6; AABB x=[1.9..3.1]
+
+        var system = new CollisionDetectionSystem(world, cellSize: 2.0f);
+
+        // Act
+        system.Detect();
+
+        // Assert — overlap on X = 2.5 - 1.9 = 0.6; centers are in adjacent cells
+        Assert.Single(system.Manifolds);
+    }
+
     #endregion
 
     #region Constructor validation

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -461,7 +461,7 @@ public class CollisionDetectionSystemTests
         // Act
         system.Detect();
 
-        // Assert — only a and b share a spatial cell and overlap; c is pruned
+        // Assert — only a and b overlap; c at (5,0) is too far away
         Assert.Single(system.Manifolds);
         var entities = new[] { system.Manifolds[0].EntityA, system.Manifolds[0].EntityB };
         Assert.Contains(a, entities);

--- a/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/CollisionDetectionSystemTests.cs
@@ -494,4 +494,23 @@ public class CollisionDetectionSystemTests
     }
 
     #endregion
+
+    #region Constructor validation
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void Constructor_InvalidCellSize_ShouldThrow(float cellSize)
+    {
+        // Arrange
+        var world = new World();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CollisionDetectionSystem(world, cellSize));
+    }
+
+    #endregion
 }

--- a/tests/Yaeger.Tests/Physics/Systems/PhysicsWorld2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/PhysicsWorld2DTests.cs
@@ -132,8 +132,8 @@ public class PhysicsWorld2DTests
         var world = new World();
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => new PhysicsWorld2D(world, broadphaseCellSize: cellSize)
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new PhysicsWorld2D(world, broadphaseCellSize: cellSize)
         );
     }
 

--- a/tests/Yaeger.Tests/Physics/Systems/PhysicsWorld2DTests.cs
+++ b/tests/Yaeger.Tests/Physics/Systems/PhysicsWorld2DTests.cs
@@ -120,6 +120,23 @@ public class PhysicsWorld2DTests
         Assert.Equal(new Vector2(0, -9.81f), physics.Gravity);
     }
 
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void Constructor_InvalidBroadphaseCellSize_ShouldThrow(float cellSize)
+    {
+        // Arrange
+        var world = new World();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new PhysicsWorld2D(world, broadphaseCellSize: cellSize)
+        );
+    }
+
     [Fact]
     public void Update_StaticFloor_DynamicBall_ShouldBounce()
     {


### PR DESCRIPTION
Replace the brute-force O(n²) pair enumeration with a uniform-grid spatial hash that inserts every collider's AABB into overlapping cells each frame and then generates only same-cell pairs as narrowphase candidates. Boxes are assigned IDs 0..boxCount-1 and circles boxCount..boxCount+circleCount-1, so pair type is determined without extra bookkeeping.

- New internal `SpatialHash` class handles cell insertion and pair collection with `HashSet` deduplication.
- `CollisionDetectionSystem` gains an optional `cellSize` parameter (default **1.0f**, suitable for unit-scale worlds).
- `PhysicsWorld2D` exposes `broadphaseCellSize` (default **1.0f**) and forwards it to `CollisionDetectionSystem`. Use ~0.1 for NDC-scale worlds, ~64 for pixel-scale worlds.
- Both `cellSize` parameters are validated (must be positive and finite).
- All existing narrowphase logic is unchanged.
- Added broadphase-specific tests verifying correct collision reporting with many entities.

https://claude.ai/code/session_01Uh2ZKAK26tMkLhKoRr4F28