### PR TITLE
Add selection gizmos to the inspector for in-world entity visualization

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -58,6 +58,34 @@ cover the engine's built-in components:
 > as Euler degrees (pitch X, yaw Y, roll Z). The displayed value is cached per selection so small
 > successive drags don't drift through repeated quaternion↔Euler round-trips.
 
+## Seeing the selected entity in the world
+
+Editing a light by typing numbers is hard when you can't see what they do. Whenever an entity is
+selected, the inspector draws **selection gizmos** directly into the 3D scene so you can see *where*
+the entity is and *which way it faces* while you drag its values:
+
+| Component | Gizmo |
+| --- | --- |
+| `Transform3D` | RGB orientation axes (X red, Y green, Z blue) at the entity's position |
+| `Aabb3D` (meshes) | an amber wireframe box around the mesh's world-space bounds |
+| `DirectionalLight` | a small "sun" with a bundle of parallel rays pointing the way the light travels |
+| `PointLight` | a wireframe sphere tracing the light's `Range`, in the light's colour |
+| `SpotLight` | a wireframe cone from the light along its `Direction`, opened to the outer cone angle |
+| `Camera3D` | a yellow view frustum showing what the camera frames |
+
+Lights and the camera are coloured to match, so a selected red point light shows a red range sphere.
+Gizmos are drawn on top of the scene (no depth testing), so a light tucked behind a wall is still
+visible while you position it.
+
+Gizmos are projected through the first `Camera3D` in the world (the same camera `MeshRenderSystem`
+renders through), so they line up exactly with the rendered scene. Purely 2D scenes — which have no
+`Camera3D` — show no gizmos. The overlay is on by default; untick **Show selection gizmos** at the
+bottom of the inspector (or set `inspector.ShowGizmos = false`) to hide it.
+
+> Because the gizmos read the live world every frame, dragging a `DirectionalLight`'s direction or a
+> `SpotLight`'s cone angle updates the gizmo immediately — no extra wiring beyond the standard
+> *scene first, overlay last* render order.
+
 ### Adding, removing, and destroying
 
 - **Add Component** — pick a type from the drop-down and press **+**. The 3D components above all

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -1,0 +1,185 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+
+namespace Yaeger.Inspector;
+
+/// <summary>
+/// Translates the components on a selected entity into editor gizmos — the world-space overlay that
+/// lets you <em>see</em> what you are editing: where a light sits, which way it faces, how far it
+/// reaches, where a mesh's bounds are, and what a camera frames. Pure (no GPU state): it only reads
+/// the world and appends lines to a <see cref="GizmoBuilder"/>, so it is fully unit-testable.
+/// </summary>
+public static class EntityGizmos
+{
+    private const float AxisLength = 0.5f;
+    private const float DirectionalArrowLength = 1.5f;
+    private const float DirectionalSunRadius = 0.15f;
+    private const float ArrowHeadSize = 0.18f;
+
+    // Selected meshes are outlined in amber so they stand out against typical scene colours.
+    private static readonly Vector4 BoundsColor = new(1f, 0.75f, 0.2f, 1f);
+    private static readonly Vector4 CameraColor = new(1f, 1f, 0.3f, 1f);
+
+    /// <summary>
+    /// Appends the gizmos for <paramref name="entity"/> to <paramref name="builder"/> based on the
+    /// components it carries. <paramref name="aspectRatio"/> is only used to shape a
+    /// <see cref="Camera3D"/> frustum.
+    /// </summary>
+    public static void Build(World world, Entity entity, float aspectRatio, GizmoBuilder builder)
+    {
+        var hasTransform = world.TryGetComponent<Transform3D>(entity, out var transform);
+        var anchor = hasTransform ? transform.Position : Vector3.Zero;
+
+        // Orientation axes + bounds give "where is the selected entity" for any 3D entity, meshes
+        // especially. Drawn first so light/camera specific shapes layer on top.
+        if (hasTransform)
+        {
+            builder.AddAxes(anchor, transform.Rotation, AxisLength);
+
+            if (world.TryGetComponent<Aabb3D>(entity, out var aabb))
+                builder.AddTransformedBox(aabb, transform.ModelMatrix, BoundsColor);
+        }
+
+        if (world.TryGetComponent<DirectionalLight>(entity, out var directional))
+            BuildDirectionalLight(builder, anchor, directional);
+
+        if (world.TryGetComponent<PointLight>(entity, out var point))
+            BuildPointLight(builder, anchor, point);
+
+        if (world.TryGetComponent<SpotLight>(entity, out var spot))
+            BuildSpotLight(builder, anchor, spot);
+
+        if (world.TryGetComponent<Camera3D>(entity, out var camera))
+            BuildCamera(builder, camera, aspectRatio);
+    }
+
+    private static void BuildDirectionalLight(
+        GizmoBuilder builder,
+        Vector3 anchor,
+        DirectionalLight light
+    )
+    {
+        var color = OpaqueColor(light.Color);
+
+        // Direction points from the surface toward the source, so light *travels* the opposite way.
+        // Visualise the travel direction as a bundle of parallel "sun ray" arrows — the standard
+        // editor cue for a directional light's facing.
+        var travel = SafeNormalize(-light.Direction, -Vector3.UnitY);
+        ParallelBasis(travel, out var u, out var v);
+
+        builder.AddWireSphere(anchor, DirectionalSunRadius, color, segments: 16);
+
+        ReadOnlySpan<Vector2> offsets =
+        [
+            Vector2.Zero,
+            new(1f, 0f),
+            new(-1f, 0f),
+            new(0f, 1f),
+            new(0f, -1f),
+        ];
+
+        const float spread = 0.18f;
+        foreach (var offset in offsets)
+        {
+            var shift = (u * offset.X + v * offset.Y) * spread;
+            var start = anchor + shift;
+            builder.AddArrow(start, start + travel * DirectionalArrowLength, color, ArrowHeadSize);
+        }
+    }
+
+    private static void BuildPointLight(GizmoBuilder builder, Vector3 anchor, PointLight light)
+    {
+        var color = OpaqueColor(light.Color);
+        var range = light.Range > 0f ? light.Range : 1f;
+
+        // The wire sphere traces the range (where the contribution falls to zero); a small core
+        // marks the exact position even when the range sphere is large.
+        builder.AddWireSphere(anchor, range, color);
+        builder.AddWireSphere(anchor, MathF.Min(0.1f, range * 0.1f), color, segments: 12);
+    }
+
+    private static void BuildSpotLight(GizmoBuilder builder, Vector3 anchor, SpotLight light)
+    {
+        var color = OpaqueColor(light.Color);
+        var range = light.Range > 0f ? light.Range : 1f;
+        var direction = SafeNormalize(light.Direction, -Vector3.UnitY);
+
+        // Base radius from the outer cone half-angle, clamped just below 90° so tan stays finite.
+        var outer = Math.Clamp(light.OuterConeAngle, 0f, 1.55f);
+        var baseRadius = range * MathF.Tan(outer);
+
+        builder.AddWireCone(anchor, direction, range, baseRadius, color);
+    }
+
+    private static void BuildCamera(GizmoBuilder builder, Camera3D camera, float aspectRatio)
+    {
+        var forward = SafeNormalize(camera.Target - camera.Position, -Vector3.UnitZ);
+        var up = SafeNormalize(camera.Up, Vector3.UnitY);
+        var right = SafeNormalize(Vector3.Cross(forward, up), Vector3.UnitX);
+        up = Vector3.Cross(right, forward);
+
+        var aspect = aspectRatio > 0f && float.IsFinite(aspectRatio) ? aspectRatio : 16f / 9f;
+        var fov = camera.Fov > 0f ? camera.Fov : MathF.PI / 4f;
+        var near = camera.Near > 0f ? camera.Near : 0.1f;
+
+        // Cap the visualised far plane so a frustum drawn for a 1000-unit camera stays on screen.
+        var far = MathF.Min(camera.Far > near ? camera.Far : near + 1f, near + 3f);
+
+        var tanHalf = MathF.Tan(fov * 0.5f);
+        var nearH = tanHalf * near;
+        var nearW = nearH * aspect;
+        var farH = tanHalf * far;
+        var farW = farH * aspect;
+
+        var nearCenter = camera.Position + forward * near;
+        var farCenter = camera.Position + forward * far;
+
+        var nearCorners = RectCorners(nearCenter, right, up, nearW, nearH);
+        var farCorners = RectCorners(farCenter, right, up, farW, farH);
+
+        for (var i = 0; i < 4; i++)
+        {
+            var next = (i + 1) % 4;
+            builder.AddLine(nearCorners[i], nearCorners[next], CameraColor);
+            builder.AddLine(farCorners[i], farCorners[next], CameraColor);
+            builder.AddLine(nearCorners[i], farCorners[i], CameraColor);
+        }
+    }
+
+    private static Vector3[] RectCorners(
+        Vector3 center,
+        Vector3 right,
+        Vector3 up,
+        float halfWidth,
+        float halfHeight
+    ) =>
+        [
+            center + right * halfWidth + up * halfHeight,
+            center + right * halfWidth - up * halfHeight,
+            center - right * halfWidth - up * halfHeight,
+            center - right * halfWidth + up * halfHeight,
+        ];
+
+    private static Vector4 OpaqueColor(Color color)
+    {
+        var v = color.ToVector4();
+        return new Vector4(v.X, v.Y, v.Z, 1f);
+    }
+
+    private static Vector3 SafeNormalize(Vector3 value, Vector3 fallback)
+    {
+        var lengthSq = value.LengthSquared();
+        return float.IsFinite(lengthSq) && lengthSq > 1e-12f
+            ? value / MathF.Sqrt(lengthSq)
+            : fallback;
+    }
+
+    // Orthonormal basis perpendicular to a unit direction, used to spread the directional rays.
+    private static void ParallelBasis(Vector3 dir, out Vector3 u, out Vector3 v)
+    {
+        var reference = MathF.Abs(dir.Y) < 0.99f ? Vector3.UnitY : Vector3.UnitX;
+        u = Vector3.Normalize(Vector3.Cross(reference, dir));
+        v = Vector3.Cross(dir, u);
+    }
+}

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -91,25 +91,39 @@ public static class EntityGizmos
     private static void BuildPointLight(GizmoBuilder builder, Vector3 anchor, PointLight light)
     {
         var color = OpaqueColor(light.Color);
-        var range = light.Range > 0f ? light.Range : 1f;
 
-        // The wire sphere traces the range (where the contribution falls to zero); a small core
-        // marks the exact position even when the range sphere is large.
-        builder.AddWireSphere(anchor, range, color);
-        builder.AddWireSphere(anchor, MathF.Min(0.1f, range * 0.1f), color, segments: 12);
+        // A non-positive (or non-finite) range disables the light in the renderer (attenuate
+        // returns 0), so don't draw a misleading reach sphere for it. The small core is always
+        // drawn so the light's position stays visible even when disabled.
+        if (float.IsFinite(light.Range) && light.Range > 0f)
+        {
+            builder.AddWireSphere(anchor, light.Range, color);
+            builder.AddWireSphere(anchor, MathF.Min(0.1f, light.Range * 0.1f), color, segments: 12);
+        }
+        else
+        {
+            builder.AddWireSphere(anchor, 0.1f, color, segments: 12);
+        }
     }
 
     private static void BuildSpotLight(GizmoBuilder builder, Vector3 anchor, SpotLight light)
     {
+        // A non-positive (or non-finite) range disables the light, so skip the cone entirely — the
+        // Transform3D axes still mark the light's position and orientation.
+        if (!(float.IsFinite(light.Range) && light.Range > 0f))
+            return;
+
         var color = OpaqueColor(light.Color);
-        var range = light.Range > 0f ? light.Range : 1f;
         var direction = SafeNormalize(light.Direction, -Vector3.UnitY);
 
-        // Base radius from the outer cone half-angle, clamped just below 90° so tan stays finite.
-        var outer = Math.Clamp(light.OuterConeAngle, 0f, 1.55f);
-        var baseRadius = range * MathF.Tan(outer);
+        // Coerce a non-finite outer angle to a safe default before clamping so a NaN/Inf set by a
+        // script can't propagate through tan() into the generated vertices. Clamp just below 90° so
+        // tan stays finite.
+        var outerRaw = float.IsFinite(light.OuterConeAngle) ? light.OuterConeAngle : MathF.PI / 6f;
+        var outer = Math.Clamp(outerRaw, 0f, 1.55f);
+        var baseRadius = light.Range * MathF.Tan(outer);
 
-        builder.AddWireCone(anchor, direction, range, baseRadius, color);
+        builder.AddWireCone(anchor, direction, light.Range, baseRadius, color);
     }
 
     private static void BuildCamera(GizmoBuilder builder, Camera3D camera, float aspectRatio)

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -128,17 +128,25 @@ public static class EntityGizmos
 
     private static void BuildCamera(GizmoBuilder builder, Camera3D camera, float aspectRatio)
     {
+        // A non-finite position/target/up would survive SafeNormalize (which falls back) but still
+        // poison the frustum corners via camera.Position, so bail before computing anything.
+        if (!IsFinite(camera.Position) || !IsFinite(camera.Target) || !IsFinite(camera.Up))
+            return;
+
         var forward = SafeNormalize(camera.Target - camera.Position, -Vector3.UnitZ);
         var up = SafeNormalize(camera.Up, Vector3.UnitY);
         var right = SafeNormalize(Vector3.Cross(forward, up), Vector3.UnitX);
         up = Vector3.Cross(right, forward);
 
+        // Require finiteness too, not just > 0: a +Inf Fov/Near would flow into tan()/the corners
+        // and emit NaN vertices, matching the NaN/Inf guarding used elsewhere in this file.
         var aspect = aspectRatio > 0f && float.IsFinite(aspectRatio) ? aspectRatio : 16f / 9f;
-        var fov = camera.Fov > 0f ? camera.Fov : MathF.PI / 4f;
-        var near = camera.Near > 0f ? camera.Near : 0.1f;
+        var fov = camera.Fov > 0f && float.IsFinite(camera.Fov) ? camera.Fov : MathF.PI / 4f;
+        var near = camera.Near > 0f && float.IsFinite(camera.Near) ? camera.Near : 0.1f;
 
         // Cap the visualised far plane so a frustum drawn for a 1000-unit camera stays on screen.
-        var far = MathF.Min(camera.Far > near ? camera.Far : near + 1f, near + 3f);
+        var farRaw = camera.Far > near && float.IsFinite(camera.Far) ? camera.Far : near + 1f;
+        var far = MathF.Min(farRaw, near + 3f);
 
         var tanHalf = MathF.Tan(fov * 0.5f);
         var nearH = tanHalf * near;
@@ -180,6 +188,9 @@ public static class EntityGizmos
         var v = color.ToVector4();
         return new Vector4(v.X, v.Y, v.Z, 1f);
     }
