### PR TITLE
docs: bring documentation in line with the current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For more information about testing, see the [Testing Guide](docs/TESTING.md).
 
 - `src/Engine/Yaeger.Core/` - Platform-agnostic engine assembly (no Silk.NET dependency): ECS, components/transforms, physics, prefabs & scenes, the platform-independent systems (animation, particles, parallax), and the platform-abstraction interfaces (render/text surfaces, input state, time source, asset resolver). These sources physically live under `src/Engine/Yaeger/` and are linked into `Yaeger.Core` via `<Compile Include>` globs (`Yaeger.Core.csproj`); `Yaeger.csproj` removes them and references `Yaeger.Core`.
 - `src/Engine/Yaeger/` - Native runtime (references `Yaeger.Core`): windowing, 2D/3D rendering, audio, input bindings, font runtime, UI + editor overlay, and model loaders — the Silk.NET/OpenGL/OpenAL-dependent pieces
-- `src/Engine/Yaeger.Browser/` - Browser runtime adapters (Canvas2D render surface, browser input/time sources)
+- `src/Engine/Yaeger.Browser/` - Browser runtime adapters (WebGL 2.0 render surface, browser input/time sources)
 - `tests/Yaeger.Tests/` - Unit test suite (ECS, Graphics, Physics, Assets, Font, Rendering, Systems, Browser)
 - `Samples/` - Example games and demos
   - `Pong/` - Classic Pong game implementation
@@ -91,7 +91,7 @@ For more information about testing, see the [Testing Guide](docs/TESTING.md).
 
 `Yaeger.Core` is the platform-agnostic engine assembly — it contains the ECS, components, physics, prefabs & scenes, and the platform-independent systems, alongside the platform-abstraction interfaces, with no Silk.NET dependency. Reference it directly for headless simulation, gameplay logic, and unit tests.
 For desktop/native behavior (windowing, 2D/3D rendering, input, audio), reference `Yaeger`.
-For browser/WebAssembly behavior (Canvas2D rendering, browser input/frame timing), reference `Yaeger.Browser`.
+For browser/WebAssembly behavior (WebGL 2.0 rendering, browser input/frame timing), reference `Yaeger.Browser`.
 See the Pong sample for a minimal end-to-end native implementation.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ YAEGER - **Y**et **A**nother **E**xperimental **G**ame **E**ngine **R**epository
 
 ## Overview
 
-Yaeger is a modular, experimental 2D/3D game engine written in C#. It aims to provide a flexible and extensible platform for rapid prototyping and development of games and interactive applications. The engine is designed with an Entity-Component-System (ECS) architecture and is split into a platform-agnostic abstraction layer (`Yaeger.Core`) plus a native runtime (`Yaeger`) for Silk.NET/OpenGL/OpenAL integration and a browser runtime (`Yaeger.Browser`).
+Yaeger is a modular, experimental 2D/3D game engine written in C#. It aims to provide a flexible and extensible platform for rapid prototyping and development of games and interactive applications. The engine is designed with an Entity-Component-System (ECS) architecture and is split into a platform-agnostic engine core (`Yaeger.Core`) plus a native runtime (`Yaeger`) for Silk.NET/OpenGL/OpenAL integration and a browser runtime (`Yaeger.Browser`).
 
 ## Features
 
@@ -67,7 +67,7 @@ For more information about testing, see the [Testing Guide](docs/TESTING.md).
 
 ## Project Structure
 
