### PR TITLE
Extend inspector selection gizmos to 2D scenes (Transform2D / Camera2D)

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -61,11 +61,13 @@ cover the engine's built-in components:
 ## Seeing the selected entity in the world
 
 Editing a light by typing numbers is hard when you can't see what they do. Whenever an entity is
-selected, the inspector draws **selection gizmos** directly into the 3D scene so you can see *where*
+selected, the inspector draws **selection gizmos** directly into the scene so you can see *where*
 the entity is and *which way it faces* while you drag its values:
 
 | Component | Gizmo |
 | --- | --- |
+| `Transform2D` | red/green X/Y orientation axes at the entity's position plus an amber rectangle tracing the sprite's scaled, rotated bounds |
+| `Camera2D` | a yellow rectangle outlining the camera's visible viewport (derived from `Position`, `Zoom`, `Rotation`) |
 | `Transform3D` | RGB orientation axes (X red, Y green, Z blue) at the entity's position |
 | `Aabb3D` (meshes) | an amber wireframe box around the mesh's world-space bounds |
 | `DirectionalLight` | a small "sun" with a bundle of parallel rays pointing the way the light travels |
@@ -77,10 +79,13 @@ Lights and the camera are coloured to match, so a selected red point light shows
 Gizmos are drawn on top of the scene (no depth testing), so a light tucked behind a wall is still
 visible while you position it.
 