+
+    private static bool IsFinite(Vector3 v) =>
+        float.IsFinite(v.X) && float.IsFinite(v.Y) && float.IsFinite(v.Z);
 
     private static Vector3 SafeNormalize(Vector3 value, Vector3 fallback)
     {

--- a/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
@@ -42,6 +42,11 @@ public sealed class GizmoBuilder
     /// <summary>Adds an arrow from <paramref name="from"/> to <paramref name="to"/> with a small 3D arrowhead.</summary>
     public void AddArrow(Vector3 from, Vector3 to, Vector4 color, float headSize)
     {
+        // Reject non-finite endpoints up front: a NaN/Inf would slip past the length check below
+        // (comparisons against NaN are false) and flow into dir/Basis as NaN vertices.
+        if (!IsFinite(from) || !IsFinite(to))
+            return;
+
         AddLine(from, to, color);
 
         var shaft = to - from;
@@ -70,7 +75,7 @@ public sealed class GizmoBuilder
         int segments = 24
     )
     {
-        if (radius <= 0f || segments < 3)
+        if (!float.IsFinite(radius) || radius <= 0f || segments < 3)
             return;
 
         var step = MathF.Tau / segments;
@@ -105,8 +110,18 @@ public sealed class GizmoBuilder
         int segments = 24
     )
     {
+        // Bail on any non-finite input before normalizing: like AddArrow, the length/height checks
+        // below pass for NaN/Inf and would otherwise emit NaN vertices.
+        if (
+            !IsFinite(apex)
+            || !IsFinite(direction)
+            || !float.IsFinite(height)
+            || !float.IsFinite(baseRadius)
+        )
+            return;
+
         var lengthSq = direction.LengthSquared();
-        if (lengthSq < 1e-12f || height <= 0f)
+        if (lengthSq < 1e-12f || height <= 0f || baseRadius < 0f)
             return;
 
         var dir = direction / MathF.Sqrt(lengthSq);
@@ -154,6 +169,9 @@ public sealed class GizmoBuilder
         AddLine(c[2], c[6], color);
         AddLine(c[3], c[7], color);
     }
+
+    private static bool IsFinite(Vector3 v) =>
+        float.IsFinite(v.X) && float.IsFinite(v.Y) && float.IsFinite(v.Z);
 
     // Builds an orthonormal basis (u, v) spanning the plane perpendicular to the unit vector dir.
     private static void Basis(Vector3 dir, out Vector3 u, out Vector3 v)

--- a/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
@@ -1,0 +1,166 @@
+using System.Numerics;
+using Yaeger.Graphics;
+
+namespace Yaeger.Inspector;
+
+/// <summary>
+/// Accumulates the <see cref="GizmoLine"/> segments that make up an editor gizmo. All shapes are
+/// expressed purely as line lists, so this type holds no GPU state and is safe to unit-test and to
+/// reuse across frames (call <see cref="Clear"/> before rebuilding). <see cref="GizmoRenderer"/>
+/// consumes <see cref="Lines"/> and draws them in world space.
+/// </summary>
+public sealed class GizmoBuilder
+{
+    private readonly List<GizmoLine> _lines = [];
+
+    /// <summary>The line segments accumulated so far.</summary>
+    public IReadOnlyList<GizmoLine> Lines => _lines;
+
+    /// <summary>Discards all accumulated lines so the builder can be reused for the next frame.</summary>
+    public void Clear() => _lines.Clear();
+
+    /// <summary>Adds a single line segment.</summary>
+    public void AddLine(Vector3 start, Vector3 end, Vector4 color) =>
+        _lines.Add(new GizmoLine(start, end, color));
+
+    /// <summary>
+    /// Adds three RGB axes (X red, Y green, Z blue) of the given length, rotated by
+    /// <paramref name="rotation"/> so they reflect the entity's orientation, anchored at
+    /// <paramref name="origin"/>.
+    /// </summary>
+    public void AddAxes(Vector3 origin, Quaternion rotation, float length)
+    {
+        var right = Vector3.Transform(Vector3.UnitX, rotation) * length;
+        var up = Vector3.Transform(Vector3.UnitY, rotation) * length;
+        var forward = Vector3.Transform(Vector3.UnitZ, rotation) * length;
+
+        AddLine(origin, origin + right, new Vector4(1f, 0.2f, 0.2f, 1f));
+        AddLine(origin, origin + up, new Vector4(0.2f, 1f, 0.2f, 1f));
+        AddLine(origin, origin + forward, new Vector4(0.3f, 0.5f, 1f, 1f));
+    }
+
+    /// <summary>Adds an arrow from <paramref name="from"/> to <paramref name="to"/> with a small 3D arrowhead.</summary>
+    public void AddArrow(Vector3 from, Vector3 to, Vector4 color, float headSize)
+    {
+        AddLine(from, to, color);
+
+        var shaft = to - from;
+        var lengthSq = shaft.LengthSquared();
+        if (lengthSq < 1e-12f)
+            return;
+
+        var dir = shaft / MathF.Sqrt(lengthSq);
+        Basis(dir, out var u, out var v);
+
+        var back = to - dir * headSize;
+        var half = headSize * 0.5f;
+        AddLine(to, back + u * half, color);
+        AddLine(to, back - u * half, color);
+        AddLine(to, back + v * half, color);
+        AddLine(to, back - v * half, color);
+    }
+
+    /// <summary>Adds a circle centred at <paramref name="center"/> spanning the <paramref name="u"/>/<paramref name="v"/> plane.</summary>
+    public void AddCircle(
+        Vector3 center,
+        Vector3 u,
+        Vector3 v,
+        float radius,
+        Vector4 color,
+        int segments = 24
+    )
+    {
+        if (radius <= 0f || segments < 3)
+            return;
+
+        var step = MathF.Tau / segments;
+        var prev = center + u * radius;
+        for (var i = 1; i <= segments; i++)
+        {
+            var a = i * step;
+            var point = center + (u * MathF.Cos(a) + v * MathF.Sin(a)) * radius;
+            AddLine(prev, point, color);
+            prev = point;
+        }
+    }
+
+    /// <summary>Adds a wireframe sphere as three orthogonal circles.</summary>
+    public void AddWireSphere(Vector3 center, float radius, Vector4 color, int segments = 24)
+    {
+        AddCircle(center, Vector3.UnitX, Vector3.UnitY, radius, color, segments);
+        AddCircle(center, Vector3.UnitY, Vector3.UnitZ, radius, color, segments);
+        AddCircle(center, Vector3.UnitX, Vector3.UnitZ, radius, color, segments);
+    }
+
+    /// <summary>
+    /// Adds a wireframe cone with its apex at <paramref name="apex"/>, opening along
+    /// <paramref name="direction"/>: a base circle plus four lines from the apex to the rim.
+    /// </summary>
+    public void AddWireCone(
+        Vector3 apex,
+        Vector3 direction,
+        float height,
+        float baseRadius,
+        Vector4 color,
+        int segments = 24
+    )
+    {
+        var lengthSq = direction.LengthSquared();
+        if (lengthSq < 1e-12f || height <= 0f)
+            return;
+
+        var dir = direction / MathF.Sqrt(lengthSq);
+        Basis(dir, out var u, out var v);
+        var baseCenter = apex + dir * height;
+
+        AddCircle(baseCenter, u, v, baseRadius, color, segments);
+
+        // Four spokes from the apex to the rim convey the cone's spread.
+        AddLine(apex, baseCenter + u * baseRadius, color);
+        AddLine(apex, baseCenter - u * baseRadius, color);
+        AddLine(apex, baseCenter + v * baseRadius, color);
+        AddLine(apex, baseCenter - v * baseRadius, color);
+    }
+
+    /// <summary>Adds the 12 edges of an axis-aligned box, each corner transformed by <paramref name="model"/>.</summary>
+    public void AddTransformedBox(Aabb3D box, Matrix4x4 model, Vector4 color)
+    {
+        Span<Vector3> c =
+        [
+            new(box.Min.X, box.Min.Y, box.Min.Z),
+            new(box.Max.X, box.Min.Y, box.Min.Z),
+            new(box.Max.X, box.Max.Y, box.Min.Z),
+            new(box.Min.X, box.Max.Y, box.Min.Z),
+            new(box.Min.X, box.Min.Y, box.Max.Z),
+            new(box.Max.X, box.Min.Y, box.Max.Z),
+            new(box.Max.X, box.Max.Y, box.Max.Z),
+            new(box.Min.X, box.Max.Y, box.Max.Z),
+        ];
+
+        for (var i = 0; i < c.Length; i++)
+            c[i] = Vector3.Transform(c[i], model);
+
+        // Bottom face, top face, then the four vertical edges connecting them.
+        AddLine(c[0], c[1], color);
+        AddLine(c[1], c[2], color);
+        AddLine(c[2], c[3], color);
+        AddLine(c[3], c[0], color);
+        AddLine(c[4], c[5], color);
+        AddLine(c[5], c[6], color);
+        AddLine(c[6], c[7], color);
+        AddLine(c[7], c[4], color);
+        AddLine(c[0], c[4], color);
+        AddLine(c[1], c[5], color);
+        AddLine(c[2], c[6], color);
+        AddLine(c[3], c[7], color);
+    }
+
+    // Builds an orthonormal basis (u, v) spanning the plane perpendicular to the unit vector dir.
+    private static void Basis(Vector3 dir, out Vector3 u, out Vector3 v)
+    {
+        // Pick a reference axis that is not (near-)parallel to dir to avoid a degenerate cross.
+        var reference = MathF.Abs(dir.Y) < 0.99f ? Vector3.UnitY : Vector3.UnitX;
+        u = Vector3.Normalize(Vector3.Cross(reference, dir));
+        v = Vector3.Cross(dir, u);
+    }
+}

--- a/src/Engine/Yaeger/Inspector/GizmoLine.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoLine.cs
@@ -1,0 +1,13 @@
+using System.Numerics;
+
+namespace Yaeger.Inspector;
+
+/// <summary>
+/// A single coloured line segment in world space, the only primitive the gizmo overlay draws.
+/// Boxes, spheres, cones and arrows are all decomposed into a list of these by
+/// <see cref="GizmoBuilder"/> and uploaded to the GPU by <see cref="GizmoRenderer"/>.
+/// </summary>
+/// <param name="Start">World-space start point.</param>
+/// <param name="End">World-space end point.</param>
+/// <param name="Color">RGBA colour (0-1 per channel).</param>
+public readonly record struct GizmoLine(Vector3 Start, Vector3 End, Vector4 Color);

--- a/src/Engine/Yaeger/Inspector/GizmoRenderer.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoRenderer.cs
@@ -1,0 +1,150 @@
+using System.Numerics;
+using Silk.NET.OpenGL;
+using Yaeger.Rendering;
+using Shader = Yaeger.Rendering.Shader;
+
+namespace Yaeger.Inspector;
+
+/// <summary>
+/// Draws the editor gizmo overlay: a batch of world-space coloured lines transformed by the active
+/// camera's view-projection. Unlike <c>PhysicsDebugRenderer</c> (which draws in NDC), this renderer
+/// applies <c>uViewProj</c> so gizmos line up with the 3D scene. Depth testing is left to the caller
+/// (the inspector draws after the 3D pass has disabled it) so gizmos stay visible through geometry —
+/// handy for finding a light tucked behind a wall.
+/// </summary>
+public sealed class GizmoRenderer : IDisposable
+{
+    private const int MaxLines = 8192;
+    private const int FloatsPerVertex = 7; // xyz + rgba
+    private const int VerticesPerLine = 2;
+
+    private const string VertexShaderSource = """
+        #version 330 core
+        layout(location = 0) in vec3 aPosition;
+        layout(location = 1) in vec4 aColor;
+
+        uniform mat4 uViewProj;
+
+        out vec4 vColor;
+
+        void main()
+        {
+            vColor = aColor;
+            gl_Position = uViewProj * vec4(aPosition, 1.0);
+        }
+        """;
+
+    private const string FragmentShaderSource = """
+        #version 330 core
+        in vec4 vColor;
+        out vec4 FragColor;
+
+        void main()
+        {
+            FragColor = vColor;
+        }
+        """;
+
+    private readonly GL _gl;
+    private readonly Shader _shader;
+    private readonly Buffer<float> _vbo;
+    private readonly uint _vao;
+    private readonly float[] _vertices;
+
+    public GizmoRenderer(GL gl)
+    {
+        _gl = gl;
+        _shader = new Shader(gl, VertexShaderSource, FragmentShaderSource);
+        _vertices = new float[MaxLines * VerticesPerLine * FloatsPerVertex];
+
+        _vbo = new Buffer<float>(
+            gl,
+            _vertices,
+            BufferTargetARB.ArrayBuffer,
+            BufferUsageARB.DynamicDraw
+        );
+
+        _vao = _gl.GenVertexArray();
+        _gl.BindVertexArray(_vao);
+        _vbo.Bind();
+        ConfigureAttributes();
+        _gl.BindVertexArray(0);
+    }
+
+    private unsafe void ConfigureAttributes()
+    {
+        var stride = (uint)(FloatsPerVertex * sizeof(float));
+        _gl.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, stride, (void*)0);
+        _gl.EnableVertexAttribArray(0);
+        _gl.VertexAttribPointer(
+            1,
+            4,
+            VertexAttribPointerType.Float,
+            false,
+            stride,
+            (void*)(3 * sizeof(float))
+        );
+        _gl.EnableVertexAttribArray(1);
+    }
+
+    /// <summary>
+    /// Draws the supplied lines in world space using <paramref name="viewProj"/>. Lines beyond the
+    /// internal capacity are dropped. A no-op when the list is empty.
+    /// </summary>
+    public unsafe void Render(IReadOnlyList<GizmoLine> lines, Matrix4x4 viewProj)
+    {
+        if (lines.Count == 0)
+            return;
+
+        var lineCount = Math.Min(lines.Count, MaxLines);
+        var floatCount = lineCount * VerticesPerLine * FloatsPerVertex;
+
+        for (var i = 0; i < lineCount; i++)
+        {
+            var line = lines[i];
+            var offset = i * VerticesPerLine * FloatsPerVertex;
+            WriteVertex(offset, line.Start, line.Color);
+            WriteVertex(offset + FloatsPerVertex, line.End, line.Color);
+        }
+
+        // Alpha-blend so coloured gizmos read well over the scene; the 3D pass already left depth
+        // testing off, so lines draw on top regardless of occluding geometry.
+        _gl.Enable(EnableCap.Blend);
+        _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+
+        _shader.Bind();
+        _shader.SetUniformMatrix4("uViewProj", viewProj);
+
+        _gl.BindVertexArray(_vao);
+        _vbo.Bind();
+
+        var byteCount = (nuint)(floatCount * sizeof(float));
+        fixed (float* ptr = _vertices)
+        {
+            _gl.BufferSubData(BufferTargetARB.ArrayBuffer, 0, byteCount, ptr);
+        }
+
+        _gl.DrawArrays(PrimitiveType.Lines, 0, (uint)(lineCount * VerticesPerLine));
+
+        _gl.BindVertexArray(0);
+        _shader.Unbind();
+    }
+
+    private void WriteVertex(int offset, Vector3 position, Vector4 color)
+    {
+        _vertices[offset + 0] = position.X;
+        _vertices[offset + 1] = position.Y;
+        _vertices[offset + 2] = position.Z;
+        _vertices[offset + 3] = color.X;
+        _vertices[offset + 4] = color.Y;
+        _vertices[offset + 5] = color.Z;
+        _vertices[offset + 6] = color.W;
+    }
+
+    public void Dispose()
+    {
+        _gl.DeleteVertexArray(_vao);
+        _vbo.Dispose();
+        _shader.Dispose();
+    }
+}

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -139,10 +139,14 @@ public sealed class ImGuiInspector : IDisposable
 
         _controller.Update((float)delta);
         DrawInspectorWindow();