-- `src/Engine/Yaeger.Core/` - Platform-agnostic engine assembly (no Silk.NET dependency): ECS, components/transforms, physics, prefabs & scenes, the platform-independent systems (animation, particles, parallax), and the platform-abstraction interfaces (render/text surfaces, input state, time source, asset resolver). These sources physically live under `src/Engine/Yaeger/` and are linked into `Yaeger.Core` via `<Compile Include>` globs (`Yaeger.Core.csproj`); `Yaeger.csproj` removes them and references `Yaeger.Core`.
+- `src/Engine/Yaeger.Core/` - Platform-agnostic engine assembly (no Silk.NET dependency): ECS, components/transforms, physics, prefabs & scenes, the platform-independent systems (animation, particles, parallax), and the platform-abstraction interfaces (render/text surfaces, input state, time source, asset resolver). The abstraction interfaces (`Platform/`) and `FontHandle` (`Graphics/`) live here under `src/Engine/Yaeger.Core/`; the ECS/Graphics/Physics/Systems sources physically live under `src/Engine/Yaeger/` and are linked into `Yaeger.Core` via `<Compile Include>` globs (`Yaeger.Core.csproj`), which `Yaeger.csproj` then removes and references.
 - `src/Engine/Yaeger/` - Native runtime (references `Yaeger.Core`): windowing, 2D/3D rendering, audio, input bindings, font runtime, UI + editor overlay, and model loaders — the Silk.NET/OpenGL/OpenAL-dependent pieces
 - `src/Engine/Yaeger.Browser/` - Browser runtime adapters (WebGL 2.0 render surface, browser input/time sources)
 - `tests/Yaeger.Tests/` - Unit test suite (ECS, Graphics, Physics, Assets, Font, Rendering, Systems, Browser)

--- a/README.md
+++ b/README.md
@@ -4,16 +4,20 @@ YAEGER - **Y**et **A**nother **E**xperimental **G**ame **E**ngine **R**epository
 
 ## Overview
 
-Yaeger is a modular, experimental 2D game engine written in C#. It aims to provide a flexible and extensible platform for rapid prototyping and development of games and interactive applications. The engine is designed with an Entity-Component-System (ECS) architecture and is split into a platform-agnostic core (`Yaeger.Core`) plus a native runtime (`Yaeger`) for Silk.NET/OpenGL/OpenAL integration.
+Yaeger is a modular, experimental 2D/3D game engine written in C#. It aims to provide a flexible and extensible platform for rapid prototyping and development of games and interactive applications. The engine is designed with an Entity-Component-System (ECS) architecture and is split into a platform-agnostic abstraction layer (`Yaeger.Core`) plus a native runtime (`Yaeger`) for Silk.NET/OpenGL/OpenAL integration and a browser runtime (`Yaeger.Browser`).
 
 ## Features
 
-- Entity-Component-System (ECS) architecture
-- 2D rendering with Silk.NET (texture-batched sprites with deterministic ordering)
-- Deterministic layered draw ordering via `RenderLayer` and `UnifiedRenderSystem`
+- Entity-Component-System (ECS) architecture, with JSON prefabs and scenes
+- 2D rendering with Silk.NET (texture-batched sprites with deterministic, layered draw ordering via `RenderLayer` and `UnifiedRenderSystem`)
+- 3D rendering — mesh rendering with lighting, shadow mapping, and PBR materials (see [`docs/`](docs/index.md))
 - Opt-in 2D camera (pan / zoom / rotate; world-space sprites + screen-space text)
+- Frame-based animation and a pooled, batched particle system
+- 2D physics (AABB/circle collision detection + impulse-based resolution)
+- Audio playback via OpenAL and text rendering via HarfBuzz/Skia
+- In-game ImGui editor overlay for live entity/component editing
 - Input handling (keyboard, mouse; browser runtime maps single-touch/pen to mouse-style input)
-- Sample games (see `Samples/Pong`, `Samples/BouncingBalls`, `Samples/Animation2D`, `Samples/CameraDemo`)
+- Sample games and demos (see [`Samples/`](Samples))
 - Extensible component and system design
 - Comprehensive unit test suite
 
