### PR TITLE
Make inspector gizmo appearance configurable (colors, sizes, depth test)

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -91,6 +91,35 @@ default; untick **Show selection gizmos** at the bottom of the inspector (or set
 > `SpotLight`'s cone angle updates the gizmo immediately — no extra wiring beyond the standard
 > *scene first, overlay last* render order.
 
+### Customising the gizmo appearance
+
+The default colours and sizes suit a roughly unit-scaled scene, but a 0.5-unit axis is invisible in a
+1000-unit world and the amber bounds may clash with a particular art style. `inspector.GizmoStyle`
+exposes a runtime [`GizmoStyle`](../src/Engine/Yaeger/Inspector/GizmoStyle.cs) you can retune — every
+value defaults to the look described above, so you only set what you want to change:
+
+```csharp
+// Make gizmos usable in a large-scale scene and tweak a couple of colours.
+inspector.GizmoStyle.SizeMultiplier = 50f;                 // scale axes, arrows, light cores
+inspector.GizmoStyle.BoundsColor = new Vector4(0, 1, 1, 1); // cyan mesh outlines
+inspector.GizmoStyle.DepthTest = true;                      // hide gizmos behind geometry
+inspector.GizmoStyle.LineWidth = 2f;                        // thicker lines
+```
+
+| Option(s) | Effect |
+| --- | --- |
+| `AxisXColor`, `AxisYColor`, `AxisZColor` | Colours of the 3D/2D orientation axes (default red / green / blue) |
+| `BoundsColor` | Mesh & sprite bounds outline colour (default amber) |
+| `CameraColor` | `Camera2D` viewport and `Camera3D` frustum colour (default yellow) |
+| `DirectionalLightColor`, `PointLightColor`, `SpotLightColor` | Override a light gizmo's colour; leave `null` (default) to keep using the light's own colour |
+| `SizeMultiplier` | Global scale for fixed-size elements (axes, directional arrows/rays/sun, point-light core). Range-driven shapes — the point-light reach sphere and the spot-light cone — keep showing the light's *actual* extent and are not scaled |
+| `AxisLength`, `Axis2DLength`, `DirectionalArrowLength`, `ArrowHeadSize`, `DirectionalRaySpread`, `DirectionalSunRadius`, `PointLightCoreSize` | Per-element base sizes (each then multiplied by `SizeMultiplier`) |
+| `SphereSegments`, `SunSphereSegments`, `PointLightCoreSegments`, `ConeSegments` | Tessellation of the circles/spheres/cone — raise for smoother shapes, lower to cut cost |
+| `DepthTest` | `false` (default) draws gizmos on top of everything; `true` lets scene geometry occlude them |
+| `LineWidth` | Gizmo line width in pixels (driver-dependent clamping applies) |
+
+The style is runtime-only — it is not saved with scenes.
+
 ### Adding, removing, and destroying
 
 - **Add Component** — pick a type from the drop-down and press **+**. The 3D components above all

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -31,11 +31,15 @@ public static class EntityGizmos
     )
     {
         style ??= DefaultStyle;
-        // Guard the user-supplied multiplier: a non-finite value would propagate into every scaled
-        // size and emit NaN vertices. Fall back to the default scale so a bad value degrades to the
-        // stock look rather than corrupting the line list (the builders also guard finiteness, but
-        // sanitising here keeps the gizmos visible instead of dropping them).
-        var scale = float.IsFinite(style.SizeMultiplier) ? style.SizeMultiplier : 1f;
+        // Guard the user-supplied multiplier: a non-finite OR non-positive value would propagate into
+        // every scaled size — emitting NaN vertices, or inverting/silently dropping shapes (a
+        // negative radius fails the builders' radius > 0 guards). Fall back to the default scale so
+        // any invalid value degrades to the stock look rather than corrupting the line list. A
+        // legitimate fractional scale (e.g. 0.5 for a small world) is positive and passes through.
+        var scale =
+            float.IsFinite(style.SizeMultiplier) && style.SizeMultiplier > 0f
+                ? style.SizeMultiplier
+                : 1f;
         // 2D gizmos live in the Z = 0 plane and are projected through a Camera2D-derived (or
         // identity) view-projection by the inspector. An entity is treated as either 2D or 3D for
         // gizmo purposes — never both — to stay consistent with

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -12,23 +12,22 @@ namespace Yaeger.Inspector;
 /// </summary>
 public static class EntityGizmos
 {
-    private const float AxisLength = 0.5f;
-    private const float Axis2DLength = 0.5f;
-    private const float DirectionalArrowLength = 1.5f;
-    private const float DirectionalSunRadius = 0.15f;
-    private const float ArrowHeadSize = 0.18f;
-
-    // Selected meshes are outlined in amber so they stand out against typical scene colours.
-    private static readonly Vector4 BoundsColor = new(1f, 0.75f, 0.2f, 1f);
-    private static readonly Vector4 CameraColor = new(1f, 1f, 0.3f, 1f);
-
     /// <summary>
     /// Appends the gizmos for <paramref name="entity"/> to <paramref name="builder"/> based on the
     /// components it carries. <paramref name="aspectRatio"/> shapes a <see cref="Camera3D"/> frustum
-    /// and a <see cref="Camera2D"/> viewport rectangle.
+    /// and a <see cref="Camera2D"/> viewport rectangle. <paramref name="style"/> tunes colours, sizes
+    /// and segment counts; when <c>null</c> a default style reproducing the original look is used.
     /// </summary>
-    public static void Build(World world, Entity entity, float aspectRatio, GizmoBuilder builder)
+    public static void Build(
+        World world,
+        Entity entity,
+        float aspectRatio,
+        GizmoBuilder builder,
+        GizmoStyle? style = null
+    )
     {
+        style ??= new GizmoStyle();
+        var scale = style.SizeMultiplier;
         // 2D gizmos live in the Z = 0 plane and are projected through a Camera2D-derived (or
         // identity) view-projection by the inspector. An entity is treated as either 2D or 3D for
         // gizmo purposes — never both — to stay consistent with
@@ -40,13 +39,13 @@ public static class EntityGizmos
 
         if (world.TryGetComponent<Transform2D>(entity, out var transform2D))
         {
-            BuildTransform2D(builder, transform2D);
+            BuildTransform2D(builder, transform2D, style, scale);
             has2D = true;
         }
 
         if (world.TryGetComponent<Camera2D>(entity, out var camera2D))
         {
-            BuildCamera2D(builder, camera2D, aspectRatio);
+            BuildCamera2D(builder, camera2D, aspectRatio, style);
             has2D = true;
         }
 
@@ -60,40 +59,63 @@ public static class EntityGizmos
         // especially. Drawn first so light/camera specific shapes layer on top.
         if (hasTransform)
         {
-            builder.AddAxes(anchor, transform.Rotation, AxisLength);
+            builder.AddAxes(
+                anchor,
+                transform.Rotation,
+                style.AxisLength * scale,
+                style.AxisXColor,
+                style.AxisYColor,
+                style.AxisZColor
+            );
 
             if (world.TryGetComponent<Aabb3D>(entity, out var aabb))
-                builder.AddTransformedBox(aabb, transform.ModelMatrix, BoundsColor);
+                builder.AddTransformedBox(aabb, transform.ModelMatrix, style.BoundsColor);
         }
 
         if (world.TryGetComponent<DirectionalLight>(entity, out var directional))
-            BuildDirectionalLight(builder, anchor, directional);
+            BuildDirectionalLight(builder, anchor, directional, style, scale);
 
         if (world.TryGetComponent<PointLight>(entity, out var point))
-            BuildPointLight(builder, anchor, point);
+            BuildPointLight(builder, anchor, point, style, scale);
 
         if (world.TryGetComponent<SpotLight>(entity, out var spot))
-            BuildSpotLight(builder, anchor, spot);
+            BuildSpotLight(builder, anchor, spot, style);
 
         if (world.TryGetComponent<Camera3D>(entity, out var camera))
-            BuildCamera(builder, camera, aspectRatio);
+            BuildCamera(builder, camera, aspectRatio, style);
     }
 
-    private static void BuildTransform2D(GizmoBuilder builder, Transform2D transform)
+    private static void BuildTransform2D(
+        GizmoBuilder builder,
+        Transform2D transform,
+        GizmoStyle style,
+        float scale
+    )
     {
         // Oriented X/Y axes mark the origin and facing; the bounds rectangle traces the sprite quad
         // (the renderer draws a unit quad scaled by Transform2D.Scale), so it lines up with what is
         // actually rendered.
-        builder.AddAxes2D(transform.Position, transform.Rotation, Axis2DLength);
+        builder.AddAxes2D(
+            transform.Position,
+            transform.Rotation,
+            style.Axis2DLength * scale,
+            style.AxisXColor,
+            style.AxisYColor
+        );
         builder.AddRect(
             transform.Position,
             transform.Scale * 0.5f,
             transform.Rotation,
-            BoundsColor
+            style.BoundsColor
         );
     }
 
-    private static void BuildCamera2D(GizmoBuilder builder, Camera2D camera, float aspectRatio)
+    private static void BuildCamera2D(
+        GizmoBuilder builder,
+        Camera2D camera,
+        float aspectRatio,
+        GizmoStyle style
+    )
     {
         // Mirror Camera2D.ViewProjection's zoom guard exactly (Zoom > 0 ? Zoom : 1) so the drawn
         // rectangle agrees with what the camera actually frames. A +Infinity zoom is kept as-is,
@@ -103,16 +125,18 @@ public static class EntityGizmos
         var zoom = camera.Zoom > 0f ? camera.Zoom : 1f;
 
         var halfExtents = new Vector2(aspect / zoom, 1f / zoom);
-        builder.AddRect(camera.Position, halfExtents, camera.Rotation, CameraColor);
+        builder.AddRect(camera.Position, halfExtents, camera.Rotation, style.CameraColor);
     }
 
     private static void BuildDirectionalLight(
         GizmoBuilder builder,
         Vector3 anchor,
-        DirectionalLight light
+        DirectionalLight light,
+        GizmoStyle style,
+        float scale
     )
     {
-        var color = OpaqueColor(light.Color);
+        var color = style.DirectionalLightColor ?? OpaqueColor(light.Color);
 
         // Direction points from the surface toward the source, so light *travels* the opposite way.
         // Visualise the travel direction as a bundle of parallel "sun ray" arrows — the standard
@@ -120,7 +144,12 @@ public static class EntityGizmos
         var travel = SafeNormalize(-light.Direction, -Vector3.UnitY);
         ParallelBasis(travel, out var u, out var v);
 
-        builder.AddWireSphere(anchor, DirectionalSunRadius, color, segments: 16);
+        builder.AddWireSphere(
+            anchor,
+            style.DirectionalSunRadius * scale,
+            color,
+            style.SunSphereSegments
+        );
 
         ReadOnlySpan<Vector2> offsets =
         [
@@ -131,41 +160,60 @@ public static class EntityGizmos
             new(0f, -1f),
         ];
 
-        const float spread = 0.18f;
+        var spread = style.DirectionalRaySpread * scale;
+        var arrowLength = style.DirectionalArrowLength * scale;
+        var headSize = style.ArrowHeadSize * scale;
         foreach (var offset in offsets)
         {
             var shift = (u * offset.X + v * offset.Y) * spread;
             var start = anchor + shift;
-            builder.AddArrow(start, start + travel * DirectionalArrowLength, color, ArrowHeadSize);
+            builder.AddArrow(start, start + travel * arrowLength, color, headSize);
         }
     }
 
-    private static void BuildPointLight(GizmoBuilder builder, Vector3 anchor, PointLight light)
+    private static void BuildPointLight(
+        GizmoBuilder builder,
+        Vector3 anchor,
+        PointLight light,
+        GizmoStyle style,
+        float scale
+    )
     {
-        var color = OpaqueColor(light.Color);
+        var color = style.PointLightColor ?? OpaqueColor(light.Color);
+        var coreSize = style.PointLightCoreSize * scale;
 
         // A non-positive (or non-finite) range disables the light in the renderer (attenuate
         // returns 0), so don't draw a misleading reach sphere for it. The small core is always
         // drawn so the light's position stays visible even when disabled.
         if (float.IsFinite(light.Range) && light.Range > 0f)
         {
-            builder.AddWireSphere(anchor, light.Range, color);
-            builder.AddWireSphere(anchor, MathF.Min(0.1f, light.Range * 0.1f), color, segments: 12);
+            builder.AddWireSphere(anchor, light.Range, color, style.SphereSegments);
+            builder.AddWireSphere(
+                anchor,
+                MathF.Min(coreSize, light.Range * 0.1f),
+                color,
+                style.PointLightCoreSegments
+            );
         }
         else
         {
-            builder.AddWireSphere(anchor, 0.1f, color, segments: 12);
+            builder.AddWireSphere(anchor, coreSize, color, style.PointLightCoreSegments);
         }
     }
 
-    private static void BuildSpotLight(GizmoBuilder builder, Vector3 anchor, SpotLight light)
+    private static void BuildSpotLight(
+        GizmoBuilder builder,
+        Vector3 anchor,
+        SpotLight light,
+        GizmoStyle style
+    )
     {
         // A non-positive (or non-finite) range disables the light, so skip the cone entirely — the
         // Transform3D axes still mark the light's position and orientation.
         if (!(float.IsFinite(light.Range) && light.Range > 0f))
             return;
 
-        var color = OpaqueColor(light.Color);
+        var color = style.SpotLightColor ?? OpaqueColor(light.Color);
         var direction = SafeNormalize(light.Direction, -Vector3.UnitY);
 
         // Coerce a non-finite outer angle to a safe default before clamping so a NaN/Inf set by a
@@ -175,10 +223,15 @@ public static class EntityGizmos
         var outer = Math.Clamp(outerRaw, 0f, 1.55f);
         var baseRadius = light.Range * MathF.Tan(outer);
 
-        builder.AddWireCone(anchor, direction, light.Range, baseRadius, color);
+        builder.AddWireCone(anchor, direction, light.Range, baseRadius, color, style.ConeSegments);
     }
 
-    private static void BuildCamera(GizmoBuilder builder, Camera3D camera, float aspectRatio)
+    private static void BuildCamera(
+        GizmoBuilder builder,
+        Camera3D camera,
+        float aspectRatio,
+        GizmoStyle style
+    )
     {
         // A non-finite position/target/up would survive SafeNormalize (which falls back) but still
         // poison the frustum corners via camera.Position, so bail before computing anything.
@@ -215,9 +268,9 @@ public static class EntityGizmos
         for (var i = 0; i < 4; i++)
         {
             var next = (i + 1) % 4;
-            builder.AddLine(nearCorners[i], nearCorners[next], CameraColor);
-            builder.AddLine(farCorners[i], farCorners[next], CameraColor);
-            builder.AddLine(nearCorners[i], farCorners[i], CameraColor);
+            builder.AddLine(nearCorners[i], nearCorners[next], style.CameraColor);
+            builder.AddLine(farCorners[i], farCorners[next], style.CameraColor);
+            builder.AddLine(nearCorners[i], farCorners[i], style.CameraColor);
         }
     }
 

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -27,7 +27,11 @@ public static class EntityGizmos
     )
     {
         style ??= new GizmoStyle();
-        var scale = style.SizeMultiplier;
+        // Guard the user-supplied multiplier: a non-finite value would propagate into every scaled
+        // size and emit NaN vertices. Fall back to the default scale so a bad value degrades to the
+        // stock look rather than corrupting the line list (the builders also guard finiteness, but
+        // sanitising here keeps the gizmos visible instead of dropping them).
+        var scale = float.IsFinite(style.SizeMultiplier) ? style.SizeMultiplier : 1f;
         // 2D gizmos live in the Z = 0 plane and are projected through a Camera2D-derived (or
         // identity) view-projection by the inspector. An entity is treated as either 2D or 3D for
         // gizmo purposes — never both — to stay consistent with

--- a/src/Engine/Yaeger/Inspector/EntityGizmos.cs
+++ b/src/Engine/Yaeger/Inspector/EntityGizmos.cs
@@ -12,6 +12,10 @@ namespace Yaeger.Inspector;
 /// </summary>
 public static class EntityGizmos
 {
+    // Shared fallback for the null-style case so a caller that omits the style (or passes null) each
+    // frame doesn't allocate a fresh GizmoStyle every call. Safe to share: Build only reads it.
+    private static readonly GizmoStyle DefaultStyle = new();
+
     /// <summary>
     /// Appends the gizmos for <paramref name="entity"/> to <paramref name="builder"/> based on the
     /// components it carries. <paramref name="aspectRatio"/> shapes a <see cref="Camera3D"/> frustum
@@ -26,7 +30,7 @@ public static class EntityGizmos
         GizmoStyle? style = null
     )
     {
-        style ??= new GizmoStyle();
+        style ??= DefaultStyle;
         // Guard the user-supplied multiplier: a non-finite value would propagate into every scaled
         // size and emit NaN vertices. Fall back to the default scale so a bad value degrades to the
         // stock look rather than corrupting the line list (the builders also guard finiteness, but

--- a/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
@@ -42,6 +42,11 @@ public sealed class GizmoBuilder
         Vector4? zColor = null
     )
     {
+        // Reject non-finite inputs up front (mirroring AddAxes2D): a NaN/Inf length — e.g. from a
+        // bad style scale factor — would otherwise flow straight into the emitted vertices.
+        if (!IsFinite(origin) || !IsFinite(rotation) || !float.IsFinite(length))
+            return;
+
         var right = Vector3.Transform(Vector3.UnitX, rotation) * length;
         var up = Vector3.Transform(Vector3.UnitY, rotation) * length;
         var forward = Vector3.Transform(Vector3.UnitZ, rotation) * length;
@@ -129,7 +134,10 @@ public sealed class GizmoBuilder
 
         var shaft = to - from;
         var lengthSq = shaft.LengthSquared();
-        if (lengthSq < 1e-12f)
+        // Skip the arrowhead for a degenerate shaft or a non-finite head size (e.g. from a bad style
+        // scale): a NaN/Inf headSize would otherwise flow into the head vertices below as NaN lines.
+        // The finite shaft is still kept.
+        if (lengthSq < 1e-12f || !float.IsFinite(headSize))
             return;
 
         var dir = shaft / MathF.Sqrt(lengthSq);
@@ -252,6 +260,9 @@ public sealed class GizmoBuilder
         float.IsFinite(v.X) && float.IsFinite(v.Y) && float.IsFinite(v.Z);
 
     private static bool IsFinite(Vector2 v) => float.IsFinite(v.X) && float.IsFinite(v.Y);
+
+    private static bool IsFinite(Quaternion q) =>
+        float.IsFinite(q.X) && float.IsFinite(q.Y) && float.IsFinite(q.Z) && float.IsFinite(q.W);
 
     // Builds an orthonormal basis (u, v) spanning the plane perpendicular to the unit vector dir.
     private static void Basis(Vector3 dir, out Vector3 u, out Vector3 v)

--- a/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
@@ -23,10 +23,12 @@ public sealed class GizmoBuilder
     public void AddLine(Vector3 start, Vector3 end, Vector4 color) =>
         _lines.Add(new GizmoLine(start, end, color));
 
-    // Default axis colours (X red, Y green, Z blue) used when a caller doesn't override them.
-    private static readonly Vector4 DefaultAxisX = new(1f, 0.2f, 0.2f, 1f);
-    private static readonly Vector4 DefaultAxisY = new(0.2f, 1f, 0.2f, 1f);
-    private static readonly Vector4 DefaultAxisZ = new(0.3f, 0.5f, 1f, 1f);
+    // Canonical default axis colours (X red, Y green, Z blue) used when a caller doesn't override
+    // them. Exposed so GizmoStyle's defaults source from the same constants instead of duplicating
+    // the literals — keep this the single place the axis colours are defined.
+    public static readonly Vector4 DefaultAxisX = new(1f, 0.2f, 0.2f, 1f);
+    public static readonly Vector4 DefaultAxisY = new(0.2f, 1f, 0.2f, 1f);
+    public static readonly Vector4 DefaultAxisZ = new(0.3f, 0.5f, 1f, 1f);
 
     /// <summary>
     /// Adds three orientation axes of the given length, rotated by <paramref name="rotation"/> so

--- a/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoBuilder.cs
@@ -23,28 +23,47 @@ public sealed class GizmoBuilder
     public void AddLine(Vector3 start, Vector3 end, Vector4 color) =>
         _lines.Add(new GizmoLine(start, end, color));
 
+    // Default axis colours (X red, Y green, Z blue) used when a caller doesn't override them.
+    private static readonly Vector4 DefaultAxisX = new(1f, 0.2f, 0.2f, 1f);
+    private static readonly Vector4 DefaultAxisY = new(0.2f, 1f, 0.2f, 1f);
+    private static readonly Vector4 DefaultAxisZ = new(0.3f, 0.5f, 1f, 1f);
+
     /// <summary>
-    /// Adds three RGB axes (X red, Y green, Z blue) of the given length, rotated by
-    /// <paramref name="rotation"/> so they reflect the entity's orientation, anchored at
-    /// <paramref name="origin"/>.
+    /// Adds three orientation axes of the given length, rotated by <paramref name="rotation"/> so
+    /// they reflect the entity's orientation, anchored at <paramref name="origin"/>. Colours default
+    /// to X red, Y green, Z blue; pass overrides to recolour them.
     /// </summary>
-    public void AddAxes(Vector3 origin, Quaternion rotation, float length)
+    public void AddAxes(
+        Vector3 origin,
+        Quaternion rotation,
+        float length,
+        Vector4? xColor = null,
+        Vector4? yColor = null,
+        Vector4? zColor = null
+    )
     {
         var right = Vector3.Transform(Vector3.UnitX, rotation) * length;
         var up = Vector3.Transform(Vector3.UnitY, rotation) * length;
         var forward = Vector3.Transform(Vector3.UnitZ, rotation) * length;
 
-        AddLine(origin, origin + right, new Vector4(1f, 0.2f, 0.2f, 1f));
-        AddLine(origin, origin + up, new Vector4(0.2f, 1f, 0.2f, 1f));
-        AddLine(origin, origin + forward, new Vector4(0.3f, 0.5f, 1f, 1f));
+        AddLine(origin, origin + right, xColor ?? DefaultAxisX);
+        AddLine(origin, origin + up, yColor ?? DefaultAxisY);
+        AddLine(origin, origin + forward, zColor ?? DefaultAxisZ);
     }
 
     /// <summary>
-    /// Adds 2D orientation axes (X red, Y green) of the given <paramref name="length"/> lying in the
-    /// Z = 0 plane, rotated by <paramref name="rotationRadians"/> about Z so they reflect a
-    /// <see cref="Yaeger.Graphics.Transform2D"/>'s orientation, anchored at <paramref name="origin"/>.
+    /// Adds 2D orientation axes (X red, Y green by default) of the given <paramref name="length"/>
+    /// lying in the Z = 0 plane, rotated by <paramref name="rotationRadians"/> about Z so they reflect
+    /// a <see cref="Yaeger.Graphics.Transform2D"/>'s orientation, anchored at <paramref name="origin"/>.
+    /// Pass colour overrides to recolour the axes.
     /// </summary>
-    public void AddAxes2D(Vector2 origin, float rotationRadians, float length)
+    public void AddAxes2D(
+        Vector2 origin,
+        float rotationRadians,
+        float length,
+        Vector4? xColor = null,
+        Vector4? yColor = null
+    )
     {
         if (!IsFinite(origin) || !float.IsFinite(rotationRadians) || !float.IsFinite(length))
             return;
@@ -57,8 +76,8 @@ public sealed class GizmoBuilder
         var right = new Vector3(cos, sin, 0f) * length;
         var up = new Vector3(-sin, cos, 0f) * length;
 
-        AddLine(o, o + right, new Vector4(1f, 0.2f, 0.2f, 1f));
-        AddLine(o, o + up, new Vector4(0.2f, 1f, 0.2f, 1f));
+        AddLine(o, o + right, xColor ?? DefaultAxisX);
+        AddLine(o, o + up, yColor ?? DefaultAxisY);
     }
 
     /// <summary>

--- a/src/Engine/Yaeger/Inspector/GizmoRenderer.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoRenderer.cs
@@ -146,6 +146,13 @@ public sealed class GizmoRenderer : IDisposable
 
         _gl.BindVertexArray(0);
         _shader.Unbind();
+
+        // Restore the baseline state the inspector path relies on: the 3D pass leaves depth testing
+        // off before gizmos draw, and the ImGui overlay rendered next expects the default line
+        // width. Undo whatever we changed so neither the overlay nor later passes inherit it.
+        if (depthTest)
+            _gl.Disable(EnableCap.DepthTest);
+        _gl.LineWidth(1f);
     }
 
     private void WriteVertex(int offset, Vector3 position, Vector4 color)

--- a/src/Engine/Yaeger/Inspector/GizmoRenderer.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoRenderer.cs
@@ -91,7 +91,17 @@ public sealed class GizmoRenderer : IDisposable
     /// Draws the supplied lines in world space using <paramref name="viewProj"/>. Lines beyond the
     /// internal capacity are dropped. A no-op when the list is empty.
     /// </summary>
-    public unsafe void Render(IReadOnlyList<GizmoLine> lines, Matrix4x4 viewProj)
+    /// <param name="depthTest">
+    /// When <c>false</c> (the default) gizmos draw on top of all geometry; when <c>true</c> they are
+    /// depth-tested against the scene so geometry in front occludes them.
+    /// </param>
+    /// <param name="lineWidth">Width of the drawn lines in pixels (driver-dependent clamping applies).</param>
+    public unsafe void Render(
+        IReadOnlyList<GizmoLine> lines,
+        Matrix4x4 viewProj,
+        bool depthTest = false,
+        float lineWidth = 1f
+    )
     {
         if (lines.Count == 0)
             return;
@@ -107,10 +117,18 @@ public sealed class GizmoRenderer : IDisposable
             WriteVertex(offset + FloatsPerVertex, line.End, line.Color);
         }
 
-        // Alpha-blend so coloured gizmos read well over the scene; the 3D pass already left depth
-        // testing off, so lines draw on top regardless of occluding geometry.
+        // Alpha-blend so coloured gizmos read well over the scene.
         _gl.Enable(EnableCap.Blend);
         _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+
+        // Depth testing is off by default (the 3D pass already left it off) so lines draw on top of
+        // occluding geometry; enable it when the caller wants gizmos hidden behind the scene.
+        if (depthTest)
+            _gl.Enable(EnableCap.DepthTest);
+        else
+            _gl.Disable(EnableCap.DepthTest);
+
+        _gl.LineWidth(lineWidth > 0f ? lineWidth : 1f);
 
         _shader.Bind();
         _shader.SetUniformMatrix4("uViewProj", viewProj);

--- a/src/Engine/Yaeger/Inspector/GizmoRenderer.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoRenderer.cs
@@ -128,7 +128,10 @@ public sealed class GizmoRenderer : IDisposable
         else
             _gl.Disable(EnableCap.DepthTest);
 
-        _gl.LineWidth(lineWidth > 0f ? lineWidth : 1f);
+        // Fall back to 1px for any non-positive or non-finite width: a NaN already fails the > 0
+        // test, but +Infinity would otherwise pass straight through to glLineWidth and produce a GL
+        // error / undefined rendering.
+        _gl.LineWidth(float.IsFinite(lineWidth) && lineWidth > 0f ? lineWidth : 1f);
 
         _shader.Bind();
         _shader.SetUniformMatrix4("uViewProj", viewProj);

--- a/src/Engine/Yaeger/Inspector/GizmoStyle.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoStyle.cs
@@ -14,14 +14,16 @@ public sealed class GizmoStyle
 {
     // ── Colours ───────────────────────────────────────────────────────────────
 
+    // Axis colour defaults source from GizmoBuilder's canonical constants so the two never drift.
+
     /// <summary>Colour of the local +X orientation axis (3D and 2D). Default red.</summary>
-    public Vector4 AxisXColor { get; set; } = new(1f, 0.2f, 0.2f, 1f);
+    public Vector4 AxisXColor { get; set; } = GizmoBuilder.DefaultAxisX;
 
     /// <summary>Colour of the local +Y orientation axis (3D and 2D). Default green.</summary>
-    public Vector4 AxisYColor { get; set; } = new(0.2f, 1f, 0.2f, 1f);
+    public Vector4 AxisYColor { get; set; } = GizmoBuilder.DefaultAxisY;
 
     /// <summary>Colour of the local +Z orientation axis (3D only). Default blue.</summary>
-    public Vector4 AxisZColor { get; set; } = new(0.3f, 0.5f, 1f, 1f);
+    public Vector4 AxisZColor { get; set; } = GizmoBuilder.DefaultAxisZ;
 
     /// <summary>Colour of mesh / sprite bounds outlines. Default amber.</summary>
     public Vector4 BoundsColor { get; set; } = new(1f, 0.75f, 0.2f, 1f);

--- a/src/Engine/Yaeger/Inspector/GizmoStyle.cs
+++ b/src/Engine/Yaeger/Inspector/GizmoStyle.cs
@@ -1,0 +1,111 @@
+using System.Numerics;
+
+namespace Yaeger.Inspector;
+
+/// <summary>
+/// Tunes the appearance of the editor selection gizmos drawn by <see cref="EntityGizmos"/> and
+/// <see cref="GizmoRenderer"/>. Every value defaults to the engine's original look, so a freshly
+/// constructed style reproduces today's gizmos exactly — assign a custom instance to
+/// <see cref="ImGuiInspector"/>'s style to adapt the overlay to a different scene scale or visual
+/// taste (e.g. raise <see cref="SizeMultiplier"/> for a 1000-unit world, or drop segment counts to
+/// trade quality for cost). Runtime-only: it is not serialized with scenes.
+/// </summary>
+public sealed class GizmoStyle
+{
+    // ── Colours ───────────────────────────────────────────────────────────────
+
+    /// <summary>Colour of the local +X orientation axis (3D and 2D). Default red.</summary>
+    public Vector4 AxisXColor { get; set; } = new(1f, 0.2f, 0.2f, 1f);
+
+    /// <summary>Colour of the local +Y orientation axis (3D and 2D). Default green.</summary>
+    public Vector4 AxisYColor { get; set; } = new(0.2f, 1f, 0.2f, 1f);
+
+    /// <summary>Colour of the local +Z orientation axis (3D only). Default blue.</summary>
+    public Vector4 AxisZColor { get; set; } = new(0.3f, 0.5f, 1f, 1f);
+
+    /// <summary>Colour of mesh / sprite bounds outlines. Default amber.</summary>
+    public Vector4 BoundsColor { get; set; } = new(1f, 0.75f, 0.2f, 1f);
+
+    /// <summary>Colour of the <see cref="Yaeger.Graphics.Camera2D"/> viewport and
+    /// <see cref="Yaeger.Graphics.Camera3D"/> frustum. Default yellow.</summary>
+    public Vector4 CameraColor { get; set; } = new(1f, 1f, 0.3f, 1f);
+
+    /// <summary>
+    /// Optional override for the directional-light gizmo colour. When <c>null</c> (the default) the
+    /// gizmo uses the light's own colour, matching the original behaviour.
+    /// </summary>
+    public Vector4? DirectionalLightColor { get; set; }
+
+    /// <summary>
+    /// Optional override for the point-light gizmo colour. When <c>null</c> (the default) the gizmo
+    /// uses the light's own colour.
+    /// </summary>
+    public Vector4? PointLightColor { get; set; }
+
+    /// <summary>
+    /// Optional override for the spot-light gizmo colour. When <c>null</c> (the default) the gizmo
+    /// uses the light's own colour.
+    /// </summary>
+    public Vector4? SpotLightColor { get; set; }
+
+    // ── Sizes / scale factors ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Global multiplier applied to every fixed-size gizmo element (orientation axes, the directional
+    /// light's arrows / ray spread / sun marker, and the point-light position core). Range-driven
+    /// shapes that visualise a real quantity — the point-light reach sphere and the spot-light cone —
+    /// are <em>not</em> scaled, so they keep showing the light's actual extent. Raise this for large
+    /// worlds where the default 0.5-unit axes are invisible. Default 1.
+    /// </summary>
+    public float SizeMultiplier { get; set; } = 1f;
+
+    /// <summary>Length of the 3D orientation axes before <see cref="SizeMultiplier"/>. Default 0.5.</summary>
+    public float AxisLength { get; set; } = 0.5f;
+
+    /// <summary>Length of the 2D orientation axes before <see cref="SizeMultiplier"/>. Default 0.5.</summary>
+    public float Axis2DLength { get; set; } = 0.5f;
+
+    /// <summary>Length of each directional-light ray arrow before <see cref="SizeMultiplier"/>. Default 1.5.</summary>
+    public float DirectionalArrowLength { get; set; } = 1.5f;
+
+    /// <summary>Size of the arrowheads on directional-light rays before <see cref="SizeMultiplier"/>. Default 0.18.</summary>
+    public float ArrowHeadSize { get; set; } = 0.18f;
+
+    /// <summary>Spread of the parallel directional-light rays before <see cref="SizeMultiplier"/>. Default 0.18.</summary>
+    public float DirectionalRaySpread { get; set; } = 0.18f;
+
+    /// <summary>Radius of the directional-light "sun" marker before <see cref="SizeMultiplier"/>. Default 0.15.</summary>
+    public float DirectionalSunRadius { get; set; } = 0.15f;
+
+    /// <summary>
+    /// Size of the small point-light position core before <see cref="SizeMultiplier"/>. The drawn
+    /// core is capped at a tenth of the light's range so it never swamps a tiny light. Default 0.1.
+    /// </summary>
+    public float PointLightCoreSize { get; set; } = 0.1f;
+
+    // ── Segment counts (quality vs. cost) ─────────────────────────────────────
+
+    /// <summary>Segment count for the point-light reach sphere. Default 24.</summary>
+    public int SphereSegments { get; set; } = 24;
+
+    /// <summary>Segment count for the directional-light "sun" marker sphere. Default 16.</summary>
+    public int SunSphereSegments { get; set; } = 16;
+
+    /// <summary>Segment count for the small point-light position core. Default 12.</summary>
+    public int PointLightCoreSegments { get; set; } = 12;
+
+    /// <summary>Segment count for the spot-light cone base circle. Default 24.</summary>
+    public int ConeSegments { get; set; } = 24;
+
+    // ── Rendering ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// When <c>false</c> (the default) gizmos draw on top of the scene regardless of occluding
+    /// geometry — handy for finding a light tucked behind a wall. Set <c>true</c> to depth-test
+    /// gizmos against the scene so they are hidden by geometry in front of them.
+    /// </summary>
+    public bool DepthTest { get; set; }
+
+    /// <summary>Width of the gizmo lines in pixels (driver-dependent clamping applies). Default 1.</summary>
+    public float LineWidth { get; set; } = 1f;
+}

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -46,6 +46,14 @@ public sealed class ImGuiInspector : IDisposable
     /// </summary>
     public bool ShowGizmos { get; set; } = true;
 
+    /// <summary>
+    /// Appearance of the selection gizmos — colours, sizes, segment counts, depth-test and line
+    /// width. Defaults reproduce the engine's original look. Mutate the properties in place or assign
+    /// a fresh <see cref="GizmoStyle"/> to retune the overlay (e.g. raise
+    /// <see cref="GizmoStyle.SizeMultiplier"/> for a large-scale scene).
+    /// </summary>
+    public GizmoStyle GizmoStyle { get; set; } = new();
+
     private bool _visible;
     private Entity? _selectedEntity;
     private int _addComponentComboIndex;
@@ -172,8 +180,13 @@ public sealed class ImGuiInspector : IDisposable
             return;
 
         _gizmoBuilder.Clear();
-        EntityGizmos.Build(_world, entity, aspectRatio, _gizmoBuilder);
-        _gizmoRenderer.Render(_gizmoBuilder.Lines, viewProj);
+        EntityGizmos.Build(_world, entity, aspectRatio, _gizmoBuilder, GizmoStyle);
+        _gizmoRenderer.Render(
+            _gizmoBuilder.Lines,
+            viewProj,
+            GizmoStyle.DepthTest,
+            GizmoStyle.LineWidth
+        );
     }
 
     // Resolves the view-projection (and aspect) used to draw gizmos for the selected entity.

--- a/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
+++ b/src/Engine/Yaeger/Inspector/ImGuiInspector.cs
@@ -46,13 +46,20 @@ public sealed class ImGuiInspector : IDisposable
     /// </summary>
     public bool ShowGizmos { get; set; } = true;
 
+    private GizmoStyle _gizmoStyle = new();
+
     /// <summary>
     /// Appearance of the selection gizmos — colours, sizes, segment counts, depth-test and line
     /// width. Defaults reproduce the engine's original look. Mutate the properties in place or assign
     /// a fresh <see cref="GizmoStyle"/> to retune the overlay (e.g. raise
-    /// <see cref="GizmoStyle.SizeMultiplier"/> for a large-scale scene).
+    /// <see cref="GizmoStyle.SizeMultiplier"/> for a large-scale scene). Never <c>null</c> — the
+    /// setter rejects it so <see cref="RenderGizmos"/> (which dereferences it every frame) can't NRE.
     /// </summary>
-    public GizmoStyle GizmoStyle { get; set; } = new();
+    public GizmoStyle GizmoStyle
+    {
+        get => _gizmoStyle;
+        set => _gizmoStyle = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
     private bool _visible;
     private Entity? _selectedEntity;

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -577,16 +577,21 @@ public class EntityGizmosTests
         );
     }
 
-    [Fact]
-    public void Style_NonFiniteSizeMultiplier_FallsBackToFiniteDefaultSizedGizmos()
+    [Theory]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(0f)]
+    [InlineData(-2f)]
+    public void Style_InvalidSizeMultiplier_FallsBackToFiniteDefaultSizedGizmos(float multiplier)
     {
         var world = new World();
         var entity = world.CreateEntity();
         world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
 
-        // A NaN multiplier must not corrupt the line list: it falls back to the default scale, so
-        // the axes are still emitted at their default 0.5 length with finite vertices.
-        var lines = Build(world, entity, new GizmoStyle { SizeMultiplier = float.NaN });
+        // A non-finite or non-positive multiplier must not corrupt the line list: it falls back to
+        // the default scale, so the axes are still emitted at their default 0.5 length with finite
+        // vertices (rather than NaN, zero-length, or inverted axes).
+        var lines = Build(world, entity, new GizmoStyle { SizeMultiplier = multiplier });
 
         Assert.Equal(3, lines.Count);
         Assert.All(

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -578,6 +578,30 @@ public class EntityGizmosTests
     }
 
     [Fact]
+    public void Style_NonFiniteSizeMultiplier_FallsBackToFiniteDefaultSizedGizmos()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+
+        // A NaN multiplier must not corrupt the line list: it falls back to the default scale, so
+        // the axes are still emitted at their default 0.5 length with finite vertices.
+        var lines = Build(world, entity, new GizmoStyle { SizeMultiplier = float.NaN });
+
+        Assert.Equal(3, lines.Count);
+        Assert.All(
+            lines,
+            l =>
+            {
+                Assert.True(float.IsFinite(l.End.X) && float.IsFinite(l.End.Y));
+                Assert.True(float.IsFinite(l.End.Z));
+            }
+        );
+        var maxAxisReach = MathF.Max(MathF.Max(lines[0].End.X, lines[1].End.Y), lines[2].End.Z);
+        Assert.Equal(0.5f, maxAxisReach, 3);
+    }
+
+    [Fact]
     public void Style_DefaultsReproduceOriginalColors()
     {
         var world = new World();

--- a/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
+++ b/tests/Yaeger.Tests/Inspector/EntityGizmosTests.cs
@@ -9,10 +9,14 @@ public class EntityGizmosTests
 {
     private const float Aspect = 16f / 9f;
 
-    private static IReadOnlyList<GizmoLine> Build(World world, Entity entity)
+    private static IReadOnlyList<GizmoLine> Build(
+        World world,
+        Entity entity,
+        GizmoStyle? style = null
+    )
     {
         var builder = new GizmoBuilder();
-        EntityGizmos.Build(world, entity, Aspect, builder);
+        EntityGizmos.Build(world, entity, Aspect, builder, style);
         return builder.Lines;
     }
 
@@ -415,6 +419,184 @@ public class EntityGizmosTests
         // Near + far rectangles (4 edges each) plus 4 connecting edges = 12 lines.
         Assert.Equal(12, lines.Count);
         Assert.All(lines, l => Assert.Equal(new Vector4(1, 1, 0.3f, 1), l.Color));
+    }
+
+    // ── Style configurability (issue #123) ────────────────────────────────────
+
+    [Fact]
+    public void Style_CustomAxisColors_FlowIntoTransform3DAxes()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+
+        var style = new GizmoStyle
+        {
+            AxisXColor = new Vector4(0.9f, 0f, 0f, 1f),
+            AxisYColor = new Vector4(0f, 0.9f, 0f, 1f),
+            AxisZColor = new Vector4(0f, 0f, 0.9f, 1f),
+        };
+
+        var lines = Build(world, entity, style);
+
+        Assert.Equal(style.AxisXColor, lines[0].Color);
+        Assert.Equal(style.AxisYColor, lines[1].Color);
+        Assert.Equal(style.AxisZColor, lines[2].Color);
+    }
+
+    [Fact]
+    public void Style_SizeMultiplier_ScalesAxisLength()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+
+        // AxisLength 0.5 × multiplier 4 → 2-unit axes.
+        var style = new GizmoStyle { SizeMultiplier = 4f };
+
+        var lines = Build(world, entity, style);
+
+        var maxAxisReach = MathF.Max(MathF.Max(lines[0].End.X, lines[1].End.Y), lines[2].End.Z);
+        Assert.Equal(2f, maxAxisReach, 3);
+    }
+
+    [Fact]
+    public void Style_CustomBoundsColor_FlowsIntoMeshBox()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+        world.AddComponent(entity, new Aabb3D(new Vector3(-1, -1, -1), new Vector3(1, 1, 1)));
+
+        var bounds = new Vector4(0.2f, 0.4f, 0.6f, 1f);
+        var style = new GizmoStyle { BoundsColor = bounds };
+
+        var lines = Build(world, entity, style);
+
+        // The 12 box edges carry the custom bounds colour (axes aside).
+        Assert.Equal(12, lines.Count(l => l.Color == bounds));
+    }
+
+    [Fact]
+    public void Style_CustomCameraColor_FlowsIntoFrustum()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(
+            entity,
+            new Camera3D(
+                new Vector3(0, 0, 5),
+                Vector3.Zero,
+                Vector3.UnitY,
+                MathF.PI / 4f,
+                0.1f,
+                100f
+            )
+        );
+
+        var cameraColor = new Vector4(0.3f, 0.6f, 0.9f, 1f);
+        var style = new GizmoStyle { CameraColor = cameraColor };
+
+        var lines = Build(world, entity, style);
+
+        Assert.All(lines, l => Assert.Equal(cameraColor, l.Color));
+    }
+
+    [Fact]
+    public void Style_DirectionalLightColorOverride_ReplacesLightColor()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(
+            entity,
+            new DirectionalLight
+            {
+                Direction = Vector3.UnitY,
+                Color = Color.White,
+                Intensity = 1f,
+            }
+        );
+
+        var overrideColor = new Vector4(0.1f, 0.2f, 0.3f, 1f);
+        var style = new GizmoStyle { DirectionalLightColor = overrideColor };
+
+        var lines = Build(world, entity, style);
+
+        Assert.NotEmpty(lines);
+        Assert.All(lines, l => Assert.Equal(overrideColor, l.Color));
+    }
+
+    [Fact]
+    public void Style_PointLightSphereSegments_ControlLineCount()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One));
+        world.AddComponent(
+            entity,
+            new PointLight
+            {
+                Color = Color.Red,
+                Intensity = 1f,
+                Range = 5f,
+            }
+        );
+
+        var style = new GizmoStyle { SphereSegments = 8, PointLightCoreSegments = 6 };
+
+        var lines = Build(world, entity, style);
+
+        // Reach sphere (3 circles × 8) + core (3 × 6) + 3 Transform3D axes.
+        Assert.Equal(8 * 3 + 6 * 3 + 3, lines.Count);
+    }
+
+    [Fact]
+    public void Style_SizeMultiplier_ScalesDirectionalArrowLength()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(
+            entity,
+            new DirectionalLight
+            {
+                Direction = Vector3.UnitY,
+                Color = Color.White,
+                Intensity = 1f,
+            }
+        );
+
+        var style = new GizmoStyle { SizeMultiplier = 2f };
+
+        var lines = Build(world, entity, style);
+
+        // Arrow length 1.5 × 2 = 3; a ray shaft (downward travel) should reach roughly that far.
+        var longestShaft = lines.Max(l => (l.End - l.Start).Length());
+        Assert.True(
+            longestShaft >= 3f - 1e-3f,
+            $"expected a ~3-unit ray, longest was {longestShaft}"
+        );
+    }
+
+    [Fact]
+    public void Style_DefaultsReproduceOriginalColors()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(new Vector2(2, 3), 0f, new Vector2(4, 2)));
+
+        // A null style must match an explicitly default-constructed one (today's look unchanged).
+        var withNull = Build(world, entity);
+        var withDefault = Build(world, entity, new GizmoStyle());
+
+        Assert.Equal(withDefault.Count, withNull.Count);
+        for (var i = 0; i < withNull.Count; i++)
+        {
+            Assert.Equal(withDefault[i].Start, withNull[i].Start);
+            Assert.Equal(withDefault[i].End, withNull[i].End);
+            Assert.Equal(withDefault[i].Color, withNull[i].Color);
+        }
+        // And the amber bounds colour is still the original.
+        Assert.Contains(withNull, l => l.Color == new Vector4(1f, 0.75f, 0.2f, 1f));
     }
 
     [Fact]