-Gizmos are projected through the first `Camera3D` in the world (the same camera `MeshRenderSystem`
-renders through), so they line up exactly with the rendered scene. Purely 2D scenes — which have no
-`Camera3D` — show no gizmos. The overlay is on by default; untick **Show selection gizmos** at the
-bottom of the inspector (or set `inspector.ShowGizmos = false`) to hide it.
+Each gizmo is projected so it lines up exactly with the rendered scene. A selected 3D entity is
+drawn through the first `Camera3D` in the world (the same camera `MeshRenderSystem` renders
+through). A selected 2D entity (`Transform2D` / `Camera2D`) is drawn through the first `Camera2D`,
+mirroring `RenderSystem`; if the 2D scene has no camera, gizmos fall back to NDC-direct exactly as
+the 2D renderer does, so even a camera-less Pong-style scene shows them. The overlay is on by
+default; untick **Show selection gizmos** at the bottom of the inspector (or set
+`inspector.ShowGizmos = false`) to hide it.
 
 > Because the gizmos read the live world every frame, dragging a `DirectionalLight`'s direction or a
 > `SpotLight`'s cone angle updates the gizmo immediately — no extra wiring beyond the standard

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -79,10 +79,12 @@ public static class EntityGizmos
 
     private static void BuildCamera2D(GizmoBuilder builder, Camera2D camera, float aspectRatio)
     {
-        // Mirror Camera2D.ViewProjection's guards so a default/invalid camera still draws a sane
-        // rectangle. At zoom z the visible world span is [-aspect/z, aspect/z] × [-1/z, 1/z].
+        // Mirror Camera2D.ViewProjection's zoom guard exactly (Zoom > 0 ? Zoom : 1) so the drawn
+        // rectangle agrees with what the camera actually frames. A +Infinity zoom is kept as-is,
+        // matching the renderer: aspect/∞ and 1/∞ both collapse to 0, so the viewport shrinks to a
+        // point while staying finite. Aspect is separately guarded against a non-finite value.
         var aspect = aspectRatio > 0f && float.IsFinite(aspectRatio) ? aspectRatio : 16f / 9f;
-        var zoom = camera.Zoom > 0f && float.IsFinite(camera.Zoom) ? camera.Zoom : 1f;
+        var zoom = camera.Zoom > 0f ? camera.Zoom : 1f;
 
         var halfExtents = new Vector2(aspect / zoom, 1f / zoom);
         builder.AddRect(camera.Position, halfExtents, camera.Rotation, CameraColor);

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -13,6 +13,7 @@ namespace Yaeger.Inspector;
 public static class EntityGizmos
 {
     private const float AxisLength = 0.5f;
+    private const float Axis2DLength = 0.5f;
     private const float DirectionalArrowLength = 1.5f;
     private const float DirectionalSunRadius = 0.15f;
     private const float ArrowHeadSize = 0.18f;
@@ -23,11 +24,19 @@ public static class EntityGizmos
 
     /// <summary>
     /// Appends the gizmos for <paramref name="entity"/> to <paramref name="builder"/> based on the
-    /// components it carries. <paramref name="aspectRatio"/> is only used to shape a
-    /// <see cref="Camera3D"/> frustum.
+    /// components it carries. <paramref name="aspectRatio"/> shapes a <see cref="Camera3D"/> frustum
+    /// and a <see cref="Camera2D"/> viewport rectangle.
     /// </summary>
     public static void Build(World world, Entity entity, float aspectRatio, GizmoBuilder builder)
     {
+        // 2D gizmos live in the Z = 0 plane and are projected through a Camera2D-derived (or
+        // identity) view-projection by the inspector, independently of the 3D path below.
+        if (world.TryGetComponent<Transform2D>(entity, out var transform2D))
+            BuildTransform2D(builder, transform2D);
+
+        if (world.TryGetComponent<Camera2D>(entity, out var camera2D))
+            BuildCamera2D(builder, camera2D, aspectRatio);
+
         var hasTransform = world.TryGetComponent<Transform3D>(entity, out var transform);
         var anchor = hasTransform ? transform.Position : Vector3.Zero;
 
@@ -52,6 +61,31 @@ public static class EntityGizmos
 
         if (world.TryGetComponent<Camera3D>(entity, out var camera))
             BuildCamera(builder, camera, aspectRatio);
+    }
+
+    private static void BuildTransform2D(GizmoBuilder builder, Transform2D transform)
+    {
+        // Oriented X/Y axes mark the origin and facing; the bounds rectangle traces the sprite quad
+        // (the renderer draws a unit quad scaled by Transform2D.Scale), so it lines up with what is
+        // actually rendered.
+        builder.AddAxes2D(transform.Position, transform.Rotation, Axis2DLength);
+        builder.AddRect(
+            transform.Position,
+            transform.Scale * 0.5f,
+            transform.Rotation,
+            BoundsColor
+        );
+    }
+
+    private static void BuildCamera2D(GizmoBuilder builder, Camera2D camera, float aspectRatio)
+    {
+        // Mirror Camera2D.ViewProjection's guards so a default/invalid camera still draws a sane
+        // rectangle. At zoom z the visible world span is [-aspect/z, aspect/z] × [-1/z, 1/z].
+        var aspect = aspectRatio > 0f && float.IsFinite(aspectRatio) ? aspectRatio : 16f / 9f;
+        var zoom = camera.Zoom > 0f && float.IsFinite(camera.Zoom) ? camera.Zoom : 1f;
+
+        var halfExtents = new Vector2(aspect / zoom, 1f / zoom);
+        builder.AddRect(camera.Position, halfExtents, camera.Rotation, CameraColor);
     }
 
     private static void BuildDirectionalLight(

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -30,12 +30,28 @@ public static class EntityGizmos
     public static void Build(World world, Entity entity, float aspectRatio, GizmoBuilder builder)
     {
         // 2D gizmos live in the Z = 0 plane and are projected through a Camera2D-derived (or
-        // identity) view-projection by the inspector, independently of the 3D path below.
+        // identity) view-projection by the inspector. An entity is treated as either 2D or 3D for
+        // gizmo purposes — never both — to stay consistent with
+        // ImGuiInspector.TryGetSceneViewProjection, which switches to that 2D view whenever a
+        // Transform2D/Camera2D is present. Emitting 3D gizmos too would draw them with the wrong
+        // (2D) projection for an entity that happens to carry both (the Add Component menu allows
+        // it), so once any 2D gizmo is emitted we skip the 3D path entirely.
+        var has2D = false;
+
         if (world.TryGetComponent<Transform2D>(entity, out var transform2D))
+        {
             BuildTransform2D(builder, transform2D);
+            has2D = true;
+        }
 
         if (world.TryGetComponent<Camera2D>(entity, out var camera2D))
+        {
             BuildCamera2D(builder, camera2D, aspectRatio);
+            has2D = true;
+        }
+
+        if (has2D)
+            return;
 
         var hasTransform = world.TryGetComponent<Transform3D>(entity, out var transform);
         var anchor = hasTransform ? transform.Position : Vector3.Zero;

--- a/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
@@ -39,6 +39,65 @@ public sealed class GizmoBuilder
         AddLine(origin, origin + forward, new Vector4(0.3f, 0.5f, 1f, 1f));
     }
 
+    /// <summary>
+    /// Adds 2D orientation axes (X red, Y green) of the given <paramref name="length"/> lying in the
+    /// Z = 0 plane, rotated by <paramref name="rotationRadians"/> about Z so they reflect a
+    /// <see cref="Yaeger.Graphics.Transform2D"/>'s orientation, anchored at <paramref name="origin"/>.
+    /// </summary>
+    public void AddAxes2D(Vector2 origin, float rotationRadians, float length)
+    {
+        if (!IsFinite(origin) || !float.IsFinite(rotationRadians) || !float.IsFinite(length))
+            return;
+
+        var cos = MathF.Cos(rotationRadians);
+        var sin = MathF.Sin(rotationRadians);
+        var o = new Vector3(origin.X, origin.Y, 0f);
+
+        // Rotated X/Y basis vectors in the Z = 0 plane. Colours match AddAxes (X red, Y green).
+        var right = new Vector3(cos, sin, 0f) * length;
+        var up = new Vector3(-sin, cos, 0f) * length;
+
+        AddLine(o, o + right, new Vector4(1f, 0.2f, 0.2f, 1f));
+        AddLine(o, o + up, new Vector4(0.2f, 1f, 0.2f, 1f));
+    }
+
+    /// <summary>
+    /// Adds the four edges of a rectangle lying in the Z = 0 plane, centred at
+    /// <paramref name="center"/> with the given <paramref name="halfExtents"/> and rotated by
+    /// <paramref name="rotationRadians"/> about Z. Used to outline 2D sprite bounds and the
+    /// <see cref="Yaeger.Graphics.Camera2D"/> viewport.
+    /// </summary>
+    public void AddRect(Vector2 center, Vector2 halfExtents, float rotationRadians, Vector4 color)
+    {
+        // Reject non-finite inputs up front, matching the other builders: a NaN/Inf would otherwise
+        // flow straight into the emitted vertices.
+        if (!IsFinite(center) || !IsFinite(halfExtents) || !float.IsFinite(rotationRadians))
+            return;
+
+        var cos = MathF.Cos(rotationRadians);
+        var sin = MathF.Sin(rotationRadians);
+
+        // Local corners (CCW), rotated into world space and lifted to Z = 0.
+        Span<Vector2> local =
+        [
+            new(-halfExtents.X, -halfExtents.Y),
+            new(halfExtents.X, -halfExtents.Y),
+            new(halfExtents.X, halfExtents.Y),
+            new(-halfExtents.X, halfExtents.Y),
+        ];
+
+        Span<Vector3> corners = stackalloc Vector3[4];
+        for (var i = 0; i < 4; i++)
+        {
+            var x = local[i].X * cos - local[i].Y * sin;
+            var y = local[i].X * sin + local[i].Y * cos;
+            corners[i] = new Vector3(center.X + x, center.Y + y, 0f);
+        }
+
+        for (var i = 0; i < 4; i++)
+            AddLine(corners[i], corners[(i + 1) % 4], color);
+    }
+
     /// <summary>Adds an arrow from <paramref name="from"/> to <paramref name="to"/> with a small 3D arrowhead.</summary>
     public void AddArrow(Vector3 from, Vector3 to, Vector4 color, float headSize)
     {
@@ -172,6 +231,8 @@ public sealed class GizmoBuilder
 
     private static bool IsFinite(Vector3 v) =>
         float.IsFinite(v.X) && float.IsFinite(v.Y) && float.IsFinite(v.Z);
+
+    private static bool IsFinite(Vector2 v) => float.IsFinite(v.X) && float.IsFinite(v.Y);
 
     // Builds an orthonormal basis (u, v) spanning the plane perpendicular to the unit vector dir.
     private static void Basis(Vector3 dir, out Vector3 u, out Vector3 v)

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -39,8 +39,10 @@ public sealed class ImGuiInspector : IDisposable
     private readonly GizmoBuilder _gizmoBuilder = new();
 
     /// <summary>
-    /// When true (the default), the selected entity is highlighted in the 3D scene with gizmos.
-    /// Requires a <see cref="Camera3D"/> in the world; purely 2D scenes show no gizmos.
+    /// When true (the default), the selected entity is highlighted in the scene with gizmos.
+    /// 3D entities are projected through the world's <see cref="Camera3D"/>; 2D entities
+    /// (<see cref="Transform2D"/> / <see cref="Camera2D"/>) through the active <see cref="Camera2D"/>,
+    /// falling back to NDC-direct when the 2D scene has no camera.
     /// </summary>
     public bool ShowGizmos { get; set; } = true;
 
@@ -153,7 +155,9 @@ public sealed class ImGuiInspector : IDisposable
 
     /// <summary>
     /// Draws the world-space gizmos for the current selection so the user can see what they are
-    /// editing. Needs a <see cref="Camera3D"/> to know how to project; no-ops without one.
+    /// editing. Projects through the world's <see cref="Camera3D"/> for 3D entities and a
+    /// <see cref="Camera2D"/>-derived (or identity) matrix for 2D entities; no-ops when it can't
+    /// resolve a projection.
     /// </summary>
     private void RenderGizmos()
     {
@@ -164,7 +168,7 @@ public sealed class ImGuiInspector : IDisposable
         if (!_world.Entities.Contains(entity))
             return;
 
-        if (!TryGetSceneViewProjection(out var viewProj, out var aspectRatio))
+        if (!TryGetSceneViewProjection(entity, out var viewProj, out var aspectRatio))
             return;
 
         _gizmoBuilder.Clear();
@@ -172,12 +176,33 @@ public sealed class ImGuiInspector : IDisposable
         _gizmoRenderer.Render(_gizmoBuilder.Lines, viewProj);
     }
 
-    // Resolves the active 3D camera's view-projection (and aspect) from the world, mirroring how
-    // MeshRenderSystem picks the first Camera3D. Returns false for purely 2D scenes.
-    private bool TryGetSceneViewProjection(out Matrix4x4 viewProj, out float aspectRatio)
+    // Resolves the view-projection (and aspect) used to draw gizmos for the selected entity.
+    //
+    // A selected 2D entity is projected through the 2D pipeline regardless of any 3D camera, since
+    // the two live in different spaces: mirror RenderSystem — the first Camera2D wins, and a scene
+    // with no Camera2D falls back to identity (NDC-direct), exactly as the 2D renderer does. So
+    // even a camera-less Pong-style scene shows gizmos. Other entities project through the active
+    // 3D camera (mirroring MeshRenderSystem); a 3D scene with no Camera3D shows nothing.
+    private bool TryGetSceneViewProjection(
+        Entity entity,
+        out Matrix4x4 viewProj,
+        out float aspectRatio
+    )
     {
         var size = _window.Size;
         aspectRatio = size.Y > 0f ? size.X / size.Y : 1f;
+
+        if (IsTwoDimensional(entity))
+        {
+            foreach (var (_, camera) in _world.GetStore<Camera2D>().All())
+            {
+                viewProj = camera.ViewProjection(aspectRatio);
+                return true;
+            }
+
+            viewProj = Matrix4x4.Identity;
+            return true;
+        }
 
         foreach (var (_, camera) in _world.GetStore<Camera3D>().All())
         {
@@ -188,6 +213,10 @@ public sealed class ImGuiInspector : IDisposable
         viewProj = Matrix4x4.Identity;
         return false;
     }
+
+    private bool IsTwoDimensional(Entity entity) =>
+        _world.TryGetComponent<Transform2D>(entity, out _)
+        || _world.TryGetComponent<Camera2D>(entity, out _);
 
     // ── Main window ──────────────────────────────────────────────────────────────
 

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -26,6 +26,108 @@ public class EntityGizmosTests
     }
 
     [Fact]
+    public void Transform2D_DrawsAxesAndScaledBounds()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        // Position (2,3), no rotation, scale (4,2) → the sprite quad spans X∈[0,4], Y∈[2,4].
+        world.AddComponent(entity, new Transform2D(new Vector2(2, 3), 0f, new Vector2(4, 2)));
+
+        var lines = Build(world, entity);
+
+        // Two axes (X, Y) + four bounds edges.
+        Assert.Equal(6, lines.Count);
+        // Axes anchored at the entity position.
+        Assert.Contains(lines, l => l.Start == new Vector3(2, 3, 0));
+        // Bounds reach the scaled sprite corners (half-extents 2 × 1 → X = 4, Y = 4).
+        Assert.Contains(lines, l => Near(l.Start.X, 4f) || Near(l.End.X, 4f));
+        Assert.Contains(lines, l => Near(l.Start.Y, 4f) || Near(l.End.Y, 4f));
+        // 2D gizmos live in the Z = 0 plane.
+        Assert.All(
+            lines,
+            l =>
+            {
+                Assert.Equal(0f, l.Start.Z);
+                Assert.Equal(0f, l.End.Z);
+            }
+        );
+        // Bounds rectangle is amber.
+        Assert.Contains(lines, l => l.Color == new Vector4(1f, 0.75f, 0.2f, 1f));
+    }
+
+    [Fact]
+    public void Transform2D_RotationOrientsAxesAndBounds()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        // 90° rotation maps the local +X axis onto world +Y.
+        world.AddComponent(entity, new Transform2D(Vector2.Zero, MathF.PI / 2f, new Vector2(2, 1)));
+
+        var lines = Build(world, entity);
+
+        // The red X axis (first line) now points up the Y axis.
+        var xAxis = lines[0];
+        Assert.True(xAxis.Color.X > xAxis.Color.Y && xAxis.Color.X > xAxis.Color.Z);
+        Assert.True(Near(xAxis.End.X, 0f) && xAxis.End.Y > 0.4f);
+    }
+
+    [Fact]
+    public void Camera2D_DrawsViewportRectangle()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Camera2D(Vector2.Zero, 1f, 0f));
+
+        var lines = Build(world, entity);
+
+        // A single rectangle (4 edges), coloured yellow.
+        Assert.Equal(4, lines.Count);
+        Assert.All(lines, l => Assert.Equal(new Vector4(1f, 1f, 0.3f, 1f), l.Color));
+        // At zoom 1 the visible span is [-aspect, aspect] × [-1, 1].
+        var maxX = lines.Max(l => MathF.Max(MathF.Abs(l.Start.X), MathF.Abs(l.End.X)));
+        var maxY = lines.Max(l => MathF.Max(MathF.Abs(l.Start.Y), MathF.Abs(l.End.Y)));
+        Assert.Equal(Aspect, maxX, 3);
+        Assert.Equal(1f, maxY, 3);
+    }
+
+    [Fact]
+    public void Camera2D_ZoomNarrowsViewport()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Camera2D(Vector2.Zero, 2f, 0f));
+
+        var lines = Build(world, entity);
+
+        // Zoom 2 halves the visible span: [-aspect/2, aspect/2] × [-0.5, 0.5].
+        var maxX = lines.Max(l => MathF.Max(MathF.Abs(l.Start.X), MathF.Abs(l.End.X)));
+        var maxY = lines.Max(l => MathF.Max(MathF.Abs(l.Start.Y), MathF.Abs(l.End.Y)));
+        Assert.Equal(Aspect / 2f, maxX, 3);
+        Assert.Equal(0.5f, maxY, 3);
+    }
+
+    [Fact]
+    public void Camera2D_DefaultZeroZoom_ProducesFiniteViewport()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        // default(Camera2D) has Zoom = 0, which Camera2D.ViewProjection treats as 1.
+        world.AddComponent(entity, default(Camera2D));
+
+        var lines = Build(world, entity);
+
+        Assert.Equal(4, lines.Count);
+        Assert.All(
+            lines,
+            l =>
+            {
+                Assert.True(float.IsFinite(l.Start.X) && float.IsFinite(l.Start.Y));
+                Assert.True(float.IsFinite(l.End.X) && float.IsFinite(l.End.Y));
+            }
+        );
+    }
+
+    [Fact]
     public void Transform3D_DrawsOrientationAxes()
     {
         var world = new World();

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -128,6 +128,29 @@ public class EntityGizmosTests
     }
 
     [Fact]