+        // Apply queued edits now, before building gizmos, so the overlay reflects the value being
+        // dragged this frame rather than lagging a frame behind. Safe here: all world-iterating
+        // ImGui code (the entity list) ran in DrawInspectorWindow, and nothing below mutates or
+        // iterates the world during draw — so this can't invalidate an in-flight iterator.
+        FlushPendingCommands();
         // Draw gizmos into the scene framebuffer first so the ImGui panel renders on top of them.
         RenderGizmos();
         _controller.Render();
-        FlushPendingCommands();
     }
 
     // ── Selection gizmos (world-space overlay) ────────────────────────────────

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -28,9 +28,21 @@ namespace Yaeger.Inspector;
 public sealed class ImGuiInspector : IDisposable
 {
     private readonly World _world;
+    private readonly Window _window;
     private readonly ComponentRegistry? _registry;
     private readonly SceneSaver? _sceneSaver;
     private readonly ImGuiController _controller;
+
+    // World-space overlay that visualises the selected entity (light direction/reach, mesh bounds,
+    // camera frustum, transform axes). Driven from Render once the ImGui panel has updated selection.
+    private readonly GizmoRenderer _gizmoRenderer;
+    private readonly GizmoBuilder _gizmoBuilder = new();
+
+    /// <summary>
+    /// When true (the default), the selected entity is highlighted in the 3D scene with gizmos.
+    /// Requires a <see cref="Camera3D"/> in the world; purely 2D scenes show no gizmos.
+    /// </summary>
+    public bool ShowGizmos { get; set; } = true;
 
     private bool _visible;
     private Entity? _selectedEntity;
@@ -102,9 +114,11 @@ public sealed class ImGuiInspector : IDisposable
     public ImGuiInspector(Window window, World world, ComponentRegistry? registry = null)
     {
         _world = world;
+        _window = window;
         _registry = registry;
         _sceneSaver = registry is not null ? new SceneSaver(registry) : null;
         _controller = new ImGuiController(window.Gl, window.InnerView, window.InputContext);
+        _gizmoRenderer = new GizmoRenderer(window.Gl);
     }
 
     /// <summary>Toggles the inspector overlay on or off.</summary>
@@ -125,8 +139,50 @@ public sealed class ImGuiInspector : IDisposable
 
         _controller.Update((float)delta);
         DrawInspectorWindow();
+        // Draw gizmos into the scene framebuffer first so the ImGui panel renders on top of them.
+        RenderGizmos();
         _controller.Render();
         FlushPendingCommands();
+    }
+
+    // ── Selection gizmos (world-space overlay) ────────────────────────────────
+
+    /// <summary>
+    /// Draws the world-space gizmos for the current selection so the user can see what they are
+    /// editing. Needs a <see cref="Camera3D"/> to know how to project; no-ops without one.
+    /// </summary>
+    private void RenderGizmos()
+    {
+        if (!ShowGizmos || !_selectedEntity.HasValue)
+            return;
+
+        var entity = _selectedEntity.Value;
+        if (!_world.Entities.Contains(entity))
+            return;
+
+        if (!TryGetSceneViewProjection(out var viewProj, out var aspectRatio))
+            return;
+
+        _gizmoBuilder.Clear();
+        EntityGizmos.Build(_world, entity, aspectRatio, _gizmoBuilder);
+        _gizmoRenderer.Render(_gizmoBuilder.Lines, viewProj);
+    }
+
+    // Resolves the active 3D camera's view-projection (and aspect) from the world, mirroring how
+    // MeshRenderSystem picks the first Camera3D. Returns false for purely 2D scenes.
+    private bool TryGetSceneViewProjection(out Matrix4x4 viewProj, out float aspectRatio)
+    {
+        var size = _window.Size;
+        aspectRatio = size.Y > 0f ? size.X / size.Y : 1f;
+
+        foreach (var (_, camera) in _world.GetStore<Camera3D>().All())
+        {
+            viewProj = camera.ViewMatrix * camera.ProjectionMatrix(aspectRatio);
+            return true;
+        }
+
+        viewProj = Matrix4x4.Identity;
+        return false;
     }
 
     // ── Main window ──────────────────────────────────────────────────────────────