@@ -59,32 +63,34 @@ The project includes a comprehensive test suite covering the ECS system and grap
 dotnet test
 ```
 
-For more information about testing, see the [Testing Guide](docs/testing.md).
+For more information about testing, see the [Testing Guide](docs/TESTING.md).
 
 ## Project Structure
 
-- `src/Engine/Yaeger.Core/` - Platform-agnostic engine core (ECS, scenes, animation, transforms, physics, gameplay logic)
-- `src/Engine/Yaeger/` - Native runtime (windowing, rendering, input bindings, audio, font runtime)
+- `src/Engine/Yaeger.Core/` - Platform-agnostic abstractions with no Silk.NET dependency (render/text surfaces, input state, time source, asset resolver, font handle)
+- `src/Engine/Yaeger/` - The engine plus native runtime (ECS, components, physics, systems, 2D/3D rendering, audio, input, font, windowing)
 - `src/Engine/Yaeger.Browser/` - Browser runtime adapters (Canvas2D render surface, browser input/time sources)
-- `tests/Yaeger.Tests/` - Unit test suite
-  - `ECS/` - Tests for ECS components
-  - `Graphics/` - Tests for graphics primitives
+- `tests/Yaeger.Tests/` - Unit test suite (ECS, Graphics, Physics, Assets, Font, Rendering, Systems, Browser)
 - `Samples/` - Example games and demos
-  - `BrowserDemo/` - Blazor/WebAssembly browser loop + browser input/runtime integration
   - `Pong/` - Classic Pong game implementation
   - `BouncingBalls/` - Physics demo
   - `Animation2D/` - Sprite-sheet animation demo
   - `CameraDemo/` - Opt-in 2D camera (pan / zoom / rotate)
   - `MouseDemo/` - Mouse input (paint trail + scroll resize)
+  - `ParticleDemo/` - Particle effects (fire, smoke, explosions)
   - `SceneDemo/` - JSON scene loading
+  - `CornellBox/` - 3D Cornell Box + F1 editor overlay
+  - `Sponza/` - glTF Sponza scene rendered through the PBR path
+  - `UiDemo/` - ImGui UI demo
+  - `BrowserDemo/` - Blazor/WebAssembly browser loop + browser input/runtime integration
   - `RenderingStressTest/` - Renderer stress test (FPS vs sprite count)
-- `docs/` - Documentation
-  - `TESTING.md` - Comprehensive testing guide
+  - `TextRenderingExample/` - Text rendering demo
+- `docs/` - Documentation (see [`docs/index.md`](docs/index.md))
 
 ## Usage
 
-For headless/platform-agnostic simulation and gameplay logic, reference `Yaeger.Core`.
-For desktop/native runtime behavior (window, rendering, input, audio), reference `Yaeger`.
+`Yaeger.Core` defines the platform-agnostic abstractions (render/text surfaces, input state, time source, asset resolver) shared by the runtimes; it has no Silk.NET dependency.
+For desktop/native behavior (ECS, window, rendering, input, audio), reference `Yaeger`.
 For browser/WebAssembly behavior (Canvas2D rendering, browser input/frame timing), reference `Yaeger.Browser`.
 See the Pong sample for a minimal end-to-end native implementation.
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ For more information about testing, see the [Testing Guide](docs/TESTING.md).
 
 ## Project Structure
 
-- `src/Engine/Yaeger.Core/` - Platform-agnostic abstractions with no Silk.NET dependency (render/text surfaces, input state, time source, asset resolver, font handle)
-- `src/Engine/Yaeger/` - The engine plus native runtime (ECS, components, physics, systems, 2D/3D rendering, audio, input, font, windowing)
+- `src/Engine/Yaeger.Core/` - Platform-agnostic engine assembly (no Silk.NET dependency): ECS, components/transforms, physics, prefabs & scenes, the platform-independent systems (animation, particles, parallax), and the platform-abstraction interfaces (render/text surfaces, input state, time source, asset resolver). These sources physically live under `src/Engine/Yaeger/` and are linked into `Yaeger.Core` via `<Compile Include>` globs (`Yaeger.Core.csproj`); `Yaeger.csproj` removes them and references `Yaeger.Core`.
+- `src/Engine/Yaeger/` - Native runtime (references `Yaeger.Core`): windowing, 2D/3D rendering, audio, input bindings, font runtime, UI + editor overlay, and model loaders — the Silk.NET/OpenGL/OpenAL-dependent pieces
 - `src/Engine/Yaeger.Browser/` - Browser runtime adapters (Canvas2D render surface, browser input/time sources)
 - `tests/Yaeger.Tests/` - Unit test suite (ECS, Graphics, Physics, Assets, Font, Rendering, Systems, Browser)
 - `Samples/` - Example games and demos
@@ -89,8 +89,8 @@ For more information about testing, see the [Testing Guide](docs/TESTING.md).
 
 ## Usage
 
-`Yaeger.Core` defines the platform-agnostic abstractions (render/text surfaces, input state, time source, asset resolver) shared by the runtimes; it has no Silk.NET dependency.
-For desktop/native behavior (ECS, window, rendering, input, audio), reference `Yaeger`.
+`Yaeger.Core` is the platform-agnostic engine assembly — it contains the ECS, components, physics, prefabs & scenes, and the platform-independent systems, alongside the platform-abstraction interfaces, with no Silk.NET dependency. Reference it directly for headless simulation, gameplay logic, and unit tests.
+For desktop/native behavior (windowing, 2D/3D rendering, input, audio), reference `Yaeger`.
 For browser/WebAssembly behavior (Canvas2D rendering, browser input/frame timing), reference `Yaeger.Browser`.
 See the Pong sample for a minimal end-to-end native implementation.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -8,7 +8,7 @@ This document describes the testing approach implemented for the Yaeger 2D/3D ga
 
 ### Framework
 
-- **Testing Framework**: xUnit 2.9.2 (with Xunit.SkippableFact for tests that need a live OpenGL context)
+- **Testing Framework**: xUnit 2.9.2 (with Xunit.SkippableFact for tests that need optional native libraries such as Assimp or HarfBuzz)
 - **Test SDK**: Microsoft.NET.Test.Sdk 17.12.0
 - **Coverage Tool**: coverlet.collector 6.0.2
 - **Target Framework**: .NET 10.0
@@ -258,9 +258,9 @@ The recommended CI pipeline should:
 ### Expected Test Results
 
 All tests should pass. The suite currently holds **500+ test cases across 50+ files**
-and runs in a few seconds. Tests that require a live OpenGL context use
-`Xunit.SkippableFact` and are skipped automatically in headless environments rather
-than failing.
+and runs in a few seconds. Tests that depend on optional native libraries (e.g.
+Assimp model loading, HarfBuzz font shaping) use `Xunit.SkippableFact` and skip
+automatically when those libraries aren't available, rather than failing.
 
 ## Future Testing Improvements
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,29 +2,34 @@
 
 ## Overview
 
-This document describes the testing approach implemented for the Yaeger 2D game engine. The test suite is built using xUnit and covers the core ECS (Entity-Component-System) architecture and graphics components.
+This document describes the testing approach implemented for the Yaeger 2D/3D game engine. The test suite is built using xUnit and covers the core ECS (Entity-Component-System) architecture, graphics components, physics, asset loading, fonts, and the engine's update/render systems.
 
 ## Test Infrastructure
 
 ### Framework
 
-- **Testing Framework**: xUnit 2.9.2
+- **Testing Framework**: xUnit 2.9.2 (with Xunit.SkippableFact for tests that need a live OpenGL context)
 - **Test SDK**: Microsoft.NET.Test.Sdk 17.12.0
 - **Coverage Tool**: coverlet.collector 6.0.2
 - **Target Framework**: .NET 10.0
 
 ### Project Structure
 
+Tests live under `tests/Yaeger.Tests/`, organized into folders that mirror the
+engine source layout:
+
 ```
 tests/
 └── Yaeger.Tests/