--- a/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
+++ b/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
@@ -55,6 +55,34 @@ public class GizmoBuilderTests
     }
 
     [Fact]
+    public void AddAxes_CustomColors_OverrideDefaults()
+    {
+        var builder = new GizmoBuilder();
+        var x = new Vector4(0.9f, 0.1f, 0.1f, 1f);
+        var y = new Vector4(0.1f, 0.9f, 0.1f, 1f);
+        var z = new Vector4(0.1f, 0.1f, 0.9f, 1f);
+
+        builder.AddAxes(Vector3.Zero, Quaternion.Identity, 1f, x, y, z);
+
+        Assert.Equal(x, builder.Lines[0].Color);
+        Assert.Equal(y, builder.Lines[1].Color);
+        Assert.Equal(z, builder.Lines[2].Color);
+    }
+
+    [Fact]
+    public void AddAxes2D_CustomColors_OverrideDefaults()
+    {
+        var builder = new GizmoBuilder();
+        var x = new Vector4(0.9f, 0.1f, 0.1f, 1f);
+        var y = new Vector4(0.1f, 0.9f, 0.1f, 1f);
+
+        builder.AddAxes2D(Vector2.Zero, 0f, 1f, x, y);
+
+        Assert.Equal(x, builder.Lines[0].Color);
+        Assert.Equal(y, builder.Lines[1].Color);
+    }
+
+    [Fact]
     public void AddArrow_EmitsShaftPlusFourHeadLines()
     {
         var builder = new GizmoBuilder();

--- a/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
+++ b/tests/Yaeger.Tests/Inspector/GizmoBuilderTests.cs
@@ -83,6 +83,30 @@ public class GizmoBuilderTests
     }
 
     [Fact]