@@ -161,6 +217,9 @@ public sealed class ImGuiInspector : IDisposable
         ImGui.Columns(1);
 
         ImGui.Separator();
+        var showGizmos = ShowGizmos;
+        if (ImGui.Checkbox("Show selection gizmos", ref showGizmos))
+            ShowGizmos = showGizmos;
         DrawSaveRow();
 
         ImGui.End();
@@ -982,5 +1041,9 @@ public sealed class ImGuiInspector : IDisposable
         }
     }
 
-    public void Dispose() => _controller.Dispose();
+    public void Dispose()
+    {
+        _gizmoRenderer.Dispose();
+        _controller.Dispose();
+    }
 }

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -270,4 +270,41 @@ public class EntityGizmosTests
         Assert.Equal(12, lines.Count);
         Assert.All(lines, l => Assert.Equal(new Vector4(1, 1, 0.3f, 1), l.Color));
     }
+
+    [Fact]
+    public void Camera3D_NonFiniteFov_FallsBackToFiniteFrustum()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(
+            entity,
+            new Camera3D(
+                new Vector3(0, 0, 5),
+                Vector3.Zero,
+                Vector3.UnitY,
+                float.PositiveInfinity, // Fov
+                0.1f,
+                100f
+            )
+        );
+
+        var lines = Build(world, entity);
+
+        // Still a complete frustum, and no NaN/Inf leaked into the vertices.
+        Assert.Equal(12, lines.Count);
+        Assert.All(
+            lines,
+            l =>
+            {
+                Assert.True(
+                    float.IsFinite(l.Start.X)
+                        && float.IsFinite(l.Start.Y)
+                        && float.IsFinite(l.Start.Z)
+                );
+                Assert.True(
+                    float.IsFinite(l.End.X) && float.IsFinite(l.End.Y) && float.IsFinite(l.End.Z)
+                );
+            }
+        );
+    }
 }

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -55,9 +55,14 @@ public class EntityGizmosTests
 
         var lines = Build(world, entity);
 