-    ├── ECS/
-    │   ├── WorldTests.cs           # World entity management tests
-    │   ├── EntityTests.cs          # Entity behavior tests
-    │   └── WorldExtensionsTests.cs # ECS query system tests
-    ├── Graphics/
-    │   ├── Transform2DTests.cs     # 2D transformation tests
-    │   └── ColorTests.cs           # Color structure tests
+    ├── AssetPathTests.cs           # Asset path resolution
+    ├── ECS/                        # World, entities, queries, prefabs, scenes, serializers
+    ├── Graphics/                   # Transforms, colors, cameras, lights, sprite sheets, particles, …
+    ├── Physics/                    # Colliders, rigid bodies + collision/movement/gravity systems
+    ├── Assets/                     # OBJ/MTL/Assimp model loaders
+    ├── Font/                       # Font manager and SDF glyph atlas
+    ├── Rendering/                  # Mesh data, vertex layout, shadow map renderer
+    ├── Systems/                    # Parallax, particle, and UI update systems
+    ├── Browser/                    # Browser runtime adapters (e.g. time source)
     └── Yaeger.Tests.csproj
 ```
 
@@ -56,54 +61,40 @@ dotnet test --collect:"XPlat Code Coverage"
 
 ## Test Coverage
 
-### ECS System (Entity-Component-System)
+The suite has grown well beyond its original ECS/graphics scope — it now contains
+**500+ test cases across 50+ files**. The areas below summarize what is covered;
+the source files under each folder are the authoritative list.
 
-#### World Tests (`WorldTests.cs`)
-- Entity creation and ID management
-- Component addition, retrieval, and removal
-- Entity destruction
-- Component store management
-- Multiple entity handling
+### ECS System (Entity-Component-System) — `ECS/`
 
-**Test Count**: 11 tests
+- Entity creation, ID management, and destruction (`WorldTests`, `EntityTests`)
+- Component addition, retrieval, removal, and store management
+- Two/three/four-component queries and filtering (`WorldExtensionsTests`)
+- Prefab loading and building (`PrefabLoaderTests`, `PrefabTests`)
+- Scene load/save round-trips (`SceneLoaderTests`, `SceneSaverTests`)
+- Component serializers, including 3D and render-layer serializers
 
-#### Entity Tests (`EntityTests.cs`)
-- Entity ID uniqueness
-- Value type behavior
-- Hash code generation
-- Equality comparison
+### Graphics System — `Graphics/`
 
-**Test Count**: 4 tests
+- 2D and 3D transforms (`Transform2DTests`, `Transform3DTests`)
+- Color construction, alpha, and predefined values (`ColorTests`)
+- 2D/3D cameras and frustum culling (`Camera2DTests`, `Camera3DTests`, `CameraFrustumTests`)
+- Lights (`DirectionalLightTests`, `PointLightTests`, `SpotLightTests`)
+- Materials, sprite sheets, sprite tinting, AABBs, mesh/font handles, particle pools, parallax layers, shadow settings
 
-#### WorldExtensions Tests (`WorldExtensionsTests.cs`)
-- Two-component queries
-- Three-component queries
-- Four-component queries
-- Query result filtering
-- Component removal interaction
-- Duplicate handling
+### Physics — `Physics/`
 
-**Test Count**: 7 tests
+- Colliders, rigid bodies, velocity, and physics materials (`Components/`)
+- Collision detection/resolution, movement, gravity, and the `PhysicsWorld2D` façade (`Systems/`)
 
-### Graphics System
+### Other areas
 
-#### Transform2D Tests (`Transform2DTests.cs`)
-- Position, rotation, and scale properties
-- Default value handling
-- Transform matrix generation
-- Matrix composition (scale, rotation, translation)
-- Property mutation
-
-**Test Count**: 12 tests
-
-#### Color Tests (`ColorTests.cs`)
-- RGB value construction
-- Alpha channel handling
-- Predefined colors (White, Black, Red, Green, Blue)
-- Value type behavior
-- Transparency support
-
-**Test Count**: 11 tests
+- **Assets/** — OBJ/MTL/Assimp model loaders
+- **Font/** — font manager and SDF glyph atlas
+- **Rendering/** — mesh data, vertex layout, shadow map renderer
+- **Systems/** — parallax, particle, and UI update systems
+- **Browser/** — browser runtime adapters (e.g. time source)
+- **AssetPathTests** — asset path resolution against `AppContext.BaseDirectory`
 
 ## Testing Approach
 
@@ -266,11 +257,10 @@ The recommended CI pipeline should:
 
 ### Expected Test Results
 
-Current test statistics:
-- **Total Tests**: 45
-- **Passed**: 45
-- **Failed**: 0
-- **Execution Time**: ~0.06 seconds
+All tests should pass. The suite currently holds **500+ test cases across 50+ files**
+and runs in a few seconds. Tests that require a live OpenGL context use
+`Xunit.SkippableFact` and are skipped automatically in headless environments rather
+than failing.
 
 ## Future Testing Improvements
 
@@ -331,10 +321,10 @@ When adding new features to Yaeger:
 2. Ensure all existing tests pass
 3. Add tests for new functionality
 4. Update this documentation if adding new test categories
-5. Run `dotnet format` before committing
+5. Run `dotnet csharpier format .` before committing (the project uses CSharpier, not `dotnet format`; a Husky pre-commit hook also formats staged `.cs` files, and CI enforces `dotnet csharpier check .`)
 
 ---
 
-**Last Updated**: January 2026
+**Last Updated**: June 2026
 **Test Framework Version**: xUnit 2.9.2
-**Test Count**: 45 tests
+**Test Count**: 500+ tests across 50+ files

--- a/docs/animation-system.md
+++ b/docs/animation-system.md
@@ -61,7 +61,9 @@ using Yaeger.Windowing;
 using var window = Window.Create();
 var world = new World();
 var renderer = new Renderer(window);
-var renderSystem = new RenderSystem(renderer, world);
+// UnifiedRenderSystem draws sprites (and optionally text) in deterministic layer order.
+// Pass null for the text renderer when you only need sprites.
+var renderSystem = new UnifiedRenderSystem(renderer, null, world);
 var animationSystem = new AnimationSystem(world);
 
 // Create an animated entity
@@ -116,7 +118,7 @@ The animation system integrates seamlessly with the existing ECS architecture:
 
 3. **AnimationSystem Updates Sprites**: The system automatically updates each entity's `Sprite` component based on the current animation frame.
 
-4. **RenderSystem Renders**: The existing `RenderSystem` renders the updated sprites normally.
+4. **UnifiedRenderSystem Renders**: `UnifiedRenderSystem` renders the updated sprites normally. (The older `RenderSystem` is now `[Obsolete]` — prefer `UnifiedRenderSystem`.)
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ src/Engine/
 │                     # text, meshes, shadows, skybox), audio, input bindings, font runtime
 │                     # (HarfBuzz/Skia), UI + editor overlay, and model loaders.
 │
-└── Yaeger.Browser/   # Browser/WebAssembly runtime adapters (Canvas2D surface, browser input/time)
+└── Yaeger.Browser/   # Browser/WebAssembly runtime adapters (WebGL 2.0 surface, browser input/time)
 ```
 
 > **Where the code physically lives.** The platform-agnostic sources sit on disk under

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,16 +2,19 @@
 
 **Y**et **A**nother **E**xperimental **G**ame **E**ngine **R**epository
 
