### PR TITLE
Add directional shadow mapping to Renderer3D (closes #105)

### DIFF
--- a/Samples/CornellBox/Program.cs
+++ b/Samples/CornellBox/Program.cs
@@ -196,9 +196,10 @@ world.AddComponent(
     lightEntity,
     new DirectionalLight
     {
-        Direction = Vector3.Normalize(new Vector3(0f, 1f, 0.15f)),
+        // Angled slightly off-vertical so the boxes throw distinct shadows across the floor.
+        Direction = Vector3.Normalize(new Vector3(0.25f, 1f, 0.2f)),
         Color = Color.White,
-        Intensity = 0.5f,
+        Intensity = 1.2f,
     }
 );
 
@@ -224,7 +225,30 @@ AddPointLight("light_green", new Vector3(0.6f, 1.3f, 0.4f), Color.Green, 2.5f, 2
 AddPointLight("light_blue", new Vector3(0f, 0.6f, -0.6f), Color.Blue, 2.5f, 2.5f);
 
 using var renderer3D = new Renderer3D(window.Gl);
-var meshRenderSystem = new MeshRenderSystem(renderer3D, registry, textures, world, window);
+
+// Directional-light shadow mapping. The orthographic frustum is sized to frame the 2×2×2 room
+// (centred on the camera target), and PCF softens the cast-shadow edges.
+using var shadowMapRenderer = new ShadowMapRenderer(
+    window.Gl,
+    new ShadowSettings
+    {
+        MapResolution = 2048,
+        OrthographicSize = 2.5f,
+        NearPlane = 0.1f,
+        FarPlane = 12f,
+        Bias = 0.004f,
+        EnablePcf = true,
+    }
+);
+
+var meshRenderSystem = new MeshRenderSystem(
+    renderer3D,
+    registry,
+    textures,
+    world,
+    window,
+    shadowMapRenderer: shadowMapRenderer
+);
 var freeFlySystem = new FreeFlySystem(world, cameraEntity);
 
 Keyboard.AddKeyDown(Keys.Escape, window.Close);

--- a/docs/lighting.md
+++ b/docs/lighting.md
@@ -13,6 +13,8 @@ There is always exactly one directional light (the first `DirectionalLight` enti
 default when none exists). Point and spot lights are optional and additive — a scene with none
 renders exactly as it did before this feature existed.
 
+The directional light can also cast shadows via shadow mapping — see [shadows.md](shadows.md).
+
 ## Components
 
 ```csharp

--- a/docs/shadows.md
+++ b/docs/shadows.md
@@ -1,0 +1,79 @@
+# Directional Shadow Mapping
+
+`Renderer3D` can cast hard or PCF-soft shadows from the scene's directional light. Shadows are
+produced with classic two-pass shadow mapping and are **opt-in** — a scene that never creates a
+`ShadowMapRenderer` renders exactly as it did before this feature existed.
+
+> **Scope (v1).** Directional light only (point/spot shadows are a follow-up). Single cascade, no
+> CSM. The shadow map has a fixed resolution and does not auto-fit the camera frustum.
+
+## How it works
+
+Each frame `MeshRenderSystem` runs two passes:
+
+1. **Shadow pass.** The scene is rendered from the directional light's point of view into an
+   off-screen depth texture (the *shadow map*) using a depth-only shader and an orthographic
+   projection. All meshes are drawn regardless of the camera frustum, so off-screen geometry can
+   still cast into view.
+2. **Lighting pass (existing).** Each fragment is projected into light space and its depth compared
+   against the shadow map. Occluded fragments lose the directional light's contribution. An optional
+   3×3 PCF kernel softens the edges.
+
+Only the directional light is shadowed; point and spot lights (see [lighting.md](lighting.md)) are
+unaffected.
+
+## Usage
+
+Create a `ShadowMapRenderer` and pass it to `MeshRenderSystem`:
+
+```csharp
+using var renderer3D = new Renderer3D(window.Gl);
+
+using var shadowMapRenderer = new ShadowMapRenderer(
+    window.Gl,
+    new ShadowSettings
+    {
+        MapResolution    = 2048,   // square depth texture dimension
+        OrthographicSize = 2.5f,   // half-width of the light's frustum, world units
+        NearPlane        = 0.1f,
+        FarPlane         = 12f,
+        Bias             = 0.004f, // depth bias against shadow acne
+        EnablePcf        = true,   // 3x3 soft-shadow filter
+    });
+
+var meshRenderSystem = new MeshRenderSystem(
+    renderer3D, registry, textures, world, window,
+    shadowMapRenderer: shadowMapRenderer);
+```
+
+That's the whole wiring — `MeshRenderSystem` orchestrates both passes and uploads the shadow map to
+the renderer automatically. The light's orthographic frustum is centred on the active camera's
+`Target`, so size `OrthographicSize`/`FarPlane` to enclose the part of the scene that should receive
+shadows.
+
+## `ShadowSettings`
+
+| Field | Meaning |
+| --- | --- |
+| `MapResolution` | Shadow map dimension in texels. Higher = crisper shadows, more memory/fill. |
+| `OrthographicSize` | Half-extent of the light's orthographic frustum in world units. |
+| `NearPlane` / `FarPlane` | Depth range of the light's projection. The scene must fit between them. |
+| `Bias` | Depth offset subtracted during the shadow test. Too low → *acne*; too high → *peter-panning*. |
+| `EnablePcf` | When true, averages a 3×3 kernel for soft edges; otherwise hard shadows. |
+
+`ShadowSettings.Default` is a 2048² map with PCF enabled.
+
+## Tuning notes
+
+- **Shadow acne** (self-shadowing moiré): raise `Bias`. The shader also applies a slope-scaled term,
+  so grazing angles already get extra offset.
+- **Peter-panning** (shadows detached from their caster): lower `Bias`, or shrink `OrthographicSize`
+  so each texel covers less world space.
+- **Blocky edges**: raise `MapResolution` or tighten `OrthographicSize`; enable PCF for softer edges.
+- Fragments outside the light's frustum sample a white (depth 1.0) border and are treated as fully
+  lit, so there is no hard cutoff at the frustum boundary.
+
+## Sample
+
+`Samples/CornellBox` enables a 2048² PCF shadow map. The two interior boxes cast visible shadows
+across the floor from the angled directional light.

--- a/src/Engine/Yaeger/Graphics/ShadowSettings.cs
+++ b/src/Engine/Yaeger/Graphics/ShadowSettings.cs
@@ -1,0 +1,38 @@
+namespace Yaeger.Graphics;
+
+/// <summary>
+/// Configuration for directional-light shadow mapping. Controls the shadow map's resolution, the
+/// light's orthographic frustum, the depth bias used to fight shadow acne, and whether a 3×3 PCF
+/// kernel softens the shadow edges.
+/// </summary>
+public record struct ShadowSettings
+{
+    /// <summary>Square shadow map dimension in texels (e.g. 2048).</summary>
+    public int MapResolution;
+
+    /// <summary>Half-extent of the light's orthographic frustum, in world units.</summary>
+    public float OrthographicSize;
+
+    /// <summary>Near plane of the light's orthographic projection.</summary>
+    public float NearPlane;
+
+    /// <summary>Far plane of the light's orthographic projection.</summary>
+    public float FarPlane;
+
+    /// <summary>Depth bias subtracted during the shadow test to prevent shadow acne.</summary>
+    public float Bias;
+
+    /// <summary>When true, a 3×3 PCF (percentage-closer filtering) kernel softens shadow edges.</summary>
+    public bool EnablePcf;
+
+    public static ShadowSettings Default =>
+        new()
+        {
+            MapResolution = 2048,
+            OrthographicSize = 10f,
+            NearPlane = 0.1f,
+            FarPlane = 50f,
+            Bias = 0.005f,
+            EnablePcf = true,
+        };
+}

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -408,7 +408,7 @@ public sealed class Renderer3D : IDisposable
         _defaultNormalTexture = CreateFlatNormalTexture();
         BindSamplerUnits();
         BindDefaultPbrTextures();
-        BindDefaultShadowTexture();
+        // DisableShadows also binds the default texture on unit 5, so no separate setup is needed.
         DisableShadows();
         SetSceneLighting(DirectionalLight.Default, Vector3.Zero);
         // Start with no point/spot lights so scenes that never call SetPointLights/SetSpotLights
@@ -498,6 +498,11 @@ public sealed class Renderer3D : IDisposable
         _shader.SetUniformInt("uShadowsEnabled", 0);
         _shader.SetUniformMatrix4("uLightSpaceMatrix", Matrix4x4.Identity);
         _shader.Unbind();
+
+        // Restore the default (complete) shadow texture on unit 5. After a prior SetShadowMap the
+        // unit may still point at a depth texture that gets deleted when its ShadowMapRenderer is
+        // disposed, leaving the statically-used sampler incomplete even though sampling is gated off.
+        BindDefaultShadowTexture();
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -189,6 +189,10 @@ public sealed class Renderer3D : IDisposable
         float directionalShadow(vec3 N, vec3 L) {
             if (uShadowsEnabled == 0) return 1.0;
 
+            // Back-facing to the light: both shading paths clamp the directional term to zero, so
+            // the shadow factor is irrelevant (shadow * 0 == 0). Skip the (PCF) texture reads.
+            if (dot(N, L) <= 0.0) return 1.0;
+
             // Perspective divide, then map NDC -> [0, 1] texture/depth space.
             vec3 proj = vLightSpacePos.xyz / vLightSpacePos.w;
             proj = proj * 0.5 + 0.5;

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -20,11 +20,13 @@ public sealed class Renderer3D : IDisposable
         uniform mat4 uModel;
         uniform mat4 uViewProj;
         uniform mat3 uNormalMatrix;
+        uniform mat4 uLightSpaceMatrix;
 
         out vec3 vNormal;
         out vec2 vTexCoord;
         out vec3 vFragPos;
         out vec3 vTangent;
+        out vec4 vLightSpacePos;
 
         void main() {
             vec4 worldPos = uModel * vec4(aPosition, 1.0);
@@ -32,6 +34,7 @@ public sealed class Renderer3D : IDisposable
             vNormal   = uNormalMatrix * aNormal;
             vTangent  = mat3(uModel) * aTangent;
             vTexCoord = aTexCoord;
+            vLightSpacePos = uLightSpaceMatrix * worldPos;
             gl_Position = uViewProj * worldPos;
         }
         """;
@@ -42,6 +45,7 @@ public sealed class Renderer3D : IDisposable
         in  vec2 vTexCoord;
         in  vec3 vFragPos;
         in  vec3 vTangent;
+        in  vec4 vLightSpacePos;
         out vec4 FragColor;
 
         uniform sampler2D uDiffuse;
@@ -49,10 +53,15 @@ public sealed class Renderer3D : IDisposable
         uniform sampler2D uMetallicRoughnessMap;
         uniform sampler2D uAoMap;
         uniform sampler2D uEmissiveMap;
+        uniform sampler2D uShadowMap;
         uniform int       uHasNormalMap;
         uniform int       uHasMetallicRoughnessMap;
         uniform int       uHasAoMap;
         uniform int       uHasEmissiveMap;
+
+        uniform int   uShadowsEnabled;
+        uniform float uShadowBias;
+        uniform int   uUsePcf;
 
         uniform vec4  uDiffuseColor;
         uniform vec4  uAmbientColor;
@@ -174,6 +183,40 @@ public sealed class Renderer3D : IDisposable
             return (texColor * diff + specColor * spec) * radiance;
         }
 
+        // Directional-light visibility in [0, 1]: 1 = fully lit, 0 = fully shadowed. Projects the
+        // fragment into light space, compares its depth against the shadow map, and (optionally)
+        // averages a 3x3 PCF kernel for soft edges. Only the directional light casts shadows in v1.
+        float directionalShadow(vec3 N, vec3 L) {
+            if (uShadowsEnabled == 0) return 1.0;
+
+            // Perspective divide, then map NDC -> [0, 1] texture/depth space.
+            vec3 proj = vLightSpacePos.xyz / vLightSpacePos.w;
+            proj = proj * 0.5 + 0.5;
+
+            // Beyond the light's far plane or outside the map footprint: treat as lit.
+            if (proj.z > 1.0) return 1.0;
+            if (proj.x < 0.0 || proj.x > 1.0 || proj.y < 0.0 || proj.y > 1.0) return 1.0;
+
+            // Slope-scaled bias: grazing angles need more offset to avoid shadow acne.
+            float bias = max(uShadowBias * (1.0 - dot(N, L)), uShadowBias * 0.1);
+            float current = proj.z;
+
+            if (uUsePcf != 0) {
+                float sum = 0.0;
+                vec2 texel = 1.0 / vec2(textureSize(uShadowMap, 0));
+                for (int x = -1; x <= 1; x++) {
+                    for (int y = -1; y <= 1; y++) {
+                        float closest = texture(uShadowMap, proj.xy + vec2(x, y) * texel).r;
+                        sum += current - bias > closest ? 1.0 : 0.0;
+                    }
+                }
+                return 1.0 - sum / 9.0;
+            }
+
+            float closest = texture(uShadowMap, proj.xy).r;
+            return current - bias > closest ? 0.0 : 1.0;
+        }
+
         void main() {
             vec3 N = normalize(vNormal);
 
@@ -196,6 +239,9 @@ public sealed class Renderer3D : IDisposable
             vec3 L = normalize(uLightDir);
             vec3 viewDir = uCameraPos - vFragPos;
             vec3 V = viewDir * inversesqrt(max(dot(viewDir, viewDir), 1e-10));
+
+            // Directional shadowing (1 = lit, 0 = shadowed); only the directional light casts.
+            float shadow = directionalShadow(N, L);
 
             vec4 rawTex = texture(uDiffuse, vTexCoord);
 
@@ -223,11 +269,11 @@ public sealed class Renderer3D : IDisposable
 
                 vec3 F0 = mix(vec3(0.04), albedo, metallic);
 
-                // Directional light.
+                // Directional light (shadowed).
                 vec3 Lo = pbrContribution(
                     N, V, L, uLightColor.rgb * uLightIntensity,
                     albedo, metallic, roughness, F0
-                );
+                ) * shadow;
 
                 // Point lights.
                 for (int i = 0; i < uPointLightCount; i++) {
@@ -264,11 +310,11 @@ public sealed class Renderer3D : IDisposable
             } else {
                 vec4 texColor = rawTex * uDiffuseColor;
 
-                // Directional light.
+                // Directional light (shadowed).
                 vec3 lit = phongContribution(
                     N, V, L, uLightColor.rgb * uLightIntensity,
                     texColor.rgb, uSpecularColor.rgb, uShininess
-                );
+                ) * shadow;
 
                 // Point lights.
                 for (int i = 0; i < uPointLightCount; i++) {
@@ -362,6 +408,8 @@ public sealed class Renderer3D : IDisposable
         _defaultNormalTexture = CreateFlatNormalTexture();
         BindSamplerUnits();
         BindDefaultPbrTextures();
+        BindDefaultShadowTexture();
+        DisableShadows();
         SetSceneLighting(DirectionalLight.Default, Vector3.Zero);
         // Start with no point/spot lights so scenes that never call SetPointLights/SetSpotLights
         // (the pre-existing single-directional-light path) render exactly as before.
@@ -379,6 +427,7 @@ public sealed class Renderer3D : IDisposable
         _shader.SetUniformInt("uMetallicRoughnessMap", 2);
         _shader.SetUniformInt("uAoMap", 3);
         _shader.SetUniformInt("uEmissiveMap", 4);
+        _shader.SetUniformInt("uShadowMap", 5);
         _shader.Unbind();
     }
 
@@ -402,6 +451,53 @@ public sealed class Renderer3D : IDisposable
         // Restore the default active unit so we don't leak Texture4 into later GL setup (e.g. the
         // Texture constructor binds without first selecting a unit).
         _gl.ActiveTexture(TextureUnit.Texture0);
+    }
+
+    // The shadow sampler (unit 5) is statically used by the fragment shader, so it must point at a
+    // complete texture even when shadows are disabled. Bind the 1×1 white texture (sampled as depth
+    // 1.0 = fully lit) until SetShadowMap swaps in a real depth map. As with the PBR fallbacks, the
+    // shadow path never unbinds this unit, so the one-time bind keeps it valid for the lifetime.
+    private void BindDefaultShadowTexture()
+    {
+        _gl.ActiveTexture(TextureUnit.Texture5);
+        _gl.BindTexture(TextureTarget.Texture2D, _defaultTexture);
+        _gl.ActiveTexture(TextureUnit.Texture0);
+    }
+
+    /// <summary>
+    /// Binds the shadow map and uploads the light-space transform for the lighting pass. Call once
+    /// per frame, after the shadow pass has populated the depth texture and before the draw loop.
+    /// </summary>
+    public void SetShadowMap(
+        Matrix4x4 lightSpaceMatrix,
+        uint depthTexture,
+        float bias,
+        bool enablePcf
+    )
+    {
+        _shader.Bind();
+        _shader.SetUniformMatrix4("uLightSpaceMatrix", lightSpaceMatrix);
+        _shader.SetUniformFloat("uShadowBias", SanitizeNonNegative(bias));
+        _shader.SetUniformInt("uUsePcf", enablePcf ? 1 : 0);
+        _shader.SetUniformInt("uShadowsEnabled", 1);
+
+        _gl.ActiveTexture(TextureUnit.Texture5);
+        _gl.BindTexture(TextureTarget.Texture2D, depthTexture);
+        _gl.ActiveTexture(TextureUnit.Texture0);
+
+        _shader.Unbind();
+    }
+
+    /// <summary>
+    /// Disables shadow sampling: the lighting pass treats every fragment as fully lit. This is the
+    /// default state until <see cref="SetShadowMap"/> is called.
+    /// </summary>
+    public void DisableShadows()
+    {
+        _shader.Bind();
+        _shader.SetUniformInt("uShadowsEnabled", 0);
+        _shader.SetUniformMatrix4("uLightSpaceMatrix", Matrix4x4.Identity);
+        _shader.Unbind();
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/Rendering/Renderer3D.cs
+++ b/src/Engine/Yaeger/Rendering/Renderer3D.cs
@@ -193,8 +193,9 @@ public sealed class Renderer3D : IDisposable
             vec3 proj = vLightSpacePos.xyz / vLightSpacePos.w;
             proj = proj * 0.5 + 0.5;
 
-            // Beyond the light's far plane or outside the map footprint: treat as lit.
-            if (proj.z > 1.0) return 1.0;
+            // Outside the light's depth range (in front of its near plane or beyond the far
+            // plane) or outside the map footprint: treat as lit.
+            if (proj.z < 0.0 || proj.z > 1.0) return 1.0;
             if (proj.x < 0.0 || proj.x > 1.0 || proj.y < 0.0 || proj.y > 1.0) return 1.0;
 
             // Slope-scaled bias: grazing angles need more offset to avoid shadow acne.

--- a/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
+++ b/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
@@ -148,6 +148,9 @@ public sealed class ShadowMapRenderer : IDisposable
 
     private unsafe uint CreateDepthTexture(int resolution)
     {
+        // Select a known unit before binding so this (and the matching unbind below) doesn't
+        // disturb whatever texture the caller had bound on an arbitrary active unit.
+        _gl.ActiveTexture(TextureUnit.Texture0);
         var handle = _gl.GenTexture();
         _gl.BindTexture(TextureTarget.Texture2D, handle);
         _gl.TexImage2D(

--- a/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
+++ b/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
@@ -1,0 +1,215 @@
+using System.Numerics;
+using Silk.NET.OpenGL;
+using Yaeger.Graphics;
+
+namespace Yaeger.Rendering;
+
+/// <summary>
+/// Renders scene depth from a directional light's point of view into an off-screen depth texture
+/// (the "shadow map"). The lighting pass (<see cref="Renderer3D"/>) samples this texture to decide
+/// which fragments are occluded from the light and should be darkened.
+///
+/// Usage each frame, before the lighting pass:
+/// <code>
+/// shadowMap.BeginPass(light, sceneCenter);
+/// foreach (var (mesh, model) in casters) shadowMap.Draw(mesh, model);
+/// shadowMap.EndPass(width, height);
+/// renderer3D.SetShadowMap(shadowMap.LightSpaceMatrix, shadowMap.DepthTexture, bias, pcf);
+/// </code>
+/// </summary>
+public sealed class ShadowMapRenderer : IDisposable
+{
+    // Depth-only pass: transform vertices into light clip space; no fragment output is needed, the
+    // depth buffer is captured automatically.
+    private const string VertexShaderSource = """
+        #version 330 core
+        layout(location = 0) in vec3 aPosition;
+
+        uniform mat4 uLightSpace;
+        uniform mat4 uModel;
+
+        void main() {
+            gl_Position = uLightSpace * uModel * vec4(aPosition, 1.0);
+        }
+        """;
+
+    private const string FragmentShaderSource = """
+        #version 330 core
+        void main() { }
+        """;
+
+    private readonly GL _gl;
+    private readonly Shader _shader;
+    private readonly uint _fbo;
+    private readonly uint _depthTexture;
+    private readonly int _resolution;
+
+    /// <summary>The settings the renderer was constructed with.</summary>
+    public ShadowSettings Settings { get; }
+
+    /// <summary>Handle of the depth texture written during the shadow pass.</summary>
+    public uint DepthTexture => _depthTexture;
+
+    /// <summary>
+    /// The light-space view-projection computed by the most recent <see cref="BeginPass"/> call.
+    /// Upload this to <see cref="Renderer3D.SetShadowMap"/> so the lighting pass projects each
+    /// fragment into the same space.
+    /// </summary>
+    public Matrix4x4 LightSpaceMatrix { get; private set; } = Matrix4x4.Identity;
+
+    public ShadowMapRenderer(GL gl, ShadowSettings settings)
+    {
+        _gl = gl;
+        Settings = settings;
+        _resolution = Math.Max(settings.MapResolution, 1);
+        _shader = new Shader(gl, VertexShaderSource, FragmentShaderSource);
+        _depthTexture = CreateDepthTexture(_resolution);
+        _fbo = CreateFramebuffer(_depthTexture);
+    }
+
+    /// <summary>
+    /// Computes the orthographic light-space view-projection that frames <paramref name="sceneCenter"/>
+    /// from the directional light's direction. The light's eye is placed back along its (toward-the-
+    /// light) direction so the centre sits midway between the near and far planes.
+    /// </summary>
+    public static Matrix4x4 ComputeLightSpaceMatrix(
+        DirectionalLight light,
+        Vector3 sceneCenter,
+        ShadowSettings settings
+    )
+    {
+        var lenSq = light.Direction.LengthSquared();
+        var dir =
+            float.IsFinite(lenSq) && lenSq > 0f
+                ? Vector3.Normalize(light.Direction)
+                : Vector3.UnitY;
+
+        var near = settings.NearPlane > 0f ? settings.NearPlane : 0.1f;
+        var far = settings.FarPlane > near ? settings.FarPlane : near + 1f;
+        var size = settings.OrthographicSize > 0f ? settings.OrthographicSize : 1f;
+
+        var distance = (near + far) * 0.5f;
+        var eye = sceneCenter + dir * distance;
+
+        // Pick an up vector that isn't (near-)parallel to the view direction so the look-at stays
+        // well-defined for top-down lights.
+        var up = MathF.Abs(dir.Y) > 0.99f ? Vector3.UnitZ : Vector3.UnitY;
+
+        var view = Matrix4x4.CreateLookAt(eye, sceneCenter, up);
+        var projection = Matrix4x4.CreateOrthographicOffCenter(-size, size, -size, size, near, far);
+        return view * projection;
+    }
+
+    /// <summary>
+    /// Binds the depth framebuffer, sets the shadow-map viewport, clears depth, and uploads the
+    /// light-space transform. Issue <see cref="Draw"/> calls for every shadow caster afterwards.
+    /// </summary>
+    public void BeginPass(DirectionalLight light, Vector3 sceneCenter)
+    {
+        LightSpaceMatrix = ComputeLightSpaceMatrix(light, sceneCenter, Settings);
+
+        var resolution = (uint)_resolution;
+        _gl.Viewport(0, 0, resolution, resolution);
+        _gl.BindFramebuffer(FramebufferTarget.Framebuffer, _fbo);
+        _gl.Clear((uint)ClearBufferMask.DepthBufferBit);
+
+        _gl.Enable(EnableCap.DepthTest);
+        _gl.DepthFunc(DepthFunction.Less);
+        // Render both faces into the depth map so single-sided geometry (walls, quads) still casts.
+        _gl.Disable(EnableCap.CullFace);
+
+        _shader.Bind();
+        _shader.SetUniformMatrix4("uLightSpace", LightSpaceMatrix);
+    }
+
+    /// <summary>Renders a single shadow caster into the depth map. Call between Begin/End.</summary>
+    public void Draw(GpuMesh mesh, Matrix4x4 model)
+    {
+        _shader.SetUniformMatrix4("uModel", model);
+        mesh.Draw();
+    }
+
+    /// <summary>
+    /// Restores the default framebuffer and the supplied viewport (the window's drawable size) so
+    /// the subsequent lighting pass renders to the screen as usual.
+    /// </summary>
+    public void EndPass(int viewportWidth, int viewportHeight)
+    {
+        _shader.Unbind();
+        _gl.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+        _gl.Viewport(0, 0, (uint)Math.Max(viewportWidth, 1), (uint)Math.Max(viewportHeight, 1));
+    }
+
+    private unsafe uint CreateDepthTexture(int resolution)
+    {
+        var handle = _gl.GenTexture();
+        _gl.BindTexture(TextureTarget.Texture2D, handle);
+        _gl.TexImage2D(
+            TextureTarget.Texture2D,
+            0,
+            (int)InternalFormat.DepthComponent24,
+            (uint)resolution,
+            (uint)resolution,
+            0,
+            PixelFormat.DepthComponent,
+            PixelType.Float,
+            null
+        );
+        _gl.TexParameter(
+            TextureTarget.Texture2D,
+            TextureParameterName.TextureMinFilter,
+            (int)GLEnum.Nearest
+        );
+        _gl.TexParameter(
+            TextureTarget.Texture2D,
+            TextureParameterName.TextureMagFilter,
+            (int)GLEnum.Nearest
+        );
+        // Clamp to a white (depth 1.0) border so fragments that fall outside the light's frustum
+        // sample "fully lit" rather than wrapping into a neighbouring shadow.
+        _gl.TexParameter(
+            TextureTarget.Texture2D,
+            TextureParameterName.TextureWrapS,
+            (int)GLEnum.ClampToBorder
+        );
+        _gl.TexParameter(
+            TextureTarget.Texture2D,
+            TextureParameterName.TextureWrapT,
+            (int)GLEnum.ClampToBorder
+        );
+        float* border = stackalloc float[] { 1f, 1f, 1f, 1f };
+        _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBorderColor, border);
+        _gl.BindTexture(TextureTarget.Texture2D, 0);
+        return handle;
+    }
+
+    private uint CreateFramebuffer(uint depthTexture)
+    {
+        var fbo = _gl.GenFramebuffer();
+        _gl.BindFramebuffer(FramebufferTarget.Framebuffer, fbo);
+        _gl.FramebufferTexture2D(
+            FramebufferTarget.Framebuffer,
+            FramebufferAttachment.DepthAttachment,
+            TextureTarget.Texture2D,
+            depthTexture,
+            0
+        );
+        // Depth-only target: no colour buffer is drawn to or read from.
+        _gl.DrawBuffer(DrawBufferMode.None);
+        _gl.ReadBuffer(ReadBufferMode.None);
+
+        var status = _gl.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
+        if (status != GLEnum.FramebufferComplete)
+            throw new InvalidOperationException($"Shadow map framebuffer incomplete: {status}");
+
+        _gl.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+        return fbo;
+    }
+
+    public void Dispose()
+    {
+        _shader.Dispose();
+        _gl.DeleteFramebuffer(_fbo);
+        _gl.DeleteTexture(_depthTexture);
+    }
+}

--- a/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
+++ b/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
@@ -148,8 +148,10 @@ public sealed class ShadowMapRenderer : IDisposable
 
     private unsafe uint CreateDepthTexture(int resolution)
     {
-        // Select a known unit before binding so this (and the matching unbind below) doesn't
-        // disturb whatever texture the caller had bound on an arbitrary active unit.
+        // Normalise to a known unit (Texture0) before binding so the texture setup lands on a
+        // predictable unit — and leaves unit 0 cleared — instead of mutating whatever unit the
+        // caller happened to leave active. Mirrors how Renderer3D settles on unit 0 after its
+        // own texture setup; construction runs during scene init, so no live binding is lost.
         _gl.ActiveTexture(TextureUnit.Texture0);
         var handle = _gl.GenTexture();
         _gl.BindTexture(TextureTarget.Texture2D, handle);

--- a/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
+++ b/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
@@ -138,6 +138,12 @@ public sealed class ShadowMapRenderer : IDisposable
         _shader.Unbind();
         _gl.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
         _gl.Viewport(0, 0, (uint)Math.Max(viewportWidth, 1), (uint)Math.Max(viewportHeight, 1));
+
+        // Restore the engine's default 3D state changed in BeginPass so a caller that doesn't
+        // immediately re-establish it (BeginFrame3D does) isn't left with culling disabled.
+        _gl.Enable(EnableCap.CullFace);
+        _gl.CullFace(TriangleFace.Back);
+        _gl.DepthFunc(DepthFunction.Less);
     }
 
     private unsafe uint CreateDepthTexture(int resolution)

--- a/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
+++ b/src/Engine/Yaeger/Rendering/ShadowMapRenderer.cs
@@ -158,7 +158,9 @@ public sealed class ShadowMapRenderer : IDisposable
             (uint)resolution,
             0,
             PixelFormat.DepthComponent,
-            PixelType.Float,
+            // Data is null, so this type only labels the (absent) source pixels; pair it with the
+            // sized DepthComponent24 internal format's conventional integer type.
+            PixelType.UnsignedInt,
             null
         );
         _gl.TexParameter(

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -11,7 +11,8 @@ namespace Yaeger.Systems;
 /// <see cref="Material3D"/> components and issues draw calls via <see cref="Renderer3D"/>.
 /// Wire this to <see cref="Window.OnRender"/>, not <see cref="Window.OnUpdate"/>.
 /// Pass a <see cref="SkyboxRenderer"/> and <see cref="CubemapRegistry"/> to render any
-/// <see cref="Skybox"/> entity automatically.
+/// <see cref="Skybox"/> entity automatically. Pass a <see cref="ShadowMapRenderer"/> to render
+/// directional-light shadows via an extra depth pre-pass.
 /// </summary>
 public class MeshRenderSystem(
     Renderer3D renderer,
@@ -20,7 +21,8 @@ public class MeshRenderSystem(
     World world,
     Window window,
     SkyboxRenderer? skyboxRenderer = null,
-    CubemapRegistry? cubemapRegistry = null
+    CubemapRegistry? cubemapRegistry = null,
+    ShadowMapRenderer? shadowMapRenderer = null
 )
 {
     // Reused across frames so collecting lights doesn't allocate per render call. Sized to the
@@ -31,7 +33,7 @@ public class MeshRenderSystem(
 
     public void Render()
     {
-        var (view, projection, cameraPos, hasCamera) = GetCameraMatrices();
+        var (view, projection, cameraPos, sceneCenter, hasCamera) = GetCameraMatrices();
         var viewProj = view * projection;
         var light = GetDirectionalLight();
         CameraFrustum? frustum = hasCamera ? CameraFrustum.FromMatrix(viewProj) : null;
@@ -41,10 +43,26 @@ public class MeshRenderSystem(
         var pointLightCount = CollectPointLights();
         var spotLightCount = CollectSpotLights();
 
+        // Shadow pre-pass: render scene depth from the directional light's point of view. Runs
+        // before BeginFrame3D so it owns the framebuffer/viewport state for its duration.
+        if (shadowMapRenderer != null)
+            RenderShadowPass(light, sceneCenter);
+
         renderer.BeginFrame3D();
         renderer.SetSceneLighting(light, cameraPos);
         renderer.SetPointLights(_pointLights!.AsSpan(0, pointLightCount));
         renderer.SetSpotLights(_spotLights!.AsSpan(0, spotLightCount));
+
+        if (shadowMapRenderer != null)
+        {
+            var settings = shadowMapRenderer.Settings;
+            renderer.SetShadowMap(
+                shadowMapRenderer.LightSpaceMatrix,
+                shadowMapRenderer.DepthTexture,
+                settings.Bias,
+                settings.EnablePcf
+            );
+        }
 
         foreach (
             (
@@ -84,10 +102,34 @@ public class MeshRenderSystem(
         renderer.EndFrame3D();
     }
 
+    // Renders every shadow caster into the shadow map from the light's perspective. Casters are not
+    // frustum-culled against the camera: geometry behind or beside the view can still cast into it.
+    private void RenderShadowPass(DirectionalLight light, Vector3 sceneCenter)
+    {
+        shadowMapRenderer!.BeginPass(light, sceneCenter);
+
+        foreach (
+            (
+                Entity _,
+                MeshHandle handle,
+                Transform3D transform,
+                Material3D _
+            ) in world.Query<MeshHandle, Transform3D, Material3D>()
+        )
+        {
+            if (meshRegistry.TryGet(handle, out var mesh))
+                shadowMapRenderer.Draw(mesh, transform.ModelMatrix);
+        }
+
+        var size = window.Size;
+        shadowMapRenderer.EndPass((int)size.X, (int)size.Y);
+    }
+
     private (
         Matrix4x4 View,
         Matrix4x4 Projection,
         Vector3 CameraPos,
+        Vector3 SceneCenter,
         bool HasCamera
     ) GetCameraMatrices()
     {
@@ -95,10 +137,16 @@ public class MeshRenderSystem(
         {
             var size = window.Size;
             var aspectRatio = size.Y > 0f ? size.X / size.Y : 1f;
-            return (camera.ViewMatrix, camera.ProjectionMatrix(aspectRatio), camera.Position, true);
+            return (
+                camera.ViewMatrix,
+                camera.ProjectionMatrix(aspectRatio),
+                camera.Position,
+                camera.Target,
+                true
+            );
         }
 
-        return (Matrix4x4.Identity, Matrix4x4.Identity, Vector3.Zero, false);
+        return (Matrix4x4.Identity, Matrix4x4.Identity, Vector3.Zero, Vector3.Zero, false);
     }
 
     // Fills _pointLights with up to MaxPointLights entities carrying a PointLight + Transform3D

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -109,12 +109,11 @@ public class MeshRenderSystem(
         shadowMapRenderer!.BeginPass(light, sceneCenter);
 
         foreach (
-            (
-                Entity _,
-                MeshHandle handle,
-                Transform3D transform,
-                Material3D _
-            ) in world.Query<MeshHandle, Transform3D, Material3D>()
+            (Entity _, MeshHandle handle, Transform3D transform, Material3D _) in world.Query<
+                MeshHandle,
+                Transform3D,
+                Material3D
+            >()
         )
         {
             if (meshRegistry.TryGet(handle, out var mesh))

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -63,6 +63,12 @@ public class MeshRenderSystem(
                 settings.EnablePcf
             );
         }
+        else
+        {
+            // Keep the opt-in robust when a Renderer3D is shared with a shadow-casting system: clear
+            // any stale shadow state so this scene doesn't sample a leftover/deleted depth texture.
+            renderer.DisableShadows();
+        }
 
         foreach (
             (

--- a/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/MeshRenderSystem.cs
@@ -106,7 +106,10 @@ public class MeshRenderSystem(
     // frustum-culled against the camera: geometry behind or beside the view can still cast into it.
     private void RenderShadowPass(DirectionalLight light, Vector3 sceneCenter)
     {
-        shadowMapRenderer!.BeginPass(light, sceneCenter);
+        // Caller guards on shadowMapRenderer != null; hoist to a non-null local so the whole method
+        // reads off a single, analysis-friendly reference.
+        var shadowMap = shadowMapRenderer!;
+        shadowMap.BeginPass(light, sceneCenter);
 
         foreach (
             (Entity _, MeshHandle handle, Transform3D transform, Material3D _) in world.Query<
@@ -117,11 +120,11 @@ public class MeshRenderSystem(
         )
         {
             if (meshRegistry.TryGet(handle, out var mesh))
-                shadowMapRenderer.Draw(mesh, transform.ModelMatrix);
+                shadowMap.Draw(mesh, transform.ModelMatrix);
         }
 
         var size = window.Size;
-        shadowMapRenderer.EndPass((int)size.X, (int)size.Y);
+        shadowMap.EndPass((int)size.X, (int)size.Y);
     }
 
     private (

--- a/src/Engine/Yaeger/TypeForwarders.cs
+++ b/src/Engine/Yaeger/TypeForwarders.cs
@@ -43,6 +43,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.ParticlePool))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.PointLight))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.RenderLayer))]
+[assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.ShadowSettings))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Skybox))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.SpotLight))]
 [assembly: TypeForwardedTo(typeof(global::Yaeger.Graphics.Sprite))]

--- a/tests/Yaeger.Tests/Graphics/ShadowSettingsTests.cs
+++ b/tests/Yaeger.Tests/Graphics/ShadowSettingsTests.cs
@@ -1,0 +1,43 @@
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Graphics;
+
+public class ShadowSettingsTests
+{
+    [Fact]
+    public void IsStruct_SatisfiesEcsConstraint()
+    {
+        Assert.True(typeof(ShadowSettings).IsValueType);
+    }
+
+    [Fact]
+    public void Default_HasSensibleValues()
+    {
+        var settings = ShadowSettings.Default;
+
+        Assert.Equal(2048, settings.MapResolution);
+        Assert.Equal(10f, settings.OrthographicSize);
+        Assert.Equal(0.1f, settings.NearPlane);
+        Assert.Equal(50f, settings.FarPlane);
+        Assert.Equal(0.005f, settings.Bias);
+        Assert.True(settings.EnablePcf);
+    }
+
+    [Fact]
+    public void RecordStruct_EqualityByValue()
+    {
+        var a = ShadowSettings.Default;
+        var b = ShadowSettings.Default;
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void DifferentResolution_NotEqual()
+    {
+        var a = ShadowSettings.Default;
+        var b = a with { MapResolution = 1024 };
+
+        Assert.NotEqual(a, b);
+    }
+}

--- a/tests/Yaeger.Tests/Rendering/ShadowMapRendererTests.cs
+++ b/tests/Yaeger.Tests/Rendering/ShadowMapRendererTests.cs
@@ -1,0 +1,99 @@
+using System.Numerics;
+using Yaeger.Graphics;
+using Yaeger.Rendering;
+
+namespace Yaeger.Tests.Rendering;
+
+// Exercises the GL-free light-space projection maths. Constructing a ShadowMapRenderer needs a live
+// OpenGL context, so only the static matrix builder is unit-tested (mirroring the renderer/window
+// test convention in CLAUDE.md).
+public class ShadowMapRendererTests
+{
+    private static Vector3 ProjectToNdc(Vector3 worldPoint, Matrix4x4 lightSpace)
+    {
+        // Matches the GL convention used throughout the engine: clip = worldPoint(row) * matrix,
+        // which Vector4.Transform computes directly.
+        var clip = Vector4.Transform(new Vector4(worldPoint, 1f), lightSpace);
+        return new Vector3(clip.X, clip.Y, clip.Z) / clip.W;
+    }
+
+    [Fact]
+    public void ComputeLightSpaceMatrix_CentersSceneCenterInNdc()
+    {
+        var light = new DirectionalLight
+        {
+            Direction = Vector3.Normalize(new Vector3(0.3f, 1f, 0.2f)),
+            Color = Color.White,
+            Intensity = 1f,
+        };
+        var center = new Vector3(1f, 2f, -3f);
+
+        var matrix = ShadowMapRenderer.ComputeLightSpaceMatrix(light, center, ShadowSettings.Default);
+        var ndc = ProjectToNdc(center, matrix);
+
+        Assert.Equal(0f, ndc.X, 3);
+        Assert.Equal(0f, ndc.Y, 3);
+    }
+
+    [Fact]
+    public void ComputeLightSpaceMatrix_PointTowardLightHasSmallerDepth()
+    {
+        var light = new DirectionalLight
+        {
+            Direction = Vector3.UnitY,
+            Color = Color.White,
+            Intensity = 1f,
+        };
+        var center = Vector3.Zero;
+        var settings = ShadowSettings.Default;
+
+        var matrix = ShadowMapRenderer.ComputeLightSpaceMatrix(light, center, settings);
+
+        var centerDepth = ProjectToNdc(center, matrix).Z;
+        // A point shifted toward the light sits nearer the light's eye, so its depth must be smaller.
+        var nearerDepth = ProjectToNdc(center + Vector3.UnitY * 2f, matrix).Z;
+
+        Assert.True(nearerDepth < centerDepth);
+    }
+
+    [Fact]
+    public void ComputeLightSpaceMatrix_SceneCenterDepthWithinUnitRange()
+    {
+        var light = new DirectionalLight
+        {
+            Direction = Vector3.UnitY,
+            Color = Color.White,
+            Intensity = 1f,
+        };
+
+        var matrix = ShadowMapRenderer.ComputeLightSpaceMatrix(
+            light,
+            Vector3.Zero,
+            ShadowSettings.Default
+        );
+        var depth = ProjectToNdc(Vector3.Zero, matrix).Z;
+
+        Assert.InRange(depth, 0f, 1f);
+    }
+
+    [Fact]
+    public void ComputeLightSpaceMatrix_DegenerateDirection_ProducesFiniteMatrix()
+    {
+        var light = new DirectionalLight
+        {
+            Direction = Vector3.Zero,
+            Color = Color.White,
+            Intensity = 1f,
+        };
+
+        var matrix = ShadowMapRenderer.ComputeLightSpaceMatrix(
+            light,
+            Vector3.Zero,
+            ShadowSettings.Default
+        );
+
+        Assert.True(float.IsFinite(matrix.M11));
+        Assert.True(float.IsFinite(matrix.M44));
+        Assert.NotEqual(default, matrix);
+    }
+}

--- a/tests/Yaeger.Tests/Rendering/ShadowMapRendererTests.cs
+++ b/tests/Yaeger.Tests/Rendering/ShadowMapRendererTests.cs
@@ -28,7 +28,11 @@ public class ShadowMapRendererTests
         };
         var center = new Vector3(1f, 2f, -3f);
 
-        var matrix = ShadowMapRenderer.ComputeLightSpaceMatrix(light, center, ShadowSettings.Default);
+        var matrix = ShadowMapRenderer.ComputeLightSpaceMatrix(
+            light,
+            center,
+            ShadowSettings.Default
+        );
         var ndc = ProjectToNdc(center, matrix);
 
         Assert.Equal(0f, ndc.X, 3);


### PR DESCRIPTION
## Summary

Implements two-pass **directional shadow mapping** for the 3D renderer (issue #105), with optional PCF soft shadows. The feature is **opt-in** — scenes that don't create a `ShadowMapRenderer` render exactly as before.

### How it works
1. **Shadow pass** — the scene is rendered from the directional light's point of view into an off-screen depth texture using a depth-only shader and an orthographic projection. All meshes are drawn (no camera-frustum culling) so off-screen geometry can still cast into view.
2. **Lighting pass** — each fragment is projected into light space, its depth compared against the shadow map, and the directional light's contribution is removed where occluded. An optional 3×3 PCF kernel softens the edges.

Only the directional light casts shadows in v1 (point/spot shadows are a follow-up). Single cascade, fixed map resolution — matching the scope agreed in the issue.

## Changes

**New types**
- `Graphics/ShadowSettings.cs` — `record struct`: `MapResolution`, `OrthographicSize`, `NearPlane`, `FarPlane`, `Bias`, `EnablePcf`, plus `Default`.
- `Rendering/ShadowMapRenderer.cs` — owns the depth FBO + depth texture and the depth-only pass (`BeginPass`/`Draw`/`EndPass`). Static, GL-free `ComputeLightSpaceMatrix` builds the light's orthographic view-projection framed on the camera target.

**Modified**
- `Rendering/Renderer3D.cs` — vertex shader emits `vLightSpacePos`; fragment shader gains `directionalShadow()` (depth compare + 3×3 PCF) applied to the directional contribution in both the PBR and Blinn-Phong paths. New `SetShadowMap(...)` / `DisableShadows()` API; shadow sampler on texture unit 5 with a white (depth-1.0 = lit) fallback so the sampler stays complete when shadows are off.
- `Systems/MeshRenderSystem.cs` — runs the shadow pre-pass before `BeginFrame3D` when a `ShadowMapRenderer` is supplied (new optional ctor arg), then uploads the map for the lighting pass.
- `Samples/CornellBox/Program.cs` — enables a 2048² PCF shadow map; angled/brightened the directional light so the boxes cast visible floor shadows.

**Docs & tests**
- `docs/shadows.md` (+ cross-link from `lighting.md`).
- `ShadowSettingsTests` and `ShadowMapRendererTests` (light-space projection maths: centering, relative depth ordering, valid range, degenerate-direction safety).

## Acceptance criteria
- [x] Depth framebuffer and shadow map texture created on init
- [x] Scene rendered into the shadow map each frame from the light's perspective
- [x] Lighting fragment shader samples the shadow map and darkens shadowed fragments
- [x] PCF soft shadows togglable via `ShadowSettings.EnablePcf`
- [x] `CornellBox` sample shows visible cast shadows
- [x] No extra draw calls beyond one depth pass; 2048² map

## ⚠️ Not verified locally
The .NET 10 SDK could not be installed in the execution sandbox (network policy blocks the Microsoft download hosts), so **`dotnet build`, `dotnet test`, and `csharpier check` were not run**. The code follows existing conventions and verified Silk.NET/GLSL usage, but should be built, tested, and formatter-checked before merge.

https://claude.ai/code/session_01ShLhirQ8BLBY5hrz4Q1ezw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShLhirQ8BLBY5hrz4Q1ezw)_