-        // The box edges should sit around the world position (10 ± 1 on X).
-        Assert.Contains(lines, l => l.Start.X is >= 9f and <= 11f && l.Start.X > 1f);
+        // Verify the actual box extents are present (min X = 9, max X = 11). The 0.5-length
+        // Transform3D axes only reach X = 10.5, so hitting 9 and 11 proves the transformed Aabb3D
+        // bounds are drawn rather than just the axes.
+        Assert.Contains(lines, l => Near(l.Start.X, 9f) || Near(l.End.X, 9f));
+        Assert.Contains(lines, l => Near(l.Start.X, 11f) || Near(l.End.X, 11f));
     }
+
+    private static bool Near(float a, float b) => MathF.Abs(a - b) < 1e-3f;
 
     [Fact]
     public void DirectionalLight_DrawsRaysAlongTravelDirection()
@@ -127,6 +132,93 @@ public class EntityGizmosTests
         var maxExtent = lines.Max(l => MathF.Max(l.Start.Length(), l.End.Length()));
         Assert.Equal(5f, maxExtent, 2);
         Assert.Contains(lines, l => l.Color == new Vector4(1, 0, 0, 1));
+    }
+
+    [Fact]
+    public void PointLight_ZeroRange_DrawsOnlyPositionCoreNoReachSphere()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+        // Range 0 disables the light in the renderer, so no reach sphere should be drawn.
+        world.AddComponent(
+            entity,
+            new PointLight
+            {
+                Color = Color.Red,
+                Intensity = 1f,
+                Range = 0f,
+            }
+        );
+
+        var lines = Build(world, entity);
+
+        // Only the small position core remains (axes aside), so nothing extends near a 1-unit reach.
+        var maxExtent = lines.Max(l => MathF.Max(l.Start.Length(), l.End.Length()));
+        Assert.True(maxExtent < 0.6f, $"expected a small core, but a line reached {maxExtent}");
+    }
+
+    [Fact]
+    public void SpotLight_ZeroRange_DrawsNoCone()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+        world.AddComponent(
+            entity,
+            new SpotLight
+            {
+                Color = Color.White,
+                Intensity = 1f,
+                Direction = -Vector3.UnitY,
+                InnerConeAngle = MathF.PI / 12f,
+                OuterConeAngle = MathF.PI / 6f,
+                Range = 0f,
+            }
+        );
+
+        var lines = Build(world, entity);
+
+        // Only the Transform3D axes remain (length 0.5); the disabled cone is skipped.
+        Assert.All(lines, l => Assert.True(l.End.Length() <= 0.5f + 1e-3f));
+    }
+
+    [Fact]
+    public void SpotLight_NonFiniteOuterAngle_ProducesFiniteVertices()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+        world.AddComponent(
+            entity,
+            new SpotLight
+            {
+                Color = Color.White,
+                Intensity = 1f,
+                Direction = -Vector3.UnitY,
+                InnerConeAngle = 0f,
+                OuterConeAngle = float.NaN,
+                Range = 5f,
+            }
+        );
+
+        var lines = Build(world, entity);
+
+        Assert.NotEmpty(lines);
+        Assert.All(
+            lines,
+            l =>
+            {
+                Assert.True(
+                    float.IsFinite(l.Start.X)
+                        && float.IsFinite(l.Start.Y)
+                        && float.IsFinite(l.Start.Z)
+                );
+                Assert.True(
+                    float.IsFinite(l.End.X) && float.IsFinite(l.End.Y) && float.IsFinite(l.End.Z)
+                );
+            }
+        );
     }
 
     [Fact]

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -1,0 +1,181 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Inspector;
+
+namespace Yaeger.Tests.Inspector;
+
+public class EntityGizmosTests
+{
+    private const float Aspect = 16f / 9f;
+
+    private static IReadOnlyList<GizmoLine> Build(World world, Entity entity)
+    {
+        var builder = new GizmoBuilder();
+        EntityGizmos.Build(world, entity, Aspect, builder);
+        return builder.Lines;
+    }
+
+    [Fact]
+    public void EntityWithNoVisualComponents_ProducesNoGizmos()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+
+        Assert.Empty(Build(world, entity));
+    }
+
+    [Fact]
+    public void Transform3D_DrawsOrientationAxes()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(
+            entity,
+            new Transform3D(new Vector3(5, 0, 0), Quaternion.Identity, Vector3.One)
+        );
+
+        var lines = Build(world, entity);
+
+        // Three axes, all anchored at the entity position.
+        Assert.True(lines.Count >= 3);
+        Assert.Contains(lines, l => l.Start == new Vector3(5, 0, 0));
+    }
+
+    [Fact]
+    public void Mesh_DrawsBoundingBoxAtWorldPosition()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(
+            entity,
+            new Transform3D(new Vector3(10, 0, 0), Quaternion.Identity, Vector3.One)
+        );
+        world.AddComponent(entity, new Aabb3D(new Vector3(-1, -1, -1), new Vector3(1, 1, 1)));
+
+        var lines = Build(world, entity);
+
+        // The box edges should sit around the world position (10 ± 1 on X).
+        Assert.Contains(lines, l => l.Start.X is >= 9f and <= 11f && l.Start.X > 1f);
+    }
+
+    [Fact]
+    public void DirectionalLight_DrawsRaysAlongTravelDirection()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        // Direction points toward the source (up), so light travels downward.
+        world.AddComponent(
+            entity,
+            new DirectionalLight
+            {
+                Direction = Vector3.UnitY,
+                Color = Color.White,
+                Intensity = 1f,
+            }
+        );
+
+        var lines = Build(world, entity);
+
+        Assert.NotEmpty(lines);
+        // At least one ray shaft should point downward (travel = -Direction).
+        Assert.Contains(
+            lines,
+            l =>
+            {
+                var d = l.End - l.Start;
+                return d.LengthSquared() > 0.5f && Vector3.Normalize(d).Y < -0.9f;
+            }
+        );
+        // Coloured by the light's colour (white, opaque).
+        Assert.Contains(lines, l => l.Color == new Vector4(1, 1, 1, 1));
+    }
+
+    [Fact]
+    public void DirectionalLight_WithoutTransform_AnchorsAtOrigin()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, DirectionalLight.Default);
+
+        var lines = Build(world, entity);
+
+        Assert.NotEmpty(lines);
+        // The sun marker sphere is centred on the origin, so points stay near it.
+        Assert.All(lines, l => Assert.True(l.Start.Length() < 5f));
+    }
+
+    [Fact]
+    public void PointLight_DrawsRangeSphere()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+        world.AddComponent(
+            entity,
+            new PointLight
+            {
+                Color = Color.Red,
+                Intensity = 1f,
+                Range = 5f,
+            }
+        );
+
+        var lines = Build(world, entity);
+
+        // The widest gizmo extent should match the light's range.
+        var maxExtent = lines.Max(l => MathF.Max(l.Start.Length(), l.End.Length()));
+        Assert.Equal(5f, maxExtent, 2);
+        Assert.Contains(lines, l => l.Color == new Vector4(1, 0, 0, 1));
+    }
+
+    [Fact]
+    public void SpotLight_DrawsConeReachingItsRange()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+        world.AddComponent(
+            entity,
+            new SpotLight
+            {
+                Color = Color.White,
+                Intensity = 1f,
+                Direction = -Vector3.UnitY,
+                InnerConeAngle = MathF.PI / 12f,
+                OuterConeAngle = MathF.PI / 6f,
+                Range = 8f,
+            }
+        );
+
+        var lines = Build(world, entity);
+
+        Assert.NotEmpty(lines);
+        // The cone base lies at range distance along the beam (downward).
+        Assert.Contains(lines, l => l.Start.Y <= -7.9f || l.End.Y <= -7.9f);
+    }
+
+    [Fact]
+    public void Camera3D_DrawsFrustum()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(
+            entity,
+            new Camera3D(
+                new Vector3(0, 0, 5),
+                Vector3.Zero,
+                Vector3.UnitY,
+                MathF.PI / 4f,
+                0.1f,
+                100f
+            )
+        );
+
+        var lines = Build(world, entity);
+
+        // Near + far rectangles (4 edges each) plus 4 connecting edges = 12 lines.
+        Assert.Equal(12, lines.Count);
+        Assert.All(lines, l => Assert.Equal(new Vector4(1, 1, 0.3f, 1), l.Color));
+    }
+}