-Yaeger is a modular, experimental 2D game engine written in C#. It provides a flexible and extensible platform for rapid prototyping and development of games and interactive applications, with a split between platform-agnostic core logic and native runtime integrations.
+Yaeger is a modular, experimental 2D/3D game engine written in C#. It provides a flexible and extensible platform for rapid prototyping and development of games and interactive applications, with a split between platform-agnostic abstractions and native/browser runtime integrations.
 
 ## Features
 
-- **Entity-Component-System (ECS)** architecture
-- **2D rendering** with Silk.NET
-- **Batch rendering** for efficient sprite rendering
-- **Animation system** with frame-based texture cycling
-- **Particle system** with pooled, batched emitters
-- **Audio system** with OpenAL support
+- **Entity-Component-System (ECS)** architecture, with JSON [prefabs and scenes](scenes.md)
+- **2D rendering** with Silk.NET — texture-batched sprites with deterministic, layered draw ordering (`UnifiedRenderSystem`)
+- **3D rendering** — mesh rendering with [lighting](lighting.md), [shadow mapping](shadows.md), and [PBR](pbr.md) materials
+- **Opt-in 2D camera** (pan / zoom / rotate) — see [camera.md](camera.md)
+- **Animation system** with frame-based texture cycling ([animation-system.md](animation-system.md))
+- **Particle system** with pooled, batched emitters ([particles.md](particles.md))
+- **2D physics** — AABB/circle collision detection and impulse-based resolution
+- **Audio system** with OpenAL support ([audio-system.md](audio-system.md))
+- **Text rendering** via HarfBuzz/Skia
 - **Input handling** (keyboard, mouse)
 - **Editor overlay** — in-game ImGui inspector for live entity/component editing ([editor.md](editor.md))
 - Extensible component and system design