+    public void Camera2D_InfiniteZoom_CollapsesToFinitePoint()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        // Match Camera2D.ViewProjection: a +Infinity zoom is kept, collapsing the visible span to a
+        // point (aspect/∞ = 0). The emitted vertices must stay finite — and all coincide at the
+        // camera position.
+        world.AddComponent(entity, new Camera2D(new Vector2(3, 4), float.PositiveInfinity, 0f));
+
+        var lines = Build(world, entity);
+
+        Assert.Equal(4, lines.Count);
+        Assert.All(
+            lines,
+            l =>
+            {
+                Assert.Equal(new Vector3(3, 4, 0), l.Start);
+                Assert.Equal(new Vector3(3, 4, 0), l.End);
+            }
+        );
+    }
+
+    [Fact]
     public void Transform3D_DrawsOrientationAxes()
     {
         var world = new World();

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -151,6 +151,27 @@ public class EntityGizmosTests
     }
 
     [Fact]
+    public void MixedDimensions_EmitsOnly2DGizmos()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        // An entity carrying both 2D and 3D components (the Add Component menu allows this) is
+        // treated as 2D for gizmos, matching the 2D projection the inspector would pick — so the
+        // far-off 3D axes must not be emitted with a 2D view-projection.
+        world.AddComponent(entity, new Transform2D(Vector2.Zero, 0f, Vector2.One));
+        world.AddComponent(
+            entity,
+            new Transform3D(new Vector3(50, 0, 0), Quaternion.Identity, Vector3.One)
+        );
+
+        var lines = Build(world, entity);
+
+        // Only the 2D gizmos (2 axes + 4 bounds edges); the 3D axes anchored at X = 50 are skipped.
+        Assert.Equal(6, lines.Count);
+        Assert.DoesNotContain(lines, l => l.Start.X > 1f || l.End.X > 1f);
+    }
+
+    [Fact]
     public void Transform3D_DrawsOrientationAxes()
     {
         var world = new World();

--- a/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
+++ b/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
@@ -237,6 +237,86 @@ public class GizmoBuilderTests
         }
     }
 