+    public void AddAxes_NonFiniteLength_EmitsNothing()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddAxes(Vector3.Zero, Quaternion.Identity, float.NaN);
+        builder.AddAxes(Vector3.Zero, Quaternion.Identity, float.PositiveInfinity);
+
+        Assert.Empty(builder.Lines);
+    }
+
+    [Fact]
+    public void AddArrow_NonFiniteHeadSize_EmitsOnlyShaft()
+    {
+        var builder = new GizmoBuilder();
+
+        builder.AddArrow(Vector3.Zero, new Vector3(0, 0, 5), Vector4.One, float.NaN);
+
+        // The finite shaft is kept; the arrowhead computed from the bad head size is skipped.
+        var shaft = Assert.Single(builder.Lines);
+        Assert.Equal(Vector3.Zero, shaft.Start);
+        Assert.Equal(new Vector3(0, 0, 5), shaft.End);
+    }
+
+    [Fact]
     public void AddArrow_EmitsShaftPlusFourHeadLines()
     {
         var builder = new GizmoBuilder();


### PR DESCRIPTION
Closes #123. Follow-up to #121.

## What

Adds a runtime `GizmoStyle` so consumers can tune the inspector selection gizmos without editing the engine. Every value defaults to the current look, so existing behaviour is unchanged.

### `GizmoStyle` options
- **Colours** — `AxisXColor`/`AxisYColor`/`AxisZColor`, `BoundsColor`, `CameraColor`, plus optional per-light overrides (`DirectionalLightColor`, `PointLightColor`, `SpotLightColor`; `null` keeps the light's own colour).
- **Sizes** — `AxisLength`, `Axis2DLength`, `DirectionalArrowLength`, `ArrowHeadSize`, `DirectionalRaySpread`, `DirectionalSunRadius`, `PointLightCoreSize`, and a global `SizeMultiplier` for very large/small worlds.
- **Segment counts** — `SphereSegments`, `SunSphereSegments`, `PointLightCoreSegments`, `ConeSegments`.
- **Rendering** — `DepthTest` toggle (always-on-top vs. occluded) and `LineWidth`.

`SizeMultiplier` scales only the fixed-size decorative elements. Range-driven shapes — the point-light reach sphere and the spot-light cone — keep showing the light's *actual* extent and are deliberately not scaled.

## How

- `EntityGizmos.Build(...)` takes an optional `GizmoStyle` (null → defaults).
- `GizmoBuilder.AddAxes` / `AddAxes2D` take optional colour overrides.
- `GizmoRenderer.Render` gains `depthTest` / `lineWidth` parameters (depth test enabled/disabled and `glLineWidth` set accordingly).
- `ImGuiInspector` exposes `GizmoStyle` and threads it through to both the builder and renderer.

## Acceptance criteria
- [x] Colours, key sizes, and segment counts configurable via a style type with defaults matching current output.
- [x] Global size multiplier makes gizmos usable in large-scale scenes.
- [x] Depth-test behaviour toggleable.
- [x] Unit tests cover style values flowing into the generated `GizmoLine`s.
- [x] `docs/editor.md` documents the new options.

## Tests
New unit tests cover custom axis/bounds/camera colours, the directional-light colour override, `SizeMultiplier` scaling axis and arrow length, point-light segment counts driving line counts, and a null-vs-default style producing identical output. Axis-colour overrides are also covered in `GizmoBuilderTests`.

> Note: the working environment has no .NET 10 SDK, so the build/tests were not run locally — CI will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y9abFSXhRAo45V2goUH9n

---
_Generated by [Claude Code](https://claude.ai/code/session_011y9abFSXhRAo45V2goUH9n)_