@@ -40,14 +43,22 @@ dotnet run --project Samples/Pong/Pong.csproj
 ## Project Structure
 
 ```
-src/Engine/Yaeger.Core/        # Platform-agnostic core (ECS/scenes/animation/transforms/physics/gameplay logic)
+src/Engine/Yaeger.Core/        # Platform-agnostic abstractions (no Silk.NET dependency)
+                               # render/text surfaces, input state, time source, asset resolver, font handle
 
-src/Engine/Yaeger/             # Native runtime integrations
-├── Rendering/                 # OpenGL rendering systems (sprites, text)
+src/Engine/Yaeger/             # The engine + native (Silk.NET/OpenGL/OpenAL) runtime
+├── ECS/                       # Entities, components, queries, prefabs, scenes
+├── Graphics/                  # Value-type components (Transform2D/3D, Sprite, Camera2D/3D, lights, …)
+├── Physics/                   # AABB/circle collision detection + impulse resolution
+├── Systems/                   # Update/render systems (animation, particles, mesh, UI, …)
+├── Rendering/                 # OpenGL 2D + 3D renderers (sprites, text, meshes, shadows, skybox)
 ├── Audio/                     # OpenAL audio runtime
 ├── Input/                     # Silk.NET input bindings
 ├── Font/                      # HarfBuzz/Skia text runtime
+├── UI/ + Inspector/           # ImGui-based UI widgets and the editor overlay
 └── Windowing/                 # Window and context management
+
+src/Engine/Yaeger.Browser/     # Browser/WebAssembly runtime adapters (Canvas2D surface, browser input/time)
 
 Samples/
 ├── Pong/                    # Classic Pong game
@@ -58,6 +69,9 @@ Samples/
 ├── ParticleDemo/            # Particle effects demo (fire, smoke, explosions)
 ├── SceneDemo/               # JSON scene loading demo
 ├── CornellBox/              # 3D Cornell Box + F1 editor overlay demo
+├── Sponza/                  # glTF Sponza scene rendered through the PBR path
+├── UiDemo/                  # ImGui UI demo
+├── BrowserDemo/             # Blazor/WebAssembly browser loop demo
 ├── RenderingStressTest/     # Renderer stress test
 └── TextRenderingExample/    # Text rendering demo
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 **Y**et **A**nother **E**xperimental **G**ame **E**ngine **R**epository
 
-Yaeger is a modular, experimental 2D/3D game engine written in C#. It provides a flexible and extensible platform for rapid prototyping and development of games and interactive applications, with a split between platform-agnostic abstractions and native/browser runtime integrations.
+Yaeger is a modular, experimental 2D/3D game engine written in C#. It provides a flexible and extensible platform for rapid prototyping and development of games and interactive applications, with a split between a platform-agnostic engine core and native/browser runtime integrations.
 
 ## Features
 
@@ -43,23 +43,31 @@ dotnet run --project Samples/Pong/Pong.csproj
 ## Project Structure
 
 ```
