### PR TITLE
Add PBR metallic/roughness shading to Renderer3D (closes #103)

### DIFF
--- a/Samples/Sponza/Program.cs
+++ b/Samples/Sponza/Program.cs
@@ -10,6 +10,8 @@ using Yaeger.Systems;
 using Yaeger.Windowing;
 
 // Sponza demo — loads the Intel/KhronosGroup Sponza glTF via AssimpLoader.
+// The glTF materials are rendered through Renderer3D's PBR metallic/roughness path
+// (AssimpLoader flags them as PBR automatically — see docs/pbr.md).
 // Assets are fetched automatically on first build via the FetchSponzaAssets MSBuild target.
 // Requires native libassimp at runtime (e.g. apt install libassimp-dev on Linux).
 // Controls: WASD move, Q/E up/down, right-mouse-drag look, ESC exit.

--- a/docs/pbr.md
+++ b/docs/pbr.md
@@ -29,7 +29,7 @@ colour is Reinhard tone-mapped and gamma-encoded back to sRGB.
 public record struct Material3D
 {
     // Blinn-Phong (used when UsePbr is false)
-    public string DiffuseTexturePath = string.Empty;
+    public string? DiffuseTexturePath = string.Empty;
     public string? NormalTexturePath;
     public Color Ambient;
     public Color Diffuse;

--- a/docs/pbr.md
+++ b/docs/pbr.md
@@ -29,7 +29,7 @@ colour is Reinhard tone-mapped and gamma-encoded back to sRGB.
 public record struct Material3D
 {
     // Blinn-Phong (used when UsePbr is false)
-    public string DiffuseTexturePath;
+    public string DiffuseTexturePath = string.Empty;
     public string? NormalTexturePath;
     public Color Ambient;
     public Color Diffuse;
@@ -40,8 +40,8 @@ public record struct Material3D
     public string? MetallicRoughnessTexturePath; // glTF packed: G=roughness, B=metallic
     public string? AoTexturePath;
     public string? EmissiveTexturePath;
-    public float MetallicFactor;   // scales the texture's metallic channel
-    public float RoughnessFactor;  // scales the texture's roughness channel
+    public float MetallicFactor = 1f;   // scales the texture's metallic channel
+    public float RoughnessFactor = 1f;  // scales the texture's roughness channel
     public Color EmissiveColor;
     public bool UsePbr;
 }

--- a/docs/pbr.md
+++ b/docs/pbr.md
@@ -26,7 +26,7 @@ colour is Reinhard tone-mapped and gamma-encoded back to sRGB.
 ## `Material3D` PBR fields
 
 ```csharp
-public struct Material3D
+public record struct Material3D
 {
     // Blinn-Phong (used when UsePbr is false)
     public string DiffuseTexturePath;

--- a/docs/pbr.md
+++ b/docs/pbr.md
@@ -1,0 +1,63 @@
+# Physically-Based Rendering (PBR)
+
+`Renderer3D` supports two shading models, selected per material:
+
+- **Blinn-Phong** (the default) — the legacy model used by hand-authored scenes such as
+  the Cornell Box.
+- **PBR metallic/roughness** — a Cook-Torrance BRDF matching the glTF 2.0 material model.
+
+The model is chosen by the `Material3D.UsePbr` flag. The same shader program implements both
+paths and branches on a `uUsePbr` uniform, so mixing PBR and Blinn-Phong entities in one scene
+works without swapping shaders.
+
+## The Cook-Torrance BRDF
+
+The PBR path implements:
+
+- **Diffuse**: Lambertian, weighted by `(1 - metallic)`.
+- **Specular**: GGX normal-distribution term, Smith geometry term, and a Schlick Fresnel
+  approximation (`F0 = 0.04` for dielectrics, lerped toward the albedo for metals).
+- A small constant ambient term (`0.03 * albedo * ao`) so unlit faces don't go fully black.
+- Emissive contribution added on top.
+
+Base colour and emissive textures are treated as sRGB and linearised before lighting; the final
+colour is Reinhard tone-mapped and gamma-encoded back to sRGB.
+
+## `Material3D` PBR fields
+
+```csharp
+public struct Material3D
+{
+    // Blinn-Phong (used when UsePbr is false)
+    public string DiffuseTexturePath;
+    public string? NormalTexturePath;
+    public Color Ambient;
+    public Color Diffuse;
+    public Color Specular;
+    public float Shininess;
+
+    // PBR metallic/roughness (used when UsePbr is true)
+    public string? MetallicRoughnessTexturePath; // glTF packed: G=roughness, B=metallic
+    public string? AoTexturePath;
+    public string? EmissiveTexturePath;
+    public float MetallicFactor;   // scales the texture's metallic channel
+    public float RoughnessFactor;  // scales the texture's roughness channel
+    public Color EmissiveColor;
+    public bool UsePbr;
+}
+```
+
+`Diffuse` doubles as the glTF base-colour factor in the PBR path. When a metallic/roughness
+texture is present, glTF packs roughness in the green channel and metallic in the blue channel;
+the `MetallicFactor`/`RoughnessFactor` scalars multiply those channels (and stand in for them when
+no texture is bound).
+
+## Loading PBR materials
+
+`AssimpLoader` maps glTF `pbrMetallicRoughness` properties onto `Material3D` automatically. A
+material is flagged as PBR when the importer surfaces any metallic/roughness data — glTF always
+provides the metallic/roughness factor keys, whereas OBJ/MTL (Blinn-Phong) never does. Existing
+Blinn-Phong scenes therefore keep `UsePbr = false` and render exactly as before.
+
+The `Sponza` sample loads the KhronosGroup Sponza glTF and renders it through the PBR path; the
+`CornellBox` sample uses hand-authored Blinn-Phong materials.

--- a/docs/pbr.md
+++ b/docs/pbr.md
@@ -52,6 +52,13 @@ texture is present, glTF packs roughness in the green channel and metallic in th
 the `MetallicFactor`/`RoughnessFactor` scalars multiply those channels (and stand in for them when
 no texture is bound).
 
+> **Colour space**: in the PBR path the `Diffuse` (base-colour) and `EmissiveColor` factors are
+> treated as **linear**, matching glTF 2.0, whereas the base-colour and emissive *textures* are
+> assumed to be sRGB and are linearised before being multiplied by the factors. When authoring PBR
+> materials by hand, pick `Color` factor values in linear space — an sRGB-intended value (e.g. a
+> mid-grey `128`) will render brighter than expected. (In the Blinn-Phong path these colours are
+> used directly, with no linearisation.)
+
 ## Loading PBR materials
 
 `AssimpLoader` maps glTF `pbrMetallicRoughness` properties onto `Material3D` automatically. A

--- a/src/Engine/Yaeger/Assets/AssimpLoader.cs
+++ b/src/Engine/Yaeger/Assets/AssimpLoader.cs
@@ -164,39 +164,8 @@ public static class AssimpLoader
         api.GetMaterialString(mat, Assimp.MaterialNameBase, 0, 0, &nameStr);
         var name = nameStr.AsString;
 
-        string? diffusePath = null;
-        AssimpString diffuseStr = default;
-        var diffuseResult = api.GetMaterialTexture(
-            mat,
-            TextureType.Diffuse,
-            0,
-            &diffuseStr,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
-        if (diffuseResult == Return.Success && diffuseStr.Length > 0)
-            diffusePath = Path.GetFullPath(Path.Combine(baseDir, diffuseStr.AsString));
-
-        string? normalPath = null;
-        AssimpString normalStr = default;
-        var normalResult = api.GetMaterialTexture(
-            mat,
-            TextureType.Normals,
-            0,
-            &normalStr,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
-        if (normalResult == Return.Success && normalStr.Length > 0)
-            normalPath = Path.GetFullPath(Path.Combine(baseDir, normalStr.AsString));
+        var diffusePath = GetTexturePath(api, mat, TextureType.Diffuse, baseDir);
+        var normalPath = GetTexturePath(api, mat, TextureType.Normals, baseDir);
 
         var diffuseColor = Color.White;
         var col = Vector4.One;
@@ -229,6 +198,110 @@ public static class AssimpLoader
             ambientColor = new Color(64, 64, 64, 255);
         }
 
-        return new ModelMaterial(name, diffusePath, normalPath, diffuseColor, ambientColor);
+        // --- PBR metallic/roughness (glTF 2.0) ---
+        // Assimp's glTF importer assigns the packed metallic-roughness texture to METALNESS,
+        // the occlusion texture to AMBIENT_OCCLUSION (Lightmap on older builds), and the
+        // emissive texture to EMISSIVE.
+        var metallicRoughnessPath = GetTexturePath(api, mat, TextureType.Metalness, baseDir);
+        var aoPath =
+            GetTexturePath(api, mat, TextureType.AmbientOcclusion, baseDir)
+            ?? GetTexturePath(api, mat, TextureType.Lightmap, baseDir);
+        var emissivePath = GetTexturePath(api, mat, TextureType.Emissive, baseDir);
+
+        var hasMetallic = TryGetMaterialFloat(
+            api,
+            mat,
+            Assimp.MatkeyMetallicFactor,
+            out var metallicFactor
+        );
+        var hasRoughness = TryGetMaterialFloat(
+            api,
+            mat,
+            Assimp.MatkeyRoughnessFactor,
+            out var roughnessFactor
+        );
+
+        var emissiveColor = Color.Black;
+        var emissive = Vector4.Zero;
+        var emissiveResult = api.GetMaterialColor(
+            mat,
+            Assimp.MaterialColorEmissiveBase,
+            0,
+            0,
+            ref emissive
+        );
+        if (emissiveResult == Return.Success)
+        {
+            emissiveColor = new Color(
+                (byte)Math.Clamp((int)(emissive.X * 255f), 0, 255),
+                (byte)Math.Clamp((int)(emissive.Y * 255f), 0, 255),
+                (byte)Math.Clamp((int)(emissive.Z * 255f), 0, 255),
+                255
+            );
+        }
+
+        // Treat the material as PBR when the importer surfaced any metallic/roughness data —
+        // glTF always provides the factor keys, whereas OBJ/MTL (Blinn-Phong) never does.
+        var usePbr =
+            hasMetallic
+            || hasRoughness
+            || metallicRoughnessPath != null
+            || aoPath != null
+            || emissivePath != null;
+
+        return new ModelMaterial(
+            name,
+            diffusePath,
+            normalPath,
+            diffuseColor,
+            ambientColor,
+            metallicRoughnessPath,
+            aoPath,
+            emissivePath,
+            hasMetallic ? metallicFactor : 1f,
+            hasRoughness ? roughnessFactor : 1f,
+            emissiveColor,
+            usePbr
+        );
+    }
+
+    private static unsafe string? GetTexturePath(
+        Assimp api,
+        Material* mat,
+        TextureType type,
+        string baseDir
+    )
+    {
+        AssimpString pathStr = default;
+        var result = api.GetMaterialTexture(
+            mat,
+            type,
+            0,
+            &pathStr,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        if (result == Return.Success && pathStr.Length > 0)
+            return Path.GetFullPath(Path.Combine(baseDir, pathStr.AsString));
+
+        return null;
+    }
+
+    private static unsafe bool TryGetMaterialFloat(
+        Assimp api,
+        Material* mat,
+        string key,
+        out float value
+    )
+    {
+        float result = 0f;
+        uint max = 1;
+        var status = api.GetMaterialFloatArray(mat, key, 0, 0, &result, &max);
+        value = result;
+        return status == Return.Success;
     }
 }

--- a/src/Engine/Yaeger/Assets/AssimpLoader.cs
+++ b/src/Engine/Yaeger/Assets/AssimpLoader.cs
@@ -171,32 +171,16 @@ public static class AssimpLoader
         var col = Vector4.One;
         var colResult = api.GetMaterialColor(mat, Assimp.MaterialColorDiffuseBase, 0, 0, ref col);
         if (colResult == Return.Success)
-        {
-            diffuseColor = new Color(
-                (byte)Math.Clamp((int)(col.X * 255f), 0, 255),
-                (byte)Math.Clamp((int)(col.Y * 255f), 0, 255),
-                (byte)Math.Clamp((int)(col.Z * 255f), 0, 255),
-                (byte)Math.Clamp((int)(col.W * 255f), 0, 255)
-            );
-        }
+            diffuseColor = Color.FromVector4(col);
 
-        var ambientColor = Color.Black;
+        Color ambientColor;
         var amb = Vector4.Zero;
         var ambResult = api.GetMaterialColor(mat, Assimp.MaterialColorAmbientBase, 0, 0, ref amb);
         if (ambResult == Return.Success && (amb.X + amb.Y + amb.Z) > 0f)
-        {
-            ambientColor = new Color(
-                (byte)Math.Clamp((int)(amb.X * 255f), 0, 255),
-                (byte)Math.Clamp((int)(amb.Y * 255f), 0, 255),
-                (byte)Math.Clamp((int)(amb.Z * 255f), 0, 255),
-                255
-            );
-        }
+            ambientColor = Color.FromVector4(amb with { W = 1f });
         else
-        {
             // Fall back to ~25% grey so unlit faces remain visible.
             ambientColor = new Color(64, 64, 64, 255);
-        }
 
         // --- PBR metallic/roughness (glTF 2.0) ---
         // Assimp's glTF importer assigns the packed metallic-roughness texture to METALNESS,
@@ -231,23 +215,13 @@ public static class AssimpLoader
             ref emissive
         );
         if (emissiveResult == Return.Success)
-        {
-            emissiveColor = new Color(
-                (byte)Math.Clamp((int)(emissive.X * 255f), 0, 255),
-                (byte)Math.Clamp((int)(emissive.Y * 255f), 0, 255),
-                (byte)Math.Clamp((int)(emissive.Z * 255f), 0, 255),
-                255
-            );
-        }
+            emissiveColor = Color.FromVector4(emissive with { W = 1f });
 
-        // Treat the material as PBR when the importer surfaced any metallic/roughness data —
-        // glTF always provides the factor keys, whereas OBJ/MTL (Blinn-Phong) never does.
-        var usePbr =
-            hasMetallic
-            || hasRoughness
-            || metallicRoughnessPath != null
-            || aoPath != null
-            || emissivePath != null;
+        // Treat the material as PBR when the importer surfaced metallic/roughness data — glTF
+        // always provides these (the factor keys, and a metalness texture slot), whereas OBJ/MTL
+        // (Blinn-Phong) never does. Emissive/AO are deliberately excluded: OBJ can carry an
+        // emissive map/colour, which must not flip an otherwise Blinn-Phong material to PBR.
+        var usePbr = hasMetallic || hasRoughness || metallicRoughnessPath != null;
 
         return new ModelMaterial(
             name,
@@ -302,6 +276,8 @@ public static class AssimpLoader
         uint max = 1;
         var status = api.GetMaterialFloatArray(mat, key, 0, 0, &result, &max);
         value = result;
-        return status == Return.Success;
+        // `max` is updated to the number of values actually written; require at least one so a
+        // present-but-empty property doesn't masquerade as a real 0.0 factor.
+        return status == Return.Success && max >= 1;
     }
 }

--- a/src/Engine/Yaeger/Assets/ModelMaterial.cs
+++ b/src/Engine/Yaeger/Assets/ModelMaterial.cs
@@ -7,5 +7,12 @@ public record ModelMaterial(
     string? DiffuseTexturePath,
     string? NormalTexturePath,
     Color DiffuseColor,
-    Color AmbientColor
+    Color AmbientColor,
+    string? MetallicRoughnessTexturePath = null,
+    string? AoTexturePath = null,
+    string? EmissiveTexturePath = null,
+    float MetallicFactor = 1f,
+    float RoughnessFactor = 1f,
+    Color EmissiveColor = default,
+    bool UsePbr = false
 );

--- a/src/Engine/Yaeger/Graphics/Color.cs
+++ b/src/Engine/Yaeger/Graphics/Color.cs
@@ -30,5 +30,5 @@ public readonly struct Color(byte r, byte g, byte b, byte a = 255)
         new(ToByte(value.X), ToByte(value.Y), ToByte(value.Z), ToByte(value.W));
 
     private static byte ToByte(float component) =>
-        (byte)Math.Clamp((int)(component * 255f), 0, 255);
+        (byte)Math.Clamp((int)MathF.Round(component * 255f), 0, 255);
 }

--- a/src/Engine/Yaeger/Graphics/Color.cs
+++ b/src/Engine/Yaeger/Graphics/Color.cs
@@ -29,6 +29,12 @@ public readonly struct Color(byte r, byte g, byte b, byte a = 255)
     public static Color FromVector4(Vector4 value) =>
         new(ToByte(value.X), ToByte(value.Y), ToByte(value.Z), ToByte(value.W));
 
-    private static byte ToByte(float component) =>
-        (byte)Math.Clamp((int)MathF.Round(component * 255f), 0, 255);
+    private static byte ToByte(float component)
+    {
+        // Clamp in float space before the int cast: converting a NaN or out-of-range float to int
+        // is unspecified in C#. Math.Clamp maps +/-Infinity to 1/0; NaN compares false, so guard it.
+        if (float.IsNaN(component))
+            return 0;
+        return (byte)MathF.Round(Math.Clamp(component, 0f, 1f) * 255f);
+    }
 }

--- a/src/Engine/Yaeger/Graphics/Color.cs
+++ b/src/Engine/Yaeger/Graphics/Color.cs
@@ -21,4 +21,14 @@ public readonly struct Color(byte r, byte g, byte b, byte a = 255)
     /// Converts this color to a normalized Vector4 (0-1 range) suitable for shaders.
     /// </summary>
     public Vector4 ToVector4() => new(R / 255f, G / 255f, B / 255f, A / 255f);
+
+    /// <summary>
+    /// Creates a color from a normalized Vector4 (0-1 range), clamping each component to [0, 255].
+    /// Inverse of <see cref="ToVector4"/>.
+    /// </summary>
+    public static Color FromVector4(Vector4 value) =>
+        new(ToByte(value.X), ToByte(value.Y), ToByte(value.Z), ToByte(value.W));
+
+    private static byte ToByte(float component) =>
+        (byte)Math.Clamp((int)(component * 255f), 0, 255);
 }

--- a/src/Engine/Yaeger/Graphics/Material3D.cs
+++ b/src/Engine/Yaeger/Graphics/Material3D.cs
@@ -4,8 +4,10 @@ namespace Yaeger.Graphics;
 
 public record struct Material3D
 {
-    // Blinn-Phong fields (used when UsePbr is false)
-    public string DiffuseTexturePath = string.Empty;
+    // Blinn-Phong fields (used when UsePbr is false).
+    // Nullable because default(Material3D) bypasses the field initializer and leaves this null;
+    // the renderer treats null/empty alike (no diffuse texture).
+    public string? DiffuseTexturePath = string.Empty;
     public string? NormalTexturePath;
     public Color Ambient;
     public Color Diffuse;

--- a/src/Engine/Yaeger/Graphics/Material3D.cs
+++ b/src/Engine/Yaeger/Graphics/Material3D.cs
@@ -5,19 +5,21 @@ namespace Yaeger.Graphics;
 public record struct Material3D
 {
     // Blinn-Phong fields (used when UsePbr is false)
-    public string DiffuseTexturePath;
+    public string DiffuseTexturePath = string.Empty;
     public string? NormalTexturePath;
     public Color Ambient;
     public Color Diffuse;
     public Color Specular;
     public float Shininess;
 
-    // PBR metallic/roughness fields (used when UsePbr is true)
+    // PBR metallic/roughness fields (used when UsePbr is true).
+    // The factors default to the glTF 2.0 values (1.0) so that hand-authored PBR materials
+    // — e.g. `new Material3D { UsePbr = true, ... }` — behave sensibly without extra boilerplate.
     public string? MetallicRoughnessTexturePath; // glTF packed: G=roughness, B=metallic
     public string? AoTexturePath;
     public string? EmissiveTexturePath;
-    public float MetallicFactor;
-    public float RoughnessFactor;
+    public float MetallicFactor = 1f;
+    public float RoughnessFactor = 1f;
     public Color EmissiveColor;
 
     /// <summary>
@@ -26,6 +28,10 @@ public record struct Material3D
     /// hand-authored scenes such as the Cornell Box keep their original appearance.
     /// </summary>
     public bool UsePbr;
+
+    // Required because the PBR factor fields above carry initializers (CS8983). Note this runs
+    // for `new Material3D()` / object initializers but not for `default(Material3D)`.
+    public Material3D() { }
 
     public static Material3D FromMtl(MtlMaterial mtl) =>
         new()

--- a/src/Engine/Yaeger/Graphics/Material3D.cs
+++ b/src/Engine/Yaeger/Graphics/Material3D.cs
@@ -4,12 +4,28 @@ namespace Yaeger.Graphics;
 
 public record struct Material3D
 {
+    // Blinn-Phong fields (used when UsePbr is false)
     public string DiffuseTexturePath;
     public string? NormalTexturePath;
     public Color Ambient;
     public Color Diffuse;
     public Color Specular;
     public float Shininess;
+
+    // PBR metallic/roughness fields (used when UsePbr is true)
+    public string? MetallicRoughnessTexturePath; // glTF packed: G=roughness, B=metallic
+    public string? AoTexturePath;
+    public string? EmissiveTexturePath;
+    public float MetallicFactor;
+    public float RoughnessFactor;
+    public Color EmissiveColor;
+
+    /// <summary>
+    /// When true, the renderer shades this material with a Cook-Torrance metallic/roughness
+    /// BRDF. When false (the default), it falls back to the legacy Blinn-Phong model so that
+    /// hand-authored scenes such as the Cornell Box keep their original appearance.
+    /// </summary>
+    public bool UsePbr;
 
     public static Material3D FromMtl(MtlMaterial mtl) =>
         new()
@@ -31,5 +47,12 @@ public record struct Material3D
             Diffuse = model.DiffuseColor,
             Specular = Color.Black,
             Shininess = 0f,
+            MetallicRoughnessTexturePath = model.MetallicRoughnessTexturePath,
+            AoTexturePath = model.AoTexturePath,
+            EmissiveTexturePath = model.EmissiveTexturePath,
+            MetallicFactor = model.MetallicFactor,
+            RoughnessFactor = model.RoughnessFactor,
+            EmissiveColor = model.EmissiveColor,
+            UsePbr = model.UsePbr,
         };
 }

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -343,8 +343,10 @@ public sealed class Renderer3D : IDisposable
         _shader.Unbind();
     }
 
-    // Binds an optional PBR texture to the given unit (or a 1×1 white fallback when absent)
-    // and sets the matching sampler + has-flag uniforms so the shader can branch on presence.
+    // Binds an optional PBR texture to the given unit and flags its presence. When the path is
+    // empty the bind is skipped entirely: the fragment shader gates each optional map behind a
+    // per-draw `uHas*Map` uniform, so the (uniform-not-taken) sample is never executed and the
+    // sampler needs no complete texture bound.
     private void BindOptionalTexture(
         TextureManager textures,
         string? path,
@@ -357,16 +359,13 @@ public sealed class Renderer3D : IDisposable
         if (!string.IsNullOrEmpty(path))
         {
             textures.Get(path).Bind(unit);
+            _shader.SetUniformInt(samplerUniform, samplerSlot);
             _shader.SetUniformInt(hasUniform, 1);
         }
         else
         {
-            _gl.ActiveTexture(unit);
-            _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
             _shader.SetUniformInt(hasUniform, 0);
         }
-
-        _shader.SetUniformInt(samplerUniform, samplerSlot);
     }
 
     private unsafe uint CreateWhiteTexture()

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -194,7 +194,21 @@ public sealed class Renderer3D : IDisposable
         _shader = new Shader(gl, VertexShaderSource, FragmentShaderSource);
         _defaultTexture = CreateWhiteTexture();
         _defaultNormalTexture = CreateFlatNormalTexture();
+        BindSamplerUnits();
         SetSceneLighting(DirectionalLight.Default, Vector3.Zero);
+    }
+
+    // Sampler-to-texture-unit assignments never change after link, so set them once here rather
+    // than re-uploading them on every Draw call.
+    private void BindSamplerUnits()
+    {
+        _shader.Bind();
+        _shader.SetUniformInt("uDiffuse", 0);
+        _shader.SetUniformInt("uNormalMap", 1);
+        _shader.SetUniformInt("uMetallicRoughnessMap", 2);
+        _shader.SetUniformInt("uAoMap", 3);
+        _shader.SetUniformInt("uEmissiveMap", 4);
+        _shader.Unbind();
     }
 
     /// <summary>
@@ -286,8 +300,6 @@ public sealed class Renderer3D : IDisposable
             _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
         }
 
-        _shader.SetUniformInt("uDiffuse", 0);
-
         if (!string.IsNullOrEmpty(material.NormalTexturePath))
         {
             textures.Get(material.NormalTexturePath).Bind(TextureUnit.Texture1);
@@ -300,8 +312,6 @@ public sealed class Renderer3D : IDisposable
             _shader.SetUniformInt("uHasNormalMap", 0);
         }
 
-        _shader.SetUniformInt("uNormalMap", 1);
-
         // Only the PBR branch samples the metallic-roughness/AO/emissive maps, so skip the
         // texture binds entirely for Blinn-Phong materials and just clear the has-flags.
         if (material.UsePbr)
@@ -310,24 +320,18 @@ public sealed class Renderer3D : IDisposable
                 textures,
                 material.MetallicRoughnessTexturePath,
                 TextureUnit.Texture2,
-                2,
-                "uMetallicRoughnessMap",
                 "uHasMetallicRoughnessMap"
             );
             BindOptionalTexture(
                 textures,
                 material.AoTexturePath,
                 TextureUnit.Texture3,
-                3,
-                "uAoMap",
                 "uHasAoMap"
             );
             BindOptionalTexture(
                 textures,
                 material.EmissiveTexturePath,
                 TextureUnit.Texture4,
-                4,
-                "uEmissiveMap",
                 "uHasEmissiveMap"
             );
         }
@@ -346,20 +350,18 @@ public sealed class Renderer3D : IDisposable
     // Binds an optional PBR texture to the given unit and flags its presence. When the path is
     // empty the bind is skipped entirely: the fragment shader gates each optional map behind a
     // per-draw `uHas*Map` uniform, so the (uniform-not-taken) sample is never executed and the
-    // sampler needs no complete texture bound.
+    // sampler needs no complete texture bound. Sampler-to-unit assignments are set once at
+    // construction (see BindSamplerUnits), so they aren't re-uploaded here.
     private void BindOptionalTexture(
         TextureManager textures,
         string? path,
         TextureUnit unit,
-        int samplerSlot,
-        string samplerUniform,
         string hasUniform
     )
     {
         if (!string.IsNullOrEmpty(path))
         {
             textures.Get(path).Bind(unit);
-            _shader.SetUniformInt(samplerUniform, samplerSlot);
             _shader.SetUniformInt(hasUniform, 1);
         }
         else

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -124,8 +124,9 @@ public sealed class Renderer3D : IDisposable
             vec4 rawTex = texture(uDiffuse, vTexCoord);
 
             if (uUsePbr != 0) {
-                // glTF base colour is sRGB-encoded; linearise before lighting.
-                vec3 albedo = pow(rawTex.rgb * uDiffuseColor.rgb, vec3(2.2));
+                // glTF base colour texture is sRGB-encoded; linearise it before applying the
+                // base-colour factor, which glTF defines in linear space.
+                vec3 albedo = pow(rawTex.rgb, vec3(2.2)) * uDiffuseColor.rgb;
 
                 float metallic  = uMetallicFactor;
                 float roughness = uRoughnessFactor;

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -315,14 +315,16 @@ public sealed class Renderer3D : IDisposable
         _shader.SetUniformFloat("uRoughnessFactor", roughness);
         _shader.SetUniformVec4("uEmissiveColor", material.EmissiveColor.ToVector4());
 
+        // Select the target unit *before* TextureManager.Get: a first-time Get constructs a
+        // Texture whose ctor binds on the currently-active unit, which would otherwise clobber a
+        // previously-bound unit. Activating first keeps that side-effect bind on the right unit.
+        _gl.ActiveTexture(TextureUnit.Texture0);
         if (!string.IsNullOrEmpty(material.DiffuseTexturePath))
             textures.Get(material.DiffuseTexturePath).Bind(TextureUnit.Texture0);
         else
-        {
-            _gl.ActiveTexture(TextureUnit.Texture0);
             _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
-        }
 
+        _gl.ActiveTexture(TextureUnit.Texture1);
         if (!string.IsNullOrEmpty(material.NormalTexturePath))
         {
             textures.Get(material.NormalTexturePath).Bind(TextureUnit.Texture1);
@@ -330,7 +332,6 @@ public sealed class Renderer3D : IDisposable
         }
         else
         {
-            _gl.ActiveTexture(TextureUnit.Texture1);
             _gl.BindTexture(TextureTarget.Texture2D, _defaultNormalTexture);
             _shader.SetUniformInt("uHasNormalMap", 0);
         }
@@ -384,6 +385,9 @@ public sealed class Renderer3D : IDisposable
     {
         if (!string.IsNullOrEmpty(path))
         {
+            // Select the unit before Get so a first-time Texture ctor binds on this unit rather
+            // than clobbering whichever unit happened to be active.
+            _gl.ActiveTexture(unit);
             textures.Get(path).Bind(unit);
             _shader.SetUniformInt(hasUniform, 1);
         }

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -46,16 +46,55 @@ public sealed class Renderer3D : IDisposable
 
         uniform sampler2D uDiffuse;
         uniform sampler2D uNormalMap;
+        uniform sampler2D uMetallicRoughnessMap;
+        uniform sampler2D uAoMap;
+        uniform sampler2D uEmissiveMap;
         uniform int       uHasNormalMap;
+        uniform int       uHasMetallicRoughnessMap;
+        uniform int       uHasAoMap;
+        uniform int       uHasEmissiveMap;
+
         uniform vec4  uDiffuseColor;
         uniform vec4  uAmbientColor;
         uniform vec4  uSpecularColor;
         uniform float uShininess;
 
+        uniform int   uUsePbr;
+        uniform float uMetallicFactor;
+        uniform float uRoughnessFactor;
+        uniform vec4  uEmissiveColor;
+
         uniform vec3  uLightDir;
         uniform vec4  uLightColor;
         uniform float uLightIntensity;
         uniform vec3  uCameraPos;
+
+        const float PI = 3.14159265359;
+
+        float distributionGGX(vec3 N, vec3 H, float roughness) {
+            float a = roughness * roughness;
+            float a2 = a * a;
+            float NdotH = max(dot(N, H), 0.0);
+            float denom = NdotH * NdotH * (a2 - 1.0) + 1.0;
+            denom = PI * denom * denom;
+            return a2 / max(denom, 1e-7);
+        }
+
+        float geometrySchlickGGX(float NdotX, float roughness) {
+            float r = roughness + 1.0;
+            float k = (r * r) / 8.0;
+            return NdotX / (NdotX * (1.0 - k) + k);
+        }
+
+        float geometrySmith(vec3 N, vec3 V, vec3 L, float roughness) {
+            float NdotV = max(dot(N, V), 0.0);
+            float NdotL = max(dot(N, L), 0.0);
+            return geometrySchlickGGX(NdotV, roughness) * geometrySchlickGGX(NdotL, roughness);
+        }
+
+        vec3 fresnelSchlick(float cosTheta, vec3 F0) {
+            return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+        }
 
         void main() {
             vec3 N = normalize(vNormal);
@@ -82,17 +121,64 @@ public sealed class Renderer3D : IDisposable
             vec3 halfDir = L + V;
             vec3 H = halfDir * inversesqrt(max(dot(halfDir, halfDir), 1e-10));
 
-            vec4 rawTex   = texture(uDiffuse, vTexCoord);
-            vec4 texColor = rawTex * uDiffuseColor;
+            vec4 rawTex = texture(uDiffuse, vTexCoord);
 
-            float diff = max(dot(N, L), 0.0);
-            float spec = diff > 0.0 ? pow(max(dot(N, H), 0.0), uShininess) : 0.0;
+            if (uUsePbr != 0) {
+                // glTF base colour is sRGB-encoded; linearise before lighting.
+                vec3 albedo = pow(rawTex.rgb * uDiffuseColor.rgb, vec3(2.2));
 
-            vec3 ambient  = (uAmbientColor * rawTex).rgb;
-            vec3 diffuse  = texColor.rgb     * diff * uLightColor.rgb * uLightIntensity;
-            vec3 specular = uSpecularColor.rgb * spec * uLightColor.rgb * uLightIntensity;
+                float metallic  = uMetallicFactor;
+                float roughness = uRoughnessFactor;
+                if (uHasMetallicRoughnessMap != 0) {
+                    // glTF packs roughness in G and metallic in B.
+                    vec3 mr = texture(uMetallicRoughnessMap, vTexCoord).rgb;
+                    roughness *= mr.g;
+                    metallic  *= mr.b;
+                }
+                roughness = clamp(roughness, 0.04, 1.0);
+                metallic  = clamp(metallic, 0.0, 1.0);
 
-            FragColor = vec4(ambient + diffuse + specular, texColor.a);
+                float ao = uHasAoMap != 0 ? texture(uAoMap, vTexCoord).r : 1.0;
+
+                vec3 emissive = uEmissiveColor.rgb;
+                if (uHasEmissiveMap != 0)
+                    emissive *= pow(texture(uEmissiveMap, vTexCoord).rgb, vec3(2.2));
+
+                vec3 radiance = uLightColor.rgb * uLightIntensity;
+
+                vec3  F0  = mix(vec3(0.04), albedo, metallic);
+                float NDF = distributionGGX(N, H, roughness);
+                float G   = geometrySmith(N, V, L, roughness);
+                vec3  F   = fresnelSchlick(max(dot(H, V), 0.0), F0);
+
+                float NdotL = max(dot(N, L), 0.0);
+                vec3  numerator = NDF * G * F;
+                float denom = 4.0 * max(dot(N, V), 0.0) * NdotL + 1e-4;
+                vec3  specular = numerator / denom;
+
+                vec3 kD = (vec3(1.0) - F) * (1.0 - metallic);
+                vec3 Lo = (kD * albedo / PI + specular) * radiance * NdotL;
+
+                vec3 ambient = vec3(0.03) * albedo * ao;
+                vec3 color = ambient + Lo + emissive;
+
+                // Reinhard tone-map, then gamma encode back to sRGB.
+                color = color / (color + vec3(1.0));
+                color = pow(color, vec3(1.0 / 2.2));
+
+                FragColor = vec4(color, rawTex.a * uDiffuseColor.a);
+            } else {
+                vec4 texColor = rawTex * uDiffuseColor;
+
+                float diff = max(dot(N, L), 0.0);
+                float spec = diff > 0.0 ? pow(max(dot(N, H), 0.0), uShininess) : 0.0;
+
+                vec3 ambient  = (uAmbientColor * rawTex).rgb;
+                vec3 diffuse  = texColor.rgb     * diff * uLightColor.rgb * uLightIntensity;
+                vec3 specular = uSpecularColor.rgb * spec * uLightColor.rgb * uLightIntensity;
+
+                FragColor = vec4(ambient + diffuse + specular, texColor.a);
+            }
         }
         """;
 
@@ -179,6 +265,18 @@ public sealed class Renderer3D : IDisposable
             float.IsFinite(material.Shininess) ? MathF.Max(material.Shininess, 1f) : 1f
         );
 
+        var metallic = float.IsFinite(material.MetallicFactor)
+            ? Math.Clamp(material.MetallicFactor, 0f, 1f)
+            : 1f;
+        var roughness = float.IsFinite(material.RoughnessFactor)
+            ? Math.Clamp(material.RoughnessFactor, 0f, 1f)
+            : 1f;
+
+        _shader.SetUniformInt("uUsePbr", material.UsePbr ? 1 : 0);
+        _shader.SetUniformFloat("uMetallicFactor", metallic);
+        _shader.SetUniformFloat("uRoughnessFactor", roughness);
+        _shader.SetUniformVec4("uEmissiveColor", material.EmissiveColor.ToVector4());
+
         if (!string.IsNullOrEmpty(material.DiffuseTexturePath))
             textures.Get(material.DiffuseTexturePath).Bind(TextureUnit.Texture0);
         else
@@ -203,9 +301,60 @@ public sealed class Renderer3D : IDisposable
 
         _shader.SetUniformInt("uNormalMap", 1);
 
+        BindOptionalTexture(
+            textures,
+            material.MetallicRoughnessTexturePath,
+            TextureUnit.Texture2,
+            2,
+            "uMetallicRoughnessMap",
+            "uHasMetallicRoughnessMap"
+        );
+        BindOptionalTexture(
+            textures,
+            material.AoTexturePath,
+            TextureUnit.Texture3,
+            3,
+            "uAoMap",
+            "uHasAoMap"
+        );
+        BindOptionalTexture(
+            textures,
+            material.EmissiveTexturePath,
+            TextureUnit.Texture4,
+            4,
+            "uEmissiveMap",
+            "uHasEmissiveMap"
+        );
+
         mesh.Draw();
 
         _shader.Unbind();
+    }
+
+    // Binds an optional PBR texture to the given unit (or a 1×1 white fallback when absent)
+    // and sets the matching sampler + has-flag uniforms so the shader can branch on presence.
+    private void BindOptionalTexture(
+        TextureManager textures,
+        string? path,
+        TextureUnit unit,
+        int samplerSlot,
+        string samplerUniform,
+        string hasUniform
+    )
+    {
+        if (!string.IsNullOrEmpty(path))
+        {
+            textures.Get(path).Bind(unit);
+            _shader.SetUniformInt(hasUniform, 1);
+        }
+        else
+        {
+            _gl.ActiveTexture(unit);
+            _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
+            _shader.SetUniformInt(hasUniform, 0);
+        }
+
+        _shader.SetUniformInt(samplerUniform, samplerSlot);
     }
 
     private unsafe uint CreateWhiteTexture()

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -302,30 +302,41 @@ public sealed class Renderer3D : IDisposable
 
         _shader.SetUniformInt("uNormalMap", 1);
 
-        BindOptionalTexture(
-            textures,
-            material.MetallicRoughnessTexturePath,
-            TextureUnit.Texture2,
-            2,
-            "uMetallicRoughnessMap",
-            "uHasMetallicRoughnessMap"
-        );
-        BindOptionalTexture(
-            textures,
-            material.AoTexturePath,
-            TextureUnit.Texture3,
-            3,
-            "uAoMap",
-            "uHasAoMap"
-        );
-        BindOptionalTexture(
-            textures,
-            material.EmissiveTexturePath,
-            TextureUnit.Texture4,
-            4,
-            "uEmissiveMap",
-            "uHasEmissiveMap"
-        );
+        // Only the PBR branch samples the metallic-roughness/AO/emissive maps, so skip the
+        // texture binds entirely for Blinn-Phong materials and just clear the has-flags.
+        if (material.UsePbr)
+        {
+            BindOptionalTexture(
+                textures,
+                material.MetallicRoughnessTexturePath,
+                TextureUnit.Texture2,
+                2,
+                "uMetallicRoughnessMap",
+                "uHasMetallicRoughnessMap"
+            );
+            BindOptionalTexture(
+                textures,
+                material.AoTexturePath,
+                TextureUnit.Texture3,
+                3,
+                "uAoMap",
+                "uHasAoMap"
+            );
+            BindOptionalTexture(
+                textures,
+                material.EmissiveTexturePath,
+                TextureUnit.Texture4,
+                4,
+                "uEmissiveMap",
+                "uHasEmissiveMap"
+            );
+        }
+        else
+        {
+            _shader.SetUniformInt("uHasMetallicRoughnessMap", 0);
+            _shader.SetUniformInt("uHasAoMap", 0);
+            _shader.SetUniformInt("uHasEmissiveMap", 0);
+        }
 
         mesh.Draw();
 

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -228,6 +228,10 @@ public sealed class Renderer3D : IDisposable
             _gl.ActiveTexture(unit);
             _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
         }
+
+        // Restore the default active unit so we don't leak Texture4 into later GL setup (e.g. the
+        // Texture constructor binds without first selecting a unit).
+        _gl.ActiveTexture(TextureUnit.Texture0);
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -195,6 +195,7 @@ public sealed class Renderer3D : IDisposable
         _defaultTexture = CreateWhiteTexture();
         _defaultNormalTexture = CreateFlatNormalTexture();
         BindSamplerUnits();
+        BindDefaultPbrTextures();
         SetSceneLighting(DirectionalLight.Default, Vector3.Zero);
     }
 
@@ -209,6 +210,24 @@ public sealed class Renderer3D : IDisposable
         _shader.SetUniformInt("uAoMap", 3);
         _shader.SetUniformInt("uEmissiveMap", 4);
         _shader.Unbind();
+    }
+
+    // Bind the 1×1 white texture to the optional PBR sampler units (2-4) once at construction.
+    // Those samplers are statically used by the fragment shader (the gating `uHas*Map` uniform
+    // doesn't make them un-referenced), so each must point at a *complete* texture for defined
+    // behaviour. Draw only ever overwrites these units with a real map and never unbinds them,
+    // so this one-time bind keeps the units complete for the renderer's lifetime — Draw can then
+    // skip binding a fallback when a map is absent.
+    private void BindDefaultPbrTextures()
+    {
+        foreach (
+            var unit in (ReadOnlySpan<TextureUnit>)
+                [TextureUnit.Texture2, TextureUnit.Texture3, TextureUnit.Texture4]
+        )
+        {
+            _gl.ActiveTexture(unit);
+            _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
+        }
     }
 
     /// <summary>
@@ -348,10 +367,10 @@ public sealed class Renderer3D : IDisposable
     }
 
     // Binds an optional PBR texture to the given unit and flags its presence. When the path is
-    // empty the bind is skipped entirely: the fragment shader gates each optional map behind a
-    // per-draw `uHas*Map` uniform, so the (uniform-not-taken) sample is never executed and the
-    // sampler needs no complete texture bound. Sampler-to-unit assignments are set once at
-    // construction (see BindSamplerUnits), so they aren't re-uploaded here.
+    // empty the bind is skipped: the unit already holds a complete fallback texture from
+    // construction (see BindDefaultPbrTextures), so the (uniform-gated) sampler stays valid and
+    // `uHas*Map = 0` tells the shader to ignore it. Sampler-to-unit assignments are likewise set
+    // once at construction (see BindSamplerUnits), so they aren't re-uploaded here.
     private void BindOptionalTexture(
         TextureManager textures,
         string? path,

--- a/tests/Yaeger.Tests/Assets/AssimpLoaderTests.cs
+++ b/tests/Yaeger.Tests/Assets/AssimpLoaderTests.cs
@@ -190,6 +190,81 @@ public class AssimpLoaderTests
         }
     }
 
+    [SkippableFact]
+    public void LoadScene_GltfPbrMaterial_ShouldMapMetallicRoughnessAndEmissive()
+    {
+        Skip.IfNot(IsAssimpAvailable(), "Native Assimp library not available.");
+
+        // Minimal glTF 2.0 triangle whose material uses pbrMetallicRoughness. The buffer
+        // (base64) holds three VEC3 positions followed by three unsigned-short indices.
+        const string gltf = """
+            {
+              "asset": { "version": "2.0" },
+              "scene": 0,
+              "scenes": [ { "nodes": [ 0 ] } ],
+              "nodes": [ { "mesh": 0 } ],
+              "meshes": [
+                {
+                  "primitives": [
+                    { "attributes": { "POSITION": 0 }, "indices": 1, "material": 0 }
+                  ]
+                }
+              ],
+              "materials": [
+                {
+                  "pbrMetallicRoughness": {
+                    "baseColorFactor": [ 1.0, 1.0, 1.0, 1.0 ],
+                    "metallicFactor": 0.25,
+                    "roughnessFactor": 0.75
+                  },
+                  "emissiveFactor": [ 0.5, 0.0, 0.0 ]
+                }
+              ],
+              "buffers": [
+                {
+                  "byteLength": 42,
+                  "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAABAAIA"
+                }
+              ],
+              "bufferViews": [
+                { "buffer": 0, "byteOffset": 0, "byteLength": 36, "target": 34962 },
+                { "buffer": 0, "byteOffset": 36, "byteLength": 6, "target": 34963 }
+              ],
+              "accessors": [
+                {
+                  "bufferView": 0,
+                  "componentType": 5126,
+                  "count": 3,
+                  "type": "VEC3",
+                  "min": [ 0.0, 0.0, 0.0 ],
+                  "max": [ 1.0, 1.0, 0.0 ]
+                },
+                { "bufferView": 1, "componentType": 5123, "count": 3, "type": "SCALAR" }
+              ]
+            }
+            """;
+        var path = WriteTempObj(gltf, ".gltf");
+        try
+        {
+            var scene = AssimpLoader.LoadScene(path);
+
+            Assert.Single(scene.Meshes);
+            var mat = scene.Meshes[0].Material;
+
+            Assert.True(mat.UsePbr);
+            Assert.Equal(0.25f, mat.MetallicFactor, 3);
+            Assert.Equal(0.75f, mat.RoughnessFactor, 3);
+            // emissiveFactor R=0.5 → ~127 after the 0-255 quantisation; G and B stay 0.
+            Assert.InRange(mat.EmissiveColor.R, (byte)120, (byte)135);
+            Assert.Equal(0, mat.EmissiveColor.G);
+            Assert.Equal(0, mat.EmissiveColor.B);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
     [Fact]
     public void LoadScene_FileNotFound_ShouldThrowFileNotFoundException()
     {

--- a/tests/Yaeger.Tests/Graphics/ColorTests.cs
+++ b/tests/Yaeger.Tests/Graphics/ColorTests.cs
@@ -241,9 +241,9 @@ public class ColorTests
         // Arrange & Act — components below 0 and above 1 should saturate to [0, 255].
         var color = Color.FromVector4(new Vector4(-0.5f, 0.5f, 2.0f, 1.5f));
 
-        // Assert
+        // Assert — 0.5 rounds to nearest (0.5 * 255 = 127.5 -> 128).
         Assert.Equal(0, color.R);
-        Assert.Equal(127, color.G);
+        Assert.Equal(128, color.G);
         Assert.Equal(255, color.B);
         Assert.Equal(255, color.A);
     }

--- a/tests/Yaeger.Tests/Graphics/ColorTests.cs
+++ b/tests/Yaeger.Tests/Graphics/ColorTests.cs
@@ -247,4 +247,19 @@ public class ColorTests
         Assert.Equal(255, color.B);
         Assert.Equal(255, color.A);
     }
+
+    [Fact]
+    public void FromVector4_HandlesNonFiniteComponents()
+    {
+        // Arrange & Act — NaN -> 0, +Infinity saturates to 255, -Infinity to 0.
+        var color = Color.FromVector4(
+            new Vector4(float.NaN, float.PositiveInfinity, float.NegativeInfinity, 1f)
+        );
+
+        // Assert
+        Assert.Equal(0, color.R);
+        Assert.Equal(255, color.G);
+        Assert.Equal(0, color.B);
+        Assert.Equal(255, color.A);
+    }
 }

--- a/tests/Yaeger.Tests/Graphics/ColorTests.cs
+++ b/tests/Yaeger.Tests/Graphics/ColorTests.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Yaeger.Graphics;
 
 namespace Yaeger.Tests.Graphics;
@@ -216,5 +217,34 @@ public class ColorTests
         Assert.Equal(0.50196f, vector.Y, precision: 5);
         Assert.Equal(0.75294f, vector.Z, precision: 5);
         Assert.Equal(1f, vector.W, precision: 5);
+    }
+
+    [Fact]
+    public void FromVector4_RoundTripsThroughToVector4()
+    {
+        // Arrange
+        var original = new Color(64, 128, 192, 200);
+
+        // Act
+        var roundTripped = Color.FromVector4(original.ToVector4());
+
+        // Assert
+        Assert.Equal(original.R, roundTripped.R);
+        Assert.Equal(original.G, roundTripped.G);
+        Assert.Equal(original.B, roundTripped.B);
+        Assert.Equal(original.A, roundTripped.A);
+    }
+
+    [Fact]
+    public void FromVector4_ClampsOutOfRangeComponents()
+    {
+        // Arrange & Act — components below 0 and above 1 should saturate to [0, 255].
+        var color = Color.FromVector4(new Vector4(-0.5f, 0.5f, 2.0f, 1.5f));
+
+        // Assert
+        Assert.Equal(0, color.R);
+        Assert.Equal(127, color.G);
+        Assert.Equal(255, color.B);
+        Assert.Equal(255, color.A);
     }
 }

--- a/tests/Yaeger.Tests/Graphics/Material3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Material3DTests.cs
@@ -141,6 +141,81 @@ public class Material3DTests
     }
 
     [Fact]
+    public void Default_IsNotPbr()
+    {
+        var material = default(Material3D);
+
+        Assert.False(material.UsePbr);
+    }
+
+    [Fact]
+    public void FromMtl_DoesNotEnablePbr()
+    {
+        var mtl = new MtlMaterial(
+            Name: "TestMat",
+            DiffuseTexturePath: "textures/wall.png",
+            NormalTexturePath: null,
+            AmbientColor: Color.Black,
+            DiffuseColor: Color.White,
+            SpecularColor: Color.White,
+            Shininess: 32f
+        );
+
+        var material = Material3D.FromMtl(mtl);
+
+        Assert.False(material.UsePbr);
+    }
+
+    [Fact]
+    public void FromModel_MapsPbrFields()
+    {
+        var emissive = new Color(10, 20, 30, 255);
+        var model = new ModelMaterial(
+            Name: "metal",
+            DiffuseTexturePath: "textures/base.png",
+            NormalTexturePath: "textures/normal.png",
+            DiffuseColor: Color.White,
+            AmbientColor: Color.Black,
+            MetallicRoughnessTexturePath: "textures/mr.png",
+            AoTexturePath: "textures/ao.png",
+            EmissiveTexturePath: "textures/emissive.png",
+            MetallicFactor: 0.8f,
+            RoughnessFactor: 0.3f,
+            EmissiveColor: emissive,
+            UsePbr: true
+        );
+
+        var material = Material3D.FromModel(model);
+
+        Assert.True(material.UsePbr);
+        Assert.Equal("textures/mr.png", material.MetallicRoughnessTexturePath);
+        Assert.Equal("textures/ao.png", material.AoTexturePath);
+        Assert.Equal("textures/emissive.png", material.EmissiveTexturePath);
+        Assert.Equal(0.8f, material.MetallicFactor);
+        Assert.Equal(0.3f, material.RoughnessFactor);
+        Assert.Equal(emissive, material.EmissiveColor);
+    }
+
+    [Fact]
+    public void FromModel_NonPbr_LeavesPbrDisabled()
+    {
+        var model = new ModelMaterial(
+            Name: "stone",
+            DiffuseTexturePath: "textures/stone.png",
+            NormalTexturePath: null,
+            DiffuseColor: Color.White,
+            AmbientColor: Color.Black
+        );
+
+        var material = Material3D.FromModel(model);
+
+        Assert.False(material.UsePbr);
+        Assert.Null(material.MetallicRoughnessTexturePath);
+        Assert.Null(material.AoTexturePath);
+        Assert.Null(material.EmissiveTexturePath);
+    }
+
+    [Fact]
     public void RecordStruct_EqualityByValue()
     {
         var a = new Material3D

--- a/tests/Yaeger.Tests/Graphics/Material3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Material3DTests.cs
@@ -141,6 +141,17 @@ public class Material3DTests
     }
 
     [Fact]
+    public void New_DefaultsMetallicAndRoughnessToGltfDefaults()
+    {
+        // Hand-authored PBR materials (`new Material3D { UsePbr = true, ... }`) should pick up
+        // glTF's 1.0 factor defaults without the caller having to set them explicitly.
+        var material = new Material3D();
+
+        Assert.Equal(1f, material.MetallicFactor);
+        Assert.Equal(1f, material.RoughnessFactor);
+    }
+
+    [Fact]
     public void Default_IsNotPbr()
     {
         var material = default(Material3D);

--- a/tests/Yaeger.Tests/Graphics/Material3DTests.cs
+++ b/tests/Yaeger.Tests/Graphics/Material3DTests.cs
@@ -145,8 +145,9 @@ public class Material3DTests
     {
         // Hand-authored PBR materials (`new Material3D { UsePbr = true, ... }`) should pick up
         // glTF's 1.0 factor defaults without the caller having to set them explicitly.
-        var material = new Material3D();
+        var material = new Material3D { UsePbr = true };
 
+        Assert.True(material.UsePbr);
         Assert.Equal(1f, material.MetallicFactor);
         Assert.Equal(1f, material.RoughnessFactor);
     }


### PR DESCRIPTION
## Summary

Adds a **PBR metallic/roughness (Cook-Torrance) shading path** to `Renderer3D`, matching the glTF 2.0 material model, while keeping the existing Blinn-Phong model for hand-authored scenes. Closes #103.

A single shader program now branches on a `uUsePbr` uniform, so PBR and Blinn-Phong entities can coexist in one scene without swapping programs.

## Changes

### Shader (`Renderer3D`)
- **PBR path**: Cook-Torrance BRDF — GGX normal distribution + Smith geometry + Schlick-Fresnel, Lambertian diffuse weighted by `(1 - metallic)`, a small constant ambient (`0.03·albedo·ao`), and additive emissive. Base colour/emissive are linearised from sRGB; the result is Reinhard tone-mapped and gamma-encoded.
- **Blinn-Phong branch** reproduces the original math exactly, so `CornellBox` is unchanged.
- Binds the metallic-roughness, AO and emissive textures (units 2–4, 1×1 white fallback) and uploads the PBR uniforms.

### `Material3D`
Extended with `MetallicRoughnessTexturePath`, `AoTexturePath`, `EmissiveTexturePath`, `MetallicFactor`, `RoughnessFactor`, `EmissiveColor`, and a `UsePbr` flag. Existing Blinn-Phong fields are retained.

### `AssimpLoader`
Maps glTF `pbrMetallicRoughness` properties (metallic/roughness factors, packed MR texture with G=roughness/B=metallic, AO, emissive) onto the new fields. **Auto-enables PBR** when the importer surfaces metallic/roughness data — OBJ/MTL never provide those keys, so legacy Blinn-Phong scenes keep `UsePbr = false`.

### Samples & docs
- `Sponza` (glTF) renders through the PBR path automatically.
- `CornellBox` stays Blinn-Phong.
- Adds `docs/pbr.md`.

## Acceptance criteria
- [x] PBR Cook-Torrance BRDF implemented in `Renderer3D`'s fragment shader.
- [x] `Material3D` extended with metallic, roughness, AO, and emissive fields.
- [x] `AssimpLoader` maps glTF PBR material properties to `Material3D`.
- [x] `Sponza` sample renders with PBR materials.
- [x] Existing `CornellBox` sample still renders correctly (Blinn-Phong path unchanged).

## Testing
- `dotnet build` — all projects incl. both 3D samples, 0 warnings/errors.
- `dotnet csharpier check .` — clean.
- `dotnet test` — **509 passed / 1 skipped**, including new `Material3D` PBR unit tests and a real **glTF PBR load integration test** asserting `metallicFactor`, `roughnessFactor`, emissive colour, and `UsePbr` are mapped correctly.

https://claude.ai/code/session_01LFftUzw7QTBFEPx1pghrZ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFftUzw7QTBFEPx1pghrZ5)_