--- a/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
+++ b/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
@@ -117,6 +117,58 @@ public class GizmoBuilderTests
     }
 
     [Fact]
+    public void AddCircle_NonFiniteRadius_EmitsNothing()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddCircle(Vector3.Zero, Vector3.UnitX, Vector3.UnitZ, float.NaN, Vector4.One);
+        builder.AddCircle(
+            Vector3.Zero,
+            Vector3.UnitX,
+            Vector3.UnitZ,
+            float.PositiveInfinity,
+            Vector4.One
+        );
+
+        Assert.Empty(builder.Lines);
+    }
+
+    [Fact]
+    public void AddArrow_NonFiniteEndpoint_EmitsNothing()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddArrow(Vector3.Zero, new Vector3(float.NaN, 0, 0), Vector4.One, 0.5f);
+        builder.AddArrow(new Vector3(float.PositiveInfinity, 0, 0), Vector3.One, Vector4.One, 0.5f);
+
+        Assert.Empty(builder.Lines);
+    }
+
+    [Fact]
+    public void AddWireCone_NonFiniteInput_EmitsNothing()
+    {
+        var builder = new GizmoBuilder();
+
+        // Non-finite direction, then non-finite base radius.
+        builder.AddWireCone(
+            Vector3.Zero,
+            new Vector3(float.NaN, 0, 0),
+            height: 4f,
+            baseRadius: 2f,
+            Vector4.One
+        );
+        builder.AddWireCone(
+            Vector3.Zero,
+            -Vector3.UnitY,
+            height: 4f,
+            baseRadius: float.PositiveInfinity,
+            Vector4.One
+        );
+
+        Assert.Empty(builder.Lines);
+    }
+
+    [Fact]
     public void AddWireSphere_EmitsThreeOrthogonalCircles()
     {
         var builder = new GizmoBuilder();

--- a/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
+++ b/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
@@ -1,0 +1,194 @@
+using System.Numerics;
+using Yaeger.Graphics;
+using Yaeger.Inspector;
+
+namespace Yaeger.Tests.Inspector;
+
+public class GizmoBuilderTests
+{
+    [Fact]
+    public void AddLine_StoresSegmentVerbatim()
+    {
+        var builder = new GizmoBuilder();
+        var color = new Vector4(0.1f, 0.2f, 0.3f, 1f);
+
+        builder.AddLine(new Vector3(1, 2, 3), new Vector3(4, 5, 6), color);
+
+        var line = Assert.Single(builder.Lines);
+        Assert.Equal(new Vector3(1, 2, 3), line.Start);
+        Assert.Equal(new Vector3(4, 5, 6), line.End);
+        Assert.Equal(color, line.Color);
+    }
+
+    [Fact]
+    public void Clear_RemovesAllLines()
+    {
+        var builder = new GizmoBuilder();
+        builder.AddLine(Vector3.Zero, Vector3.One, Vector4.One);
+
+        builder.Clear();
+
+        Assert.Empty(builder.Lines);
+    }
+
+    [Fact]
+    public void AddAxes_Identity_EmitsThreeUnitAxesWithRgbColors()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddAxes(Vector3.Zero, Quaternion.Identity, 2f);
+
+        Assert.Equal(3, builder.Lines.Count);
+
+        var x = builder.Lines[0];
+        var y = builder.Lines[1];
+        var z = builder.Lines[2];
+
+        Assert.Equal(new Vector3(2, 0, 0), x.End);
+        Assert.Equal(new Vector3(0, 2, 0), y.End);
+        Assert.Equal(new Vector3(0, 0, 2), z.End);
+
+        // Red dominant on X, green on Y, blue on Z.
+        Assert.True(x.Color.X > x.Color.Y && x.Color.X > x.Color.Z);
+        Assert.True(y.Color.Y > y.Color.X && y.Color.Y > y.Color.Z);
+        Assert.True(z.Color.Z > z.Color.X && z.Color.Z > z.Color.Y);
+    }
+
+    [Fact]
+    public void AddArrow_EmitsShaftPlusFourHeadLines()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddArrow(Vector3.Zero, new Vector3(0, 0, 5), Vector4.One, 0.5f);
+
+        Assert.Equal(5, builder.Lines.Count);
+        var shaft = builder.Lines[0];
+        Assert.Equal(Vector3.Zero, shaft.Start);
+        Assert.Equal(new Vector3(0, 0, 5), shaft.End);
+
+        // Every arrowhead line starts at the tip.
+        for (var i = 1; i < builder.Lines.Count; i++)
+            Assert.Equal(new Vector3(0, 0, 5), builder.Lines[i].Start);
+    }
+
+    [Fact]
+    public void AddArrow_DegenerateLength_EmitsOnlyShaft()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddArrow(Vector3.One, Vector3.One, Vector4.One, 0.5f);
+
+        Assert.Single(builder.Lines);
+    }
+
+    [Fact]
+    public void AddCircle_EmitsSegmentLinesAllOnRadius()
+    {
+        var builder = new GizmoBuilder();
+        const int segments = 16;
+        const float radius = 3f;
+
+        builder.AddCircle(
+            Vector3.Zero,
+            Vector3.UnitX,
+            Vector3.UnitZ,
+            radius,
+            Vector4.One,
+            segments
+        );
+
+        Assert.Equal(segments, builder.Lines.Count);
+        foreach (var line in builder.Lines)
+        {
+            Assert.Equal(radius, line.Start.Length(), 3);
+            Assert.Equal(radius, line.End.Length(), 3);
+            Assert.Equal(0f, line.Start.Y, 5); // stays in the X/Z plane
+        }
+    }
+
+    [Fact]
+    public void AddCircle_NonPositiveRadius_EmitsNothing()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddCircle(Vector3.Zero, Vector3.UnitX, Vector3.UnitZ, 0f, Vector4.One);
+
+        Assert.Empty(builder.Lines);
+    }
+
+    [Fact]
+    public void AddWireSphere_EmitsThreeOrthogonalCircles()
+    {
+        var builder = new GizmoBuilder();
+        const int segments = 12;
+
+        builder.AddWireSphere(Vector3.Zero, 1f, Vector4.One, segments);
+
+        Assert.Equal(segments * 3, builder.Lines.Count);
+        foreach (var line in builder.Lines)
+            Assert.Equal(1f, line.Start.Length(), 3);
+    }
+
+    [Fact]
+    public void AddWireCone_EmitsBaseCirclePlusFourSpokesFromApex()
+    {
+        var builder = new GizmoBuilder();
+        const int segments = 16;
+        var apex = Vector3.Zero;
+
+        builder.AddWireCone(
+            apex,
+            -Vector3.UnitY,
+            height: 4f,
+            baseRadius: 2f,
+            Vector4.One,
+            segments
+        );
+
+        Assert.Equal(segments + 4, builder.Lines.Count);
+
+        // The last four lines are the spokes, each starting at the apex.
+        for (var i = segments; i < builder.Lines.Count; i++)
+            Assert.Equal(apex, builder.Lines[i].Start);
+    }
+
+    [Fact]
+    public void AddTransformedBox_EmitsTwelveEdgesWithinBounds()
+    {
+        var builder = new GizmoBuilder();
+        var box = new Aabb3D(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
+
+        builder.AddTransformedBox(box, Matrix4x4.Identity, Vector4.One);
+
+        Assert.Equal(12, builder.Lines.Count);
+        foreach (var line in builder.Lines)
+        {
+            AssertWithinBounds(line.Start, box);
+            AssertWithinBounds(line.End, box);
+        }
+    }
+
+    [Fact]
+    public void AddTransformedBox_AppliesModelTransform()
+    {
+        var builder = new GizmoBuilder();
+        var box = new Aabb3D(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
+        var model = Matrix4x4.CreateTranslation(10, 0, 0);
+
+        builder.AddTransformedBox(box, model, Vector4.One);
+
+        // Every translated corner sits in [9, 11] on X.
+        foreach (var line in builder.Lines)
+        {
+            Assert.InRange(line.Start.X, 9f, 11f);
+            Assert.InRange(line.End.X, 9f, 11f);
+        }
+    }
+
+    private static void AssertWithinBounds(Vector3 point, Aabb3D box)
+    {
+        Assert.InRange(point.X, box.Min.X - 1e-4f, box.Max.X + 1e-4f);
+        Assert.InRange(point.Y, box.Min.Y - 1e-4f, box.Max.Y + 1e-4f);
+        Assert.InRange(point.Z, box.Min.Z - 1e-4f, box.Max.Z + 1e-4f);
+    }
+}


### PR DESCRIPTION
The ImGui overlay editor let you edit a directional light's direction but
gave no way to see where the light is or which way it faces. Now selecting
an entity draws world-space gizmos into the 3D scene:

- DirectionalLight: a sun with parallel rays along the travel direction
- PointLight: a wireframe range sphere in the light's colour
- SpotLight: a wireframe cone along the beam, opened to the outer angle
- Camera3D: a view frustum
- Transform3D: RGB orientation axes; meshes also outline their Aabb3D bounds

Geometry building (GizmoBuilder/EntityGizmos) is pure and unit-tested; the
GL line drawing lives in a camera-aware GizmoRenderer. Gizmos project
through the world's Camera3D, draw on top of the scene so occluded lights
stay visible, and can be toggled via ImGuiInspector.ShowGizmos.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pehbBNRdusQM99cyUy3BC