-src/Engine/Yaeger.Core/        # Platform-agnostic abstractions (no Silk.NET dependency)
-                               # render/text surfaces, input state, time source, asset resolver, font handle
+src/Engine/
+├── Yaeger.Core/      # Platform-agnostic engine assembly — NO Silk.NET dependency.
+│                     # Compiles the core logic: ECS (entities, components, queries),
+│                     # transforms, physics, prefabs & scenes, and the platform-independent
+│                     # systems (animation, particles, parallax), plus the platform-abstraction
+│                     # interfaces in Platform/ (render/text surfaces, input state, time source,
+│                     # asset resolver) and FontHandle.
+│
+├── Yaeger/           # Native runtime assembly — references Yaeger.Core and adds the
+│                     # Silk.NET/OpenGL/OpenAL pieces: windowing, 2D + 3D rendering (sprites,
+│                     # text, meshes, shadows, skybox), audio, input bindings, font runtime
+│                     # (HarfBuzz/Skia), UI + editor overlay, and model loaders.
+│
+└── Yaeger.Browser/   # Browser/WebAssembly runtime adapters (Canvas2D surface, browser input/time)
+```
 
-src/Engine/Yaeger/             # The engine + native (Silk.NET/OpenGL/OpenAL) runtime
-├── ECS/                       # Entities, components, queries, prefabs, scenes
-├── Graphics/                  # Value-type components (Transform2D/3D, Sprite, Camera2D/3D, lights, …)
-├── Physics/                   # AABB/circle collision detection + impulse resolution
-├── Systems/                   # Update/render systems (animation, particles, mesh, UI, …)
-├── Rendering/                 # OpenGL 2D + 3D renderers (sprites, text, meshes, shadows, skybox)
-├── Audio/                     # OpenAL audio runtime
-├── Input/                     # Silk.NET input bindings
-├── Font/                      # HarfBuzz/Skia text runtime
-├── UI/ + Inspector/           # ImGui-based UI widgets and the editor overlay
-└── Windowing/                 # Window and context management
+> **Where the code physically lives.** The platform-agnostic sources sit on disk under
+> `src/Engine/Yaeger/` (e.g. `Yaeger/ECS`, `Yaeger/Graphics`, `Yaeger/Physics`) but are linked into
+> **`Yaeger.Core`** via `<Compile Include>` globs in `Yaeger.Core.csproj`; `Yaeger.csproj` then
+> `<Compile Remove>`s them and references `Yaeger.Core`. So the folder a file sits in does not always
+> match the assembly it compiles into — the `ECS`/`Graphics`/`Physics` folders compile into
+> `Yaeger.Core`, while `Text.cs`, `PhysicsDebugRenderer.cs`, `Rendering/`, `Audio/`, `Windowing/`,
+> `Font/`, `UI/`, and `Inspector/` compile into `Yaeger`.
 
-src/Engine/Yaeger.Browser/     # Browser/WebAssembly runtime adapters (Canvas2D surface, browser input/time)
-
+```
 Samples/
 ├── Pong/                    # Classic Pong game
 ├── BouncingBalls/           # Physics demo