+    [Fact]
+    public void AddAxes2D_Identity_EmitsRedXAndGreenYInZPlane()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddAxes2D(Vector2.Zero, 0f, 2f);
+
+        Assert.Equal(2, builder.Lines.Count);
+        var x = builder.Lines[0];
+        var y = builder.Lines[1];
+
+        Assert.Equal(new Vector3(2, 0, 0), x.End);
+        Assert.Equal(new Vector3(0, 2, 0), y.End);
+        Assert.True(x.Color.X > x.Color.Y && x.Color.X > x.Color.Z); // red dominant
+        Assert.True(y.Color.Y > y.Color.X && y.Color.Y > y.Color.Z); // green dominant
+        Assert.Equal(0f, x.End.Z);
+        Assert.Equal(0f, y.End.Z);
+    }
+
+    [Fact]
+    public void AddAxes2D_NonFinite_EmitsNothing()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddAxes2D(new Vector2(float.NaN, 0), 0f, 1f);
+        builder.AddAxes2D(Vector2.Zero, float.PositiveInfinity, 1f);
+
+        Assert.Empty(builder.Lines);
+    }
+
+    [Fact]
+    public void AddRect_EmitsFourClosedEdgesInZPlane()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddRect(new Vector2(1, 2), new Vector2(3, 1), 0f, Vector4.One);
+
+        Assert.Equal(4, builder.Lines.Count);
+        // Corners sit at (1 ± 3, 2 ± 1), all in the Z = 0 plane.
+        foreach (var line in builder.Lines)
+        {
+            Assert.Equal(0f, line.Start.Z);
+            Assert.Equal(0f, line.End.Z);
+            Assert.InRange(line.Start.X, -2f, 4f);
+            Assert.InRange(line.Start.Y, 1f, 3f);
+        }
+        // The edges form a closed loop: each end meets the next start.
+        for (var i = 0; i < 4; i++)
+        {
+            var next = (i + 1) % 4;
+            Assert.Equal(builder.Lines[i].End, builder.Lines[next].Start);
+        }
+    }
+
+    [Fact]
+    public void AddRect_Rotation90_SwapsExtents()
+    {
+        var builder = new GizmoBuilder();
+
+        // 90° rotation maps the X half-extent (2) onto the Y axis.
+        builder.AddRect(Vector2.Zero, new Vector2(2, 1), MathF.PI / 2f, Vector4.One);
+
+        var maxY = builder.Lines.Max(l => MathF.Max(MathF.Abs(l.Start.Y), MathF.Abs(l.End.Y)));
+        var maxX = builder.Lines.Max(l => MathF.Max(MathF.Abs(l.Start.X), MathF.Abs(l.End.X)));
+        Assert.Equal(2f, maxY, 3);
+        Assert.Equal(1f, maxX, 3);
+    }
+
+    [Fact]
+    public void AddRect_NonFinite_EmitsNothing()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddRect(new Vector2(float.NaN, 0), Vector2.One, 0f, Vector4.One);
+        builder.AddRect(Vector2.Zero, new Vector2(float.PositiveInfinity, 1), 0f, Vector4.One);
+        builder.AddRect(Vector2.Zero, Vector2.One, float.NaN, Vector4.One);
+
+        Assert.Empty(builder.Lines);
+    }
+
     private static void AssertWithinBounds(Vector3 point, Aabb3D box)
     {
         Assert.InRange(point.X, box.Min.X - 1e-4f, box.Max.X + 1e-4f);


### PR DESCRIPTION
Closes #122.

## Summary

PR #121 added world-space selection gizmos to `ImGuiInspector`, but they were **3D-only** — projected through the world's `Camera3D`, so purely 2D scenes (no `Camera3D`) showed nothing. This extends the gizmo overlay to 2D scenes so selecting a `Transform2D` / `Camera2D` entity gives the same "see what you're editing" feedback.

## What changed

**`GizmoBuilder`** — two new 2D primitives in the Z = 0 plane, both with the same NaN/Inf guarding as the existing builders:
- `AddAxes2D(origin, rotation, length)` — oriented X (red) / Y (green) axes honoring rotation.
- `AddRect(center, halfExtents, rotation, color)` — a rotated rectangle (4 closed edges).

**`EntityGizmos`** — pure, unit-testable geometry for the 2D components:
- `Transform2D` → origin axes + an amber bounds rectangle. The rect traces the rendered sprite quad exactly (the renderer draws a unit quad scaled by `Transform2D.Scale`), so it lines up with what's on screen.
- `Camera2D` → a yellow viewport rectangle derived from `Position` / `Zoom` / `Rotation`, mirroring `Camera2D.ViewProjection`'s guards (at zoom `z` the visible span is `[-aspect/z, aspect/z] × [-1/z, 1/z]`).

**`ImGuiInspector`** — `TryGetSceneViewProjection` now resolves a projection per selected entity:
- A selected 2D entity projects through the first `Camera2D` (mirroring `RenderSystem`), falling back to **identity / NDC-direct** when the 2D scene has no camera — exactly as the 2D renderer does. This means even a camera-less Pong-style scene shows gizmos.
- Other entities still project through the active `Camera3D`; a 3D scene with no camera still shows nothing.

**Docs** — `docs/editor.md` updated: the new 2D gizmos are added to the table and the "purely 2D scenes show no gizmos" limitation is removed.

## Acceptance criteria

- [x] Selecting a `Transform2D` entity draws axes/bounds aligned with the rendered sprite.
- [x] Selecting a `Camera2D` entity draws its viewport rectangle.
- [x] Unit tests cover the new 2D gizmo geometry (`GizmoBuilderTests` + `EntityGizmosTests`).
- [x] Docs updated.

## Testing

- `dotnet build` — clean (0 warnings, 0 errors).
- `dotnet test` — **614 passed**, 7 skipped (the skipped ones require a live GL/font context).
- `dotnet csharpier check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWc1LYNNsRqbEoMqWN2et3

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWc1LYNNsRqbEoMqWN2et3)_