### PR DESCRIPTION
## Summary

I reviewed the documentation (`docs/` + `README.md`) against the current code and fixed several places where it had drifted out of date. The biggest issues were the engine still being described as "2D-only" and a badly stale `TESTING.md`.

> **Correction (after review):** an earlier revision of this PR mistakenly claimed `Yaeger.Core` "only holds platform-agnostic abstractions" with ECS/components/physics living in `Yaeger`. That was wrong. `Yaeger.Core.csproj` compiles the platform-agnostic engine logic — ECS, components/transforms, physics, prefabs & scenes, and the animation/particle/parallax systems — via `<Compile Include>` linked-source globs. Those `.cs` files physically live under `src/Engine/Yaeger/`, but they compile into `Yaeger.Core` (which has no Silk.NET dependency); `Yaeger.csproj` `<Compile Remove>`s them and references `Yaeger.Core`. The docs and this description now reflect that.

## What was wrong & what changed

- **`Yaeger.Core` characterization.** README and `docs/index.md` now describe `Yaeger.Core` as the platform-agnostic engine assembly (ECS, components, physics, scenes, platform-independent systems, plus the `Platform/` abstraction interfaces), with an explicit note that the sources live under `src/Engine/Yaeger/` and are linked into Core — so a file's folder doesn't always match the assembly it compiles into. `Yaeger` adds the Silk.NET/OpenGL/OpenAL pieces (windowing, 2D/3D rendering, audio, input bindings, font runtime, UI/editor, model loaders).

- **The engine is 2D *and* 3D now.** `Renderer3D`, mesh rendering, lighting, shadow mapping, and PBR all exist (with `CornellBox`/`Sponza` samples and dedicated docs), but the headline text said "2D game engine". Updated framing and feature lists in `index.md`, `README.md`, and `TESTING.md`.

- **`animation-system.md` used the obsolete `RenderSystem`.** It's now `[Obsolete("Use UnifiedRenderSystem instead.")]`, and the `Animation2D` sample already uses `UnifiedRenderSystem`. Updated the example and integration notes.

- **`TESTING.md` was significantly stale.** It claimed 45 tests across 2 folders and recommended `dotnet format`. The suite is now 500+ tests across 50+ files (ECS, Graphics, Physics, Assets, Font, Rendering, Systems, Browser), and the project uses **CSharpier** (`dotnet csharpier format .`). Also corrected: `Xunit.SkippableFact` guards optional native libraries (Assimp, HarfBuzz), not a live OpenGL context.

- **Browser surface is WebGL 2.0, not Canvas2D.** `BrowserRenderSurface` initializes a WebGL 2.0 context (`JsInterop.InitWebGL`); corrected the wording in README and `docs/index.md`.

- **Broken link & incomplete sample lists.** Fixed the `docs/testing.md` → `docs/TESTING.md` link (case-sensitive on Linux) and completed the `Samples/` lists (`ParticleDemo`, `CornellBox`, `Sponza`, `UiDemo`, `TextRenderingExample`, etc.).

## Notes

- Docs that were already accurate were left untouched: `audio-system.md`, `camera.md`, `particles.md`, `scenes.md`, `editor.md`, `lighting.md`, `shadows.md`, `pbr.md`.
- I couldn't run `dotnet test` in this environment (no .NET SDK), so the "500+ tests / 50+ files" figure is derived from the test sources (52 test files, 530+ `[Fact]`/`[Theory]` attributes) rather than an exact run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)