### PR TITLE
Add tilemap component and renderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,11 @@ Subscribe to `physicsWorld.OnCollision` for collision events. Read `physicsWorld
 
 ### Graphics components (`Graphics/`)
 
-Value-type ECS components: `Sprite`, `Transform2D`, `Camera2D`, `Color`, `SpriteSheet`, `Animation`, `AnimationState`, `Text`.
+Value-type ECS components: `Sprite`, `Transform2D`, `Camera2D`, `Color`, `SpriteSheet`, `Animation`, `AnimationState`, `Text`, `Tilemap` (+ `Tileset`).
 
 `SpriteSheet` calculates normalised UV rectangles per frame index via `GetFrameUv(int frameIndex)`.
+
+`Tilemap` + `Transform2D` renders a grid of tiles from a `Tileset` texture through `UnifiedRenderSystem` — one draw call per map (shared texture), camera-culled, `RenderLayer`-ordered. Tile indices are row-major with row 0 at the **top**; the transform position is the map's **bottom-left corner**; `Tilemap.EmptyTile` (`-1`) marks empty cells. See `docs/tilemaps.md`.
 
 `Camera2D` is a `record struct` with `Position`, `Zoom`, `Rotation`. Attach it to an entity and construct `RenderSystem` with a `Window` (third arg) to activate camera-aware rendering. Without a `Window`, or without a `Camera2D` entity, the renderer falls back to identity view (NDC-direct — the pre-camera behaviour). `TextRenderer` is explicitly screen-space and does NOT honour the camera. See `docs/camera.md` and `Samples/CameraDemo`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Value-type ECS components: `Sprite`, `Transform2D`, `Camera2D`, `Color`, `Sprite
 
 `SpriteSheet` calculates normalised UV rectangles per frame index via `GetFrameUv(int frameIndex)`.
 
-`Tilemap` + `Transform2D` renders a grid of tiles from a `Tileset` texture through `UnifiedRenderSystem` — one draw call per map (shared texture), camera-culled, `RenderLayer`-ordered. Tile indices are row-major with row 0 at the **top**; the transform position is the map's **bottom-left corner**; `Tilemap.EmptyTile` (`-1`) marks empty cells. See `docs/tilemaps.md`.
+`Tilemap` + `Transform2D` renders a grid of tiles from a `Tileset` texture through `UnifiedRenderSystem` — batched by the shared texture (typically one draw call per map, subject to the renderer's 1 000-quad batch limit), camera-culled, `RenderLayer`-ordered. Tile indices are row-major with row 0 at the **top**; the transform position is the map's **bottom-left corner**; `Tilemap.EmptyTile` (`-1`) marks empty cells. See `docs/tilemaps.md`.
 
 `Camera2D` is a `record struct` with `Position`, `Zoom`, `Rotation`. Attach it to an entity and construct `RenderSystem` with a `Window` (third arg) to activate camera-aware rendering. Without a `Window`, or without a `Camera2D` entity, the renderer falls back to identity view (NDC-direct — the pre-camera behaviour). `TextRenderer` is explicitly screen-space and does NOT honour the camera. See `docs/camera.md` and `Samples/CameraDemo`.
 

--- a/docs/tilemaps.md
+++ b/docs/tilemaps.md
@@ -9,8 +9,9 @@ tileset texture, instead of one entity per tile. The engine provides:
   the tile size in world units, and a tint. Pair it with a `Transform2D`.
 - Rendering via **`UnifiedRenderSystem`** — tilemaps are drawn in the same
   `RenderLayer`-sorted pass as sprites and text, and all tiles of a map share the
-  tileset texture, so each map collapses into a single draw call in the batched
-  renderer.
+  tileset texture, so each map renders in as few draw calls as the batched renderer
+  allows — typically one (the renderer flushes every 1 000 quads, so a very large
+  visible region can span multiple batches).
 
 ## Coordinate conventions
 

--- a/docs/tilemaps.md
+++ b/docs/tilemaps.md
@@ -1,0 +1,97 @@
+# Tilemaps
+
+A tilemap describes a level as a rectangular grid of tile indices referencing a shared
+tileset texture, instead of one entity per tile. The engine provides:
+
+- **`Tileset`** — a texture divided into a uniform grid of equally-sized tiles, with
+  per-tile UV lookup (`GetTileUv`). Uses the same UV math as `SpriteSheet`.
+- **`Tilemap`** — an ECS component holding the grid (`Width` × `Height` tile indices),
+  the tile size in world units, and a tint. Pair it with a `Transform2D`.
+- Rendering via **`UnifiedRenderSystem`** — tilemaps are drawn in the same
+  `RenderLayer`-sorted pass as sprites and text, and all tiles of a map share the
+  tileset texture, so each map collapses into a single draw call in the batched
+  renderer.
+
+## Coordinate conventions
+
+- The entity's `Transform2D.Position` is the **bottom-left corner** of the map in world
+  space.
+- Tile indices are stored row-major with **row 0 at the top** of the map — the same
+  order the grid reads when written as text or exported from editors such as Tiled.
+- Cell `(column, row)` therefore occupies the world-space cell whose bottom-left corner
+  is `(column * TileSize.X, (Height - 1 - row) * TileSize.Y)` relative to the entity's
+  position.
+- `Tilemap.EmptyTile` (`-1`) marks an empty cell; nothing is rendered for it.
+
+## Usage
+
+```csharp
+var tileset = new Tileset("Assets/tiles.png", columns: 8, rows: 4);
+
+// 6 wide, 3 high; row 0 is the top row.
+var tilemap = new Tilemap(
+    tileset,
+    width: 6,
+    height: 3,
+    tiles:
+    [
+        -1, -1, -1, -1, -1, -1,
+        -1, -1,  4,  5, -1, -1,
+         0,  1,  1,  1,  1,  2,
+    ]
+);
+
+var level = world.CreateEntity("level");
+world.AddComponent(level, new Transform2D(new Vector2(0f, 0f)));
+world.AddComponent(level, tilemap);
+world.AddComponent(level, new RenderLayer(0)); // background layer
+```
+
+Edit cells at runtime with `SetTile` / `GetTile`:
+
+```csharp
+tilemap.SetTile(column: 2, row: 1, tileIndex: 7);
+tilemap.SetTile(column: 2, row: 1, Tilemap.EmptyTile); // clear the cell
+```
+
+The tile array is shared between copies of the component (like `Animation.Frames`), so
+mutating a copy retrieved from the `World` updates the rendered map without re-adding
+the component.
+
+### Layering
+
+Use multiple tilemap entities with different `RenderLayer` values for
+background/foreground layers. Layer ordering is shared with sprites and text, so a
+player sprite on layer 1 renders between a background map on layer 0 and a foreground
+map on layer 2.
+
+### Culling
+
+When a `Camera2D` is active (a `UnifiedRenderSystem` constructed with a `Window` and a
+camera entity present), only the tiles intersecting the camera's visible span are
+submitted each frame. Maps with a rotated `Transform2D` fall back to submitting every
+tile (conservative — never culls a visible tile).
+
+## Scenes and prefabs
+
+`Tilemap` is registered with `ComponentRegistry.RegisterEngineComponents()` under the
+type id `"Tilemap"`, so tilemaps load from prefab/scene JSON and round-trip through
+`SceneSaver`:
+
+```json
+{
+  "type": "Tilemap",
+  "texturePath": "Assets/tiles.png",
+  "columns": 8,
+  "rows": 4,
+  "width": 6,
+  "height": 3,
+  "tileWidth": 1.0,
+  "tileHeight": 1.0,
+  "tiles": [-1, -1, -1, -1, -1, -1, -1, -1, 4, 5, -1, -1, 0, 1, 1, 1, 1, 2],
+  "tint": [255, 255, 255, 255]
+}
+```
+
+`rows` defaults to `1`, `tileWidth`/`tileHeight` default to `1.0`, `tiles` defaults to
+an all-empty map, and `tint` defaults to white when absent.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - Camera: camera.md
       - Particles: particles.md
       - Scenes: scenes.md
+      - Tilemaps: tilemaps.md
   - Contributing:
       - Testing Guide: testing.md
 

--- a/src/Engine/Yaeger/ECS/Serializers/EngineComponentRegistryExtensions.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/EngineComponentRegistryExtensions.cs
@@ -16,6 +16,7 @@ public static class EngineComponentRegistryExtensions
     ///   <item><see cref="Yaeger.Graphics.Animation"/> – type id <c>"Animation"</c></item>
     ///   <item><see cref="Yaeger.Graphics.AnimationState"/> – type id <c>"AnimationState"</c></item>
     ///   <item><see cref="Yaeger.Graphics.RenderLayer"/> – type id <c>"RenderLayer"</c></item>
+    ///   <item><see cref="Yaeger.Graphics.Tilemap"/> – type id <c>"Tilemap"</c></item>
     /// </list>
     /// <para>3D components:</para>
     /// <list type="bullet">
@@ -42,6 +43,7 @@ public static class EngineComponentRegistryExtensions
         registry.Register(new AnimationSerializer());
         registry.Register(new AnimationStateSerializer());
         registry.Register(new RenderLayerSerializer());
+        registry.Register(new TilemapSerializer());
 
         // 3D components
         registry.Register(new Transform3DSerializer());

--- a/src/Engine/Yaeger/ECS/Serializers/TilemapSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/TilemapSerializer.cs
@@ -116,6 +116,14 @@ public sealed class TilemapSerializer : IComponentSerializer
         if (!world.TryGetComponent<Tilemap>(entity, out var tilemap))
             return null;
 
+        // A default-constructed Tilemap has no tile array (and an empty tileset); fail with a
+        // clear message instead of a NullReferenceException from the tiles loop below.
+        if (tilemap.Tiles is null)
+            throw new InvalidOperationException(
+                "Tilemap component has no tile data — was it default-constructed? "
+                    + "Construct tilemaps through a Tilemap constructor before saving."
+            );
+
         var obj = new JsonObject
         {
             ["type"] = TypeId,

--- a/src/Engine/Yaeger/ECS/Serializers/TilemapSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/TilemapSerializer.cs
@@ -1,0 +1,228 @@
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Yaeger.Graphics;
+
+namespace Yaeger.ECS.Serializers;
+
+/// <summary>
+/// Serializer for the <see cref="Tilemap"/> component.
+/// </summary>
+/// <remarks>
+/// JSON format:
+/// <code>
+/// {
+///   "type": "Tilemap",
+///   "texturePath": "Assets/tiles.png",
+///   "columns": 8,
+///   "rows": 4,
+///   "width": 4,
+///   "height": 2,
+///   "tileWidth": 1.0,
+///   "tileHeight": 1.0,
+///   "tiles": [0, 1, -1, 2, 3, 3, 3, 3],
+///   "tint": [255, 255, 255, 255]
+/// }
+/// </code>
+/// <c>rows</c> defaults to <c>1</c>, <c>tileWidth</c>/<c>tileHeight</c> default to <c>1.0</c>,
+/// <c>tiles</c> defaults to an all-empty map, and <c>tint</c> defaults to white when absent.
+/// The <c>tiles</c> array is row-major with row 0 at the top of the map; <c>-1</c> marks an
+/// empty cell.
+/// </remarks>
+public sealed class TilemapSerializer : IComponentSerializer
+{
+    /// <inheritdoc/>
+    public string TypeId => "Tilemap";
+
+    /// <inheritdoc/>
+    public Type? ComponentType => typeof(Tilemap);
+
+    /// <inheritdoc/>
+    public Action<World, Entity> Deserialize(JsonElement element)
+    {
+        var texturePath = GetRequiredString(element, "texturePath");
+        var columns = GetRequiredPositiveInt(element, "columns");
+        var rows = GetOptionalPositiveInt(element, "rows") ?? 1;
+        var width = GetRequiredPositiveInt(element, "width");
+        var height = GetRequiredPositiveInt(element, "height");
+        var tileWidth = GetOptionalPositiveFloat(element, "tileWidth") ?? 1f;
+        var tileHeight = GetOptionalPositiveFloat(element, "tileHeight") ?? 1f;
+
+        int tileCount;
+        try
+        {
+            tileCount = checked(columns * rows);
+        }
+        catch (OverflowException)
+        {
+            throw new PrefabLoadException(
+                $"Tilemap 'columns' ({columns}) and 'rows' ({rows}) produce too many tiles."
+            );
+        }
+
+        long cellCount = (long)width * height;
+        if (cellCount > int.MaxValue)
+            throw new PrefabLoadException(
+                $"Tilemap 'width' ({width}) and 'height' ({height}) produce too many cells."
+            );
+
+        int[]? tiles = null;
+        if (element.TryGetProperty("tiles", out var tilesEl))
+        {
+            if (tilesEl.ValueKind != JsonValueKind.Array)
+                throw new PrefabLoadException("Tilemap 'tiles' must be an array of integers.");
+
+            tiles = new int[cellCount];
+            var index = 0;
+            foreach (var tileEl in tilesEl.EnumerateArray())
+            {
+                if (index == tiles.Length)
+                    throw new PrefabLoadException(
+                        $"Tilemap 'tiles' must contain exactly width * height ({cellCount}) elements."
+                    );
+
+                if (!tileEl.TryGetInt32(out var tileIndex))
+                    throw new PrefabLoadException(
+                        "Tilemap 'tiles' array elements must be integers."
+                    );
+
+                if (tileIndex < Tilemap.EmptyTile || tileIndex >= tileCount)
+                    throw new PrefabLoadException(
+                        $"Tilemap tile index {tileIndex} must be {Tilemap.EmptyTile} (empty) or within [0, {tileCount})."
+                    );
+
+                tiles[index++] = tileIndex;
+            }
+
+            if (index != tiles.Length)
+                throw new PrefabLoadException(
+                    $"Tilemap 'tiles' must contain exactly width * height ({cellCount}) elements."
+                );
+        }
+
+        var tint = ComponentJson.GetOptionalColor(element, "tint", Color.White);
+        var tileset = new Tileset(texturePath, columns, rows);
+        var tileSize = new Vector2(tileWidth, tileHeight);
+
+        var component = tiles is null
+            ? new Tilemap(tileset, width, height, tileSize, tint)
+            : new Tilemap(tileset, width, height, tiles, tileSize, tint);
+        return (world, entity) => world.AddComponent(entity, component);
+    }
+
+    /// <inheritdoc/>
+    public JsonNode? TrySerialize(World world, Entity entity)
+    {
+        if (!world.TryGetComponent<Tilemap>(entity, out var tilemap))
+            return null;
+
+        var obj = new JsonObject
+        {
+            ["type"] = TypeId,
+            ["texturePath"] = tilemap.Tileset.TexturePath,
+            ["columns"] = tilemap.Tileset.Columns,
+            ["rows"] = tilemap.Tileset.Rows,
+            ["width"] = tilemap.Width,
+            ["height"] = tilemap.Height,
+        };
+
+        if (tilemap.TileSize.X != 1f)
+            obj["tileWidth"] = tilemap.TileSize.X;
+        if (tilemap.TileSize.Y != 1f)
+            obj["tileHeight"] = tilemap.TileSize.Y;
+
+        var tiles = new JsonArray();
+        foreach (var tileIndex in tilemap.Tiles)
+        {
+            tiles.Add(tileIndex);
+        }
+        obj["tiles"] = tiles;
+
+        if (
+            tilemap.Tint.R != 255
+            || tilemap.Tint.G != 255
+            || tilemap.Tint.B != 255
+            || tilemap.Tint.A != 255
+        )
+        {
+            obj["tint"] = new JsonArray(
+                tilemap.Tint.R,
+                tilemap.Tint.G,
+                tilemap.Tint.B,
+                tilemap.Tint.A
+            );
+        }
+
+        return obj;
+    }
+
+    private static string GetRequiredString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+            throw new PrefabLoadException(
+                $"Tilemap is missing required '{propertyName}' property."
+            );
+
+        if (property.ValueKind != JsonValueKind.String)
+            throw new PrefabLoadException($"Tilemap '{propertyName}' must be a string.");
+
+        return property.GetString() is { } value && !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new PrefabLoadException(
+                $"Tilemap '{propertyName}' must be a non-empty string."
+            );
+    }
+
+    private static int GetRequiredPositiveInt(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+            throw new PrefabLoadException(
+                $"Tilemap is missing required '{propertyName}' property."
+            );
+
+        if (!property.TryGetInt32(out var value))
+            throw new PrefabLoadException($"Tilemap '{propertyName}' must be an integer.");
+
+        if (value <= 0)
+            throw new PrefabLoadException($"Tilemap '{propertyName}' must be greater than 0.");
+
+        return value;
+    }
+
+    private static int? GetOptionalPositiveInt(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+            return null;
+
+        if (!property.TryGetInt32(out var value))
+            throw new PrefabLoadException(
+                $"Tilemap '{propertyName}' must be an integer when provided."
+            );
+
+        if (value <= 0)
+            throw new PrefabLoadException(
+                $"Tilemap '{propertyName}' must be greater than 0 when provided."
+            );
+
+        return value;
+    }
+
+    private static float? GetOptionalPositiveFloat(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+            return null;
+
+        if (property.ValueKind != JsonValueKind.Number)
+            throw new PrefabLoadException(
+                $"Tilemap '{propertyName}' must be a number when provided."
+            );
+
+        var value = (float)property.GetDouble();
+        if (!float.IsFinite(value) || value <= 0)
+            throw new PrefabLoadException(
+                $"Tilemap '{propertyName}' must be a positive finite number when provided."
+            );
+
+        return value;
+    }
+}

--- a/src/Engine/Yaeger/ECS/Serializers/TilemapSerializer.cs
+++ b/src/Engine/Yaeger/ECS/Serializers/TilemapSerializer.cs
@@ -60,11 +60,11 @@ public sealed class TilemapSerializer : IComponentSerializer
             );
         }
 
-        long cellCount = (long)width * height;
-        if (cellCount > int.MaxValue)
+        if ((long)width * height > int.MaxValue)
             throw new PrefabLoadException(
                 $"Tilemap 'width' ({width}) and 'height' ({height}) produce too many cells."
             );
+        var cellCount = width * height;
 
         int[]? tiles = null;
         if (element.TryGetProperty("tiles", out var tilesEl))

--- a/src/Engine/Yaeger/Graphics/Tilemap.cs
+++ b/src/Engine/Yaeger/Graphics/Tilemap.cs
@@ -1,0 +1,205 @@
+using System.Numerics;
+
+namespace Yaeger.Graphics;
+
+/// <summary>
+/// Component that describes a rectangular grid of tiles referencing a <see cref="Tileset"/>.
+/// Pair with a <see cref="Transform2D"/>, whose position is the <b>bottom-left corner</b>
+/// of the map in world space.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tiles are stored row-major with row 0 at the <b>top</b> of the map (matching how tile
+/// grids read when authored as text or exported from editors such as Tiled). During
+/// rendering, rows are mapped to a Y-up world: tile (column, row) occupies the world-space
+/// cell whose bottom-left corner is
+/// <c>(column * TileSize.X, (Height - 1 - row) * TileSize.Y)</c> relative to the entity's
+/// position.
+/// </para>
+/// <para>
+/// A cell holding <see cref="EmptyTile"/> renders nothing. All tiles share the tileset
+/// texture, so a tilemap collapses into a single draw call per map in the batched renderer.
+/// Use multiple tilemap entities with different <see cref="RenderLayer"/> values for
+/// background/foreground layering.
+/// </para>
+/// </remarks>
+public struct Tilemap
+{
+    /// <summary>Sentinel tile index for an empty cell (renders nothing).</summary>
+    public const int EmptyTile = -1;
+
+    /// <summary>Gets the tileset providing the texture and per-tile UV rectangles.</summary>
+    public Tileset Tileset { get; }
+
+    /// <summary>Gets the width of the map in tiles.</summary>
+    public int Width { get; }
+
+    /// <summary>Gets the height of the map in tiles.</summary>
+    public int Height { get; }
+
+    /// <summary>
+    /// Gets the tile indices, row-major with row 0 at the top of the map.
+    /// Prefer <see cref="GetTile"/> / <see cref="SetTile"/> for validated access.
+    /// </summary>
+    public int[] Tiles { get; }
+
+    /// <summary>Size of one tile in world units.</summary>
+    public Vector2 TileSize;
+
+    /// <summary>Tint colour applied when rendering this map. Defaults to white (no tint).</summary>
+    public Color Tint;
+
+    /// <summary>
+    /// Initializes a new <see cref="Tilemap"/> with every cell set to <see cref="EmptyTile"/>.
+    /// </summary>
+    /// <param name="tileset">The tileset providing texture and tile UVs. Must contain at least one tile.</param>
+    /// <param name="width">Width of the map in tiles. Must be at least 1.</param>
+    /// <param name="height">Height of the map in tiles. Must be at least 1.</param>
+    /// <param name="tileSize">
+    /// Size of one tile in world units. Both components must be greater than zero.
+    /// Defaults to (1, 1).
+    /// </param>
+    /// <param name="tint">Tint colour applied during rendering. Defaults to <see cref="Color.White"/>.</param>
+    public Tilemap(
+        Tileset tileset,
+        int width,
+        int height,
+        Vector2? tileSize = null,
+        Color? tint = null
+    )
+    {
+        ValidateDimensions(tileset, width, height, tileSize);
+
+        Tileset = tileset;
+        Width = width;
+        Height = height;
+        TileSize = tileSize ?? Vector2.One;
+        Tint = tint ?? Color.White;
+        Tiles = new int[width * height];
+        Array.Fill(Tiles, EmptyTile);
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="Tilemap"/> from an existing tile array.
+    /// </summary>
+    /// <param name="tileset">The tileset providing texture and tile UVs. Must contain at least one tile.</param>
+    /// <param name="width">Width of the map in tiles. Must be at least 1.</param>
+    /// <param name="height">Height of the map in tiles. Must be at least 1.</param>
+    /// <param name="tiles">
+    /// Tile indices, row-major with row 0 at the top. Length must equal
+    /// <paramref name="width"/> × <paramref name="height"/>, and every index must be
+    /// <see cref="EmptyTile"/> or within [0, <see cref="Yaeger.Graphics.Tileset.TileCount"/>).
+    /// The array is used directly (not copied).
+    /// </param>
+    /// <param name="tileSize">
+    /// Size of one tile in world units. Both components must be greater than zero.
+    /// Defaults to (1, 1).
+    /// </param>
+    /// <param name="tint">Tint colour applied during rendering. Defaults to <see cref="Color.White"/>.</param>
+    public Tilemap(
+        Tileset tileset,
+        int width,
+        int height,
+        int[] tiles,
+        Vector2? tileSize = null,
+        Color? tint = null
+    )
+    {
+        ValidateDimensions(tileset, width, height, tileSize);
+        ArgumentNullException.ThrowIfNull(tiles);
+
+        if (tiles.Length != width * height)
+            throw new ArgumentException(
+                $"Tile array length ({tiles.Length}) must equal width * height ({width * height}).",
+                nameof(tiles)
+            );
+
+        for (var i = 0; i < tiles.Length; i++)
+        {
+            if (tiles[i] < EmptyTile || tiles[i] >= tileset.TileCount)
+                throw new ArgumentOutOfRangeException(
+                    nameof(tiles),
+                    tiles[i],
+                    $"Tile index at position {i} must be {EmptyTile} (empty) or within [0, {tileset.TileCount})."
+                );
+        }
+
+        Tileset = tileset;
+        Width = width;
+        Height = height;
+        TileSize = tileSize ?? Vector2.One;
+        Tint = tint ?? Color.White;
+        Tiles = tiles;
+    }
+
+    /// <summary>
+    /// Gets the tile index at the given cell.
+    /// </summary>
+    /// <param name="column">Zero-based column from the left edge.</param>
+    /// <param name="row">Zero-based row from the <b>top</b> edge.</param>
+    /// <returns>The tile index, or <see cref="EmptyTile"/> for an empty cell.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the cell is outside the map.</exception>
+    public readonly int GetTile(int column, int row)
+    {
+        ValidateCell(column, row);
+        return Tiles[row * Width + column];
+    }
+
+    /// <summary>
+    /// Sets the tile index at the given cell. The backing array is shared between copies
+    /// of this component, so the change is visible without re-adding the component.
+    /// </summary>
+    /// <param name="column">Zero-based column from the left edge.</param>
+    /// <param name="row">Zero-based row from the <b>top</b> edge.</param>
+    /// <param name="tileIndex">
+    /// The new tile index: <see cref="EmptyTile"/> or within [0, <see cref="Yaeger.Graphics.Tileset.TileCount"/>).
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when the cell is outside the map or the tile index is invalid.
+    /// </exception>
+    public readonly void SetTile(int column, int row, int tileIndex)
+    {
+        ValidateCell(column, row);
+
+        if (tileIndex < EmptyTile || tileIndex >= Tileset.TileCount)
+            throw new ArgumentOutOfRangeException(
+                nameof(tileIndex),
+                tileIndex,
+                $"Tile index must be {EmptyTile} (empty) or within [0, {Tileset.TileCount})."
+            );
+
+        Tiles[row * Width + column] = tileIndex;
+    }
+
+    private static void ValidateDimensions(
+        Tileset tileset,
+        int width,
+        int height,
+        Vector2? tileSize
+    )
+    {
+        if (tileset.TileCount < 1)
+            throw new ArgumentException(
+                "Tileset must contain at least one tile. Was it default-constructed?",
+                nameof(tileset)
+            );
+
+        ArgumentOutOfRangeException.ThrowIfLessThan(width, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(height, 1);
+
+        if (tileSize is { } size && (size.X <= 0 || size.Y <= 0))
+            throw new ArgumentOutOfRangeException(
+                nameof(tileSize),
+                size,
+                "Tile size components must be greater than zero."
+            );
+    }
+
+    private readonly void ValidateCell(int column, int row)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(column);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(column, Width);
+        ArgumentOutOfRangeException.ThrowIfNegative(row);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(row, Height);
+    }
+}

--- a/src/Engine/Yaeger/Graphics/Tilemap.cs
+++ b/src/Engine/Yaeger/Graphics/Tilemap.cs
@@ -18,9 +18,10 @@ namespace Yaeger.Graphics;
 /// </para>
 /// <para>
 /// A cell holding <see cref="EmptyTile"/> renders nothing. All tiles share the tileset
-/// texture, so a tilemap collapses into a single draw call per map in the batched renderer.
-/// Use multiple tilemap entities with different <see cref="RenderLayer"/> values for
-/// background/foreground layering.
+/// texture, so the batched renderer draws a tilemap in as few draw calls as its batch
+/// capacity allows — typically one per map (it flushes every 1 000 quads, so very large
+/// visible regions may span multiple batches). Use multiple tilemap entities with
+/// different <see cref="RenderLayer"/> values for background/foreground layering.
 /// </para>
 /// </remarks>
 public struct Tilemap

--- a/src/Engine/Yaeger/Graphics/Tilemap.cs
+++ b/src/Engine/Yaeger/Graphics/Tilemap.cs
@@ -57,7 +57,7 @@ public struct Tilemap
     /// <param name="width">Width of the map in tiles. Must be at least 1.</param>
     /// <param name="height">Height of the map in tiles. Must be at least 1.</param>
     /// <param name="tileSize">
-    /// Size of one tile in world units. Both components must be greater than zero.
+    /// Size of one tile in world units. Both components must be positive finite numbers.
     /// Defaults to (1, 1).
     /// </param>
     /// <param name="tint">Tint colour applied during rendering. Defaults to <see cref="Color.White"/>.</param>
@@ -93,7 +93,7 @@ public struct Tilemap
     /// The array is used directly (not copied).
     /// </param>
     /// <param name="tileSize">
-    /// Size of one tile in world units. Both components must be greater than zero.
+    /// Size of one tile in world units. Both components must be positive finite numbers.
     /// Defaults to (1, 1).
     /// </param>
     /// <param name="tint">Tint colour applied during rendering. Defaults to <see cref="Color.White"/>.</param>
@@ -188,11 +188,17 @@ public struct Tilemap
         ArgumentOutOfRangeException.ThrowIfLessThan(width, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(height, 1);
 
-        if (tileSize is { } size && (size.X <= 0 || size.Y <= 0))
+        // !(x > 0) rather than x <= 0 so NaN is rejected too (NaN comparisons are false).
+        if (
+            tileSize is { } size
+            && (
+                !(size.X > 0) || !(size.Y > 0) || !float.IsFinite(size.X) || !float.IsFinite(size.Y)
+            )
+        )
             throw new ArgumentOutOfRangeException(
                 nameof(tileSize),
                 size,
-                "Tile size components must be greater than zero."
+                "Tile size components must be positive finite numbers."
             );
     }
 

--- a/src/Engine/Yaeger/Graphics/Tileset.cs
+++ b/src/Engine/Yaeger/Graphics/Tileset.cs
@@ -1,0 +1,51 @@
+using System.Numerics;
+
+namespace Yaeger.Graphics;
+
+/// <summary>
+/// Describes a tileset texture divided into a uniform grid of equally-sized tiles.
+/// Tiles are indexed left-to-right, top-to-bottom starting at 0, using the same
+/// UV math as <see cref="SpriteSheet"/>.
+/// </summary>
+public readonly struct Tileset
+{
+    private readonly SpriteSheet _sheet;
+
+    /// <summary>
+    /// Initializes a new <see cref="Tileset"/>.
+    /// </summary>
+    /// <param name="texturePath">Path to the tileset image file.</param>
+    /// <param name="columns">Number of equally-wide columns in the tileset.</param>
+    /// <param name="rows">Number of equally-tall rows in the tileset. Defaults to 1.</param>
+    public Tileset(string texturePath, int columns, int rows = 1)
+    {
+        _sheet = new SpriteSheet(texturePath, columns, rows);
+    }
+
+    /// <summary>Gets the path to the tileset texture.</summary>
+    public string TexturePath => _sheet.TexturePath;
+
+    /// <summary>Gets the number of columns in the tileset.</summary>
+    public int Columns => _sheet.Columns;
+
+    /// <summary>Gets the number of rows in the tileset.</summary>
+    public int Rows => _sheet.Rows;
+
+    /// <summary>
+    /// Gets the total number of tiles (<see cref="Columns"/> × <see cref="Rows"/>).
+    /// A default-constructed tileset has a tile count of 0.
+    /// </summary>
+    public int TileCount => _sheet.FrameCount;
+
+    /// <summary>
+    /// Returns the normalised UV rectangle for the given zero-based tile index.
+    /// </summary>
+    /// <param name="tileIndex">Zero-based tile index (left-to-right, top-to-bottom).</param>
+    /// <returns>
+    /// A tuple of (<c>uvMin</c>, <c>uvMax</c>) where both are normalised [0, 1] coordinates.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="tileIndex"/> is outside [0, <see cref="TileCount"/>).
+    /// </exception>
+    public (Vector2 UvMin, Vector2 UvMax) GetTileUv(int tileIndex) => _sheet.GetFrameUv(tileIndex);
+}

--- a/src/Engine/Yaeger/Graphics/Tileset.cs
+++ b/src/Engine/Yaeger/Graphics/Tileset.cs
@@ -17,8 +17,19 @@ public readonly struct Tileset
     /// <param name="texturePath">Path to the tileset image file.</param>
     /// <param name="columns">Number of equally-wide columns in the tileset.</param>
     /// <param name="rows">Number of equally-tall rows in the tileset. Defaults to 1.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="columns"/> × <paramref name="rows"/> exceeds
+    /// <see cref="int.MaxValue"/> (SpriteSheet computes the product unchecked, so it would
+    /// silently wrap to a wrong tile count otherwise).
+    /// </exception>
     public Tileset(string texturePath, int columns, int rows = 1)
     {
+        if (columns > 0 && rows > 0 && (long)columns * rows > int.MaxValue)
+            throw new ArgumentOutOfRangeException(
+                nameof(columns),
+                $"'columns' ({columns}) x 'rows' ({rows}) must not exceed {int.MaxValue}."
+            );
+
         _sheet = new SpriteSheet(texturePath, columns, rows);
     }
 

--- a/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
@@ -286,9 +286,9 @@ public class UnifiedRenderSystem(
     /// <summary>
     /// Computes the inclusive tile-cell range of <paramref name="map"/> that can intersect the
     /// camera's visible span, in (columnMin, columnMax, rowMin, rowMax) form. Falls back to the
-    /// full map when the map transform is rotated or non-positively scaled (conservative: never
-    /// culls a visible tile). Returns an empty range (min &gt; max) when the map is fully
-    /// off-screen.
+    /// full map when the map transform is rotated or non-positively scaled, or the tile size is
+    /// non-positive (conservative: never culls a visible tile). Returns an empty range
+    /// (min &gt; max) when the map is fully off-screen.
     /// </summary>
     internal static (int ColumnMin, int ColumnMax, int RowMin, int RowMax) GetVisibleTileRange(
         Tilemap map,
@@ -298,8 +298,16 @@ public class UnifiedRenderSystem(
     )
     {
         // Culling maps the camera's world-space AABB into tile cells, which is only valid for
-        // an axis-aligned, positively scaled map. Anything else renders the full map.
-        if (mapTransform.Rotation != 0f || mapTransform.Scale.X <= 0f || mapTransform.Scale.Y <= 0f)
+        // an axis-aligned, positively scaled map with a positive tile size (TileSize is a
+        // mutable field, so it can be zeroed after construction). Anything else renders the
+        // full map.
+        if (
+            mapTransform.Rotation != 0f
+            || mapTransform.Scale.X <= 0f
+            || mapTransform.Scale.Y <= 0f
+            || map.TileSize.X <= 0f
+            || map.TileSize.Y <= 0f
+        )
             return (0, map.Width - 1, 0, map.Height - 1);
 
         // Visible world region: a rect centred on the camera with half-extents

--- a/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
@@ -343,12 +343,15 @@ public class UnifiedRenderSystem(
         return (columnMin, columnMax, rowMin, rowMax);
     }
 
+    // Text must stay the last kind: it is the tie-break for commands on the same entity and
+    // layer, and text execution flushes queued quads before drawing — any quad kind sorted
+    // after it would paint over the text.
     private enum RenderCommandKind
     {
         Sprite = 0,
         SpriteSheet = 1,
-        Text = 2,
-        Tilemap = 3,
+        Tilemap = 2,
+        Text = 3,
     }
 
     private readonly record struct RenderCommand(

--- a/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
@@ -7,7 +7,7 @@ using Yaeger.Windowing;
 namespace Yaeger.Systems;
 
 /// <summary>
-/// Renders sprites, sprite sheets, and text in a shared deterministic order using
+/// Renders sprites, sprite sheets, tilemaps, and text in a shared deterministic order using
 /// <see cref="RenderLayer"/>, <see cref="Entity.Id"/>, and command kind as sort keys.
 /// </summary>
 public class UnifiedRenderSystem(
@@ -18,6 +18,10 @@ public class UnifiedRenderSystem(
 )
 {
     private readonly List<RenderCommand> _commands = Validate(renderer, textRenderer);
+
+    // Active camera state captured during UpdateCamera, used for tilemap culling.
+    private Camera2D? _activeCamera;
+    private float _aspectRatio = 1f;
 
     private static List<RenderCommand> Validate(
         IRenderSurface? renderer,
@@ -53,6 +57,9 @@ public class UnifiedRenderSystem(
                         command.UvMax,
                         command.Color
                     );
+                    break;
+                case RenderCommandKind.Tilemap:
+                    SubmitTilemap(command);
                     break;
                 case RenderCommandKind.Text:
                     renderer?.FlushQueuedQuads();
@@ -147,6 +154,28 @@ public class UnifiedRenderSystem(
                     )
                 );
             }
+
+            // One command per tilemap; individual tile quads are expanded at execution time
+            // so the per-frame sort stays proportional to entity count, not tile count.
+            foreach (
+                (Entity entity, Tilemap tilemap, Transform2D transform) in world.Query<
+                    Tilemap,
+                    Transform2D
+                >()
+            )
+            {
+                if (tilemap.Tiles is null || tilemap.Tileset.TileCount <= 0)
+                    continue;
+
+                _commands.Add(
+                    RenderCommand.ForTilemap(
+                        entity,
+                        GetRenderLayerValue(renderLayerStore, entity),
+                        transform,
+                        tilemap
+                    )
+                );
+            }
         }
 
         if (textRenderer != null)
@@ -194,6 +223,8 @@ public class UnifiedRenderSystem(
 
     private void UpdateCamera()
     {
+        _activeCamera = null;
+
         if (renderer is null || window is null)
             return;
 
@@ -201,6 +232,8 @@ public class UnifiedRenderSystem(
         {
             var size = window.Size;
             var aspectRatio = size.Y > 0 ? size.X / size.Y : 1f;
+            _activeCamera = camera;
+            _aspectRatio = aspectRatio;
             renderer.SetCamera(camera.ViewProjection(aspectRatio));
             return;
         }
@@ -208,11 +241,106 @@ public class UnifiedRenderSystem(
         renderer.SetCamera(Matrix4x4.Identity);
     }
 
+    private void SubmitTilemap(in RenderCommand command)
+    {
+        var map = command.TilemapComponent;
+        var mapTransform = command.SourceTransform;
+        var tint = map.Tint.ToVector4();
+
+        var (columnMin, columnMax, rowMin, rowMax) = _activeCamera is { } camera
+            ? GetVisibleTileRange(map, mapTransform, camera, _aspectRatio)
+            : (0, map.Width - 1, 0, map.Height - 1);
+
+        for (var row = rowMin; row <= rowMax; row++)
+        {
+            for (var column = columnMin; column <= columnMax; column++)
+            {
+                var tileIndex = map.Tiles[row * map.Width + column];
+                if (tileIndex == Tilemap.EmptyTile)
+                    continue;
+
+                var (uvMin, uvMax) = map.Tileset.GetTileUv(tileIndex);
+
+                // Tile quad in map-local space: the unit quad is centred on the origin, so
+                // scale it to tile size and translate to the cell centre (row 0 is the top
+                // row, hence the Height - 1 - row flip into the Y-up world).
+                var local =
+                    Matrix4x4.CreateScale(map.TileSize.X, map.TileSize.Y, 1f)
+                    * Matrix4x4.CreateTranslation(
+                        (column + 0.5f) * map.TileSize.X,
+                        (map.Height - 1 - row + 0.5f) * map.TileSize.Y,
+                        0f
+                    );
+
+                renderer!.SubmitQuad(
+                    local * command.Transform,
+                    map.Tileset.TexturePath,
+                    uvMin,
+                    uvMax,
+                    tint
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Computes the inclusive tile-cell range of <paramref name="map"/> that can intersect the
+    /// camera's visible span, in (columnMin, columnMax, rowMin, rowMax) form. Falls back to the
+    /// full map when the map transform is rotated or non-positively scaled (conservative: never
+    /// culls a visible tile). Returns an empty range (min &gt; max) when the map is fully
+    /// off-screen.
+    /// </summary>
+    internal static (int ColumnMin, int ColumnMax, int RowMin, int RowMax) GetVisibleTileRange(
+        Tilemap map,
+        Transform2D mapTransform,
+        Camera2D camera,
+        float aspectRatio
+    )
+    {
+        // Culling maps the camera's world-space AABB into tile cells, which is only valid for
+        // an axis-aligned, positively scaled map. Anything else renders the full map.
+        if (mapTransform.Rotation != 0f || mapTransform.Scale.X <= 0f || mapTransform.Scale.Y <= 0f)
+            return (0, map.Width - 1, 0, map.Height - 1);
+
+        // Visible world region: a rect centred on the camera with half-extents
+        // (aspect / zoom, 1 / zoom), rotated by the camera rotation. Use its AABB.
+        var zoom = camera.Zoom > 0f ? camera.Zoom : 1f;
+        var halfWidth = aspectRatio / zoom;
+        var halfHeight = 1f / zoom;
+        var cos = MathF.Abs(MathF.Cos(camera.Rotation));
+        var sin = MathF.Abs(MathF.Sin(camera.Rotation));
+        var extentX = cos * halfWidth + sin * halfHeight;
+        var extentY = sin * halfWidth + cos * halfHeight;
+
+        // View AABB in map-local units (map origin at the bottom-left corner).
+        var localMinX =
+            (camera.Position.X - extentX - mapTransform.Position.X) / mapTransform.Scale.X;
+        var localMaxX =
+            (camera.Position.X + extentX - mapTransform.Position.X) / mapTransform.Scale.X;
+        var localMinY =
+            (camera.Position.Y - extentY - mapTransform.Position.Y) / mapTransform.Scale.Y;
+        var localMaxY =
+            (camera.Position.Y + extentY - mapTransform.Position.Y) / mapTransform.Scale.Y;
+
+        var columnMin = Math.Max((int)MathF.Floor(localMinX / map.TileSize.X), 0);
+        var columnMax = Math.Min((int)MathF.Ceiling(localMaxX / map.TileSize.X) - 1, map.Width - 1);
+
+        // Row 0 is the top row: local Y grows towards row 0.
+        var rowMin = Math.Max(map.Height - (int)MathF.Ceiling(localMaxY / map.TileSize.Y), 0);
+        var rowMax = Math.Min(
+            map.Height - 1 - (int)MathF.Floor(localMinY / map.TileSize.Y),
+            map.Height - 1
+        );
+
+        return (columnMin, columnMax, rowMin, rowMax);
+    }
+
     private enum RenderCommandKind
     {
         Sprite = 0,
         SpriteSheet = 1,
         Text = 2,
+        Tilemap = 3,
     }
 
     private readonly record struct RenderCommand(
@@ -224,7 +352,9 @@ public class UnifiedRenderSystem(
         Vector2 UvMin,
         Vector2 UvMax,
         Vector4 Color,
-        Text TextComponent
+        Text TextComponent,
+        Tilemap TilemapComponent,
+        Transform2D SourceTransform
     )
     {
         public static RenderCommand ForSprite(
@@ -242,6 +372,8 @@ public class UnifiedRenderSystem(
                 Vector2.Zero,
                 Vector2.One,
                 sprite.Tint.ToVector4(),
+                default,
+                default,
                 default
             );
 
@@ -263,6 +395,8 @@ public class UnifiedRenderSystem(
                 uvMin,
                 uvMax,
                 color,
+                default,
+                default,
                 default
             );
 
@@ -281,7 +415,29 @@ public class UnifiedRenderSystem(
                 Vector2.Zero,
                 Vector2.One,
                 Vector4.Zero,
-                text
+                text,
+                default,
+                default
+            );
+
+        public static RenderCommand ForTilemap(
+            Entity entity,
+            int layer,
+            Transform2D transform,
+            Tilemap tilemap
+        ) =>
+            new(
+                entity,
+                layer,
+                RenderCommandKind.Tilemap,
+                transform.TransformMatrix,
+                null,
+                Vector2.Zero,
+                Vector2.One,
+                Vector4.Zero,
+                default,
+                tilemap,
+                transform
             );
     }
 }

--- a/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
@@ -251,6 +251,10 @@ public class UnifiedRenderSystem(
             ? GetVisibleTileRange(map, mapTransform, camera, _aspectRatio)
             : (0, map.Width - 1, 0, map.Height - 1);
 
+        // Fully off-screen map: skip without scanning rows.
+        if (columnMin > columnMax || rowMin > rowMax)
+            return;
+
         for (var row = rowMin; row <= rowMax; row++)
         {
             for (var column = columnMin; column <= columnMax; column++)

--- a/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
+++ b/src/Engine/Yaeger/Systems/UnifiedRenderSystem.cs
@@ -305,12 +305,15 @@ public class UnifiedRenderSystem(
         // an axis-aligned, positively scaled map with a positive tile size (TileSize is a
         // mutable field, so it can be zeroed after construction). Anything else renders the
         // full map.
+        // !(x > 0) rather than x <= 0 so NaN also falls back (NaN comparisons are false).
         if (
             mapTransform.Rotation != 0f
-            || mapTransform.Scale.X <= 0f
-            || mapTransform.Scale.Y <= 0f
-            || map.TileSize.X <= 0f
-            || map.TileSize.Y <= 0f
+            || !(mapTransform.Scale.X > 0f)
+            || !(mapTransform.Scale.Y > 0f)
+            || !float.IsFinite(map.TileSize.X)
+            || !float.IsFinite(map.TileSize.Y)
+            || !(map.TileSize.X > 0f)
+            || !(map.TileSize.Y > 0f)
         )
             return (0, map.Width - 1, 0, map.Height - 1);
 

--- a/tests/Yaeger.Tests/ECS/TilemapSerializerTests.cs
+++ b/tests/Yaeger.Tests/ECS/TilemapSerializerTests.cs
@@ -1,0 +1,229 @@
+using System.Numerics;
+using System.Text.Json;
+using Yaeger.ECS;
+using Yaeger.ECS.Serializers;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.ECS;
+
+public class TilemapSerializerTests
+{
+    private static PrefabLoader MakeLoader() =>
+        new(new ComponentRegistry().RegisterEngineComponents());
+
+    // ── Deserialization ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Deserialize_FullDefinition_ShouldPopulateAllFields()
+    {
+        var prefab = MakeLoader()
+            .Parse(
+                """
+                {
+                  "components": [
+                    {
+                      "type": "Tilemap",
+                      "texturePath": "Assets/tiles.png",
+                      "columns": 4,
+                      "rows": 2,
+                      "width": 3,
+                      "height": 2,
+                      "tileWidth": 2.0,
+                      "tileHeight": 0.5,
+                      "tiles": [0, 1, -1, 2, 3, 7],
+                      "tint": [255, 0, 0, 128]
+                    }
+                  ]
+                }
+                """
+            );
+
+        var world = new World();
+        var entity = world.Instantiate(prefab);
+
+        Assert.True(world.TryGetComponent<Tilemap>(entity, out var tilemap));
+        Assert.Equal("Assets/tiles.png", tilemap.Tileset.TexturePath);
+        Assert.Equal(4, tilemap.Tileset.Columns);
+        Assert.Equal(2, tilemap.Tileset.Rows);
+        Assert.Equal(3, tilemap.Width);
+        Assert.Equal(2, tilemap.Height);
+        Assert.Equal(new Vector2(2f, 0.5f), tilemap.TileSize);
+        Assert.Equal(new[] { 0, 1, -1, 2, 3, 7 }, tilemap.Tiles);
+        Assert.Equal(new Color(255, 0, 0, 128), tilemap.Tint);
+    }
+
+    [Fact]
+    public void Deserialize_MinimalDefinition_ShouldApplyDefaults()
+    {
+        var prefab = MakeLoader()
+            .Parse(
+                """
+                {
+                  "components": [
+                    {
+                      "type": "Tilemap",
+                      "texturePath": "Assets/tiles.png",
+                      "columns": 4,
+                      "width": 2,
+                      "height": 3
+                    }
+                  ]
+                }
+                """
+            );
+
+        var world = new World();
+        var entity = world.Instantiate(prefab);
+
+        Assert.True(world.TryGetComponent<Tilemap>(entity, out var tilemap));
+        Assert.Equal(1, tilemap.Tileset.Rows);
+        Assert.Equal(Vector2.One, tilemap.TileSize);
+        Assert.Equal(Color.White, tilemap.Tint);
+        Assert.All(tilemap.Tiles, tile => Assert.Equal(Tilemap.EmptyTile, tile));
+    }
+
+    [Fact]
+    public void Deserialize_MissingTexturePath_ShouldThrow()
+    {
+        var ex = Assert.Throws<PrefabLoadException>(() =>
+            MakeLoader()
+                .Parse(
+                    """{ "components": [ { "type": "Tilemap", "columns": 4, "width": 1, "height": 1 } ] }"""
+                )
+        );
+
+        Assert.Contains("texturePath", ex.Message);
+    }
+
+    [Fact]
+    public void Deserialize_NonPositiveWidth_ShouldThrow()
+    {
+        Assert.Throws<PrefabLoadException>(() =>
+            MakeLoader()
+                .Parse(
+                    """
+                    { "components": [ { "type": "Tilemap", "texturePath": "Assets/tiles.png", "columns": 4, "width": 0, "height": 1 } ] }
+                    """
+                )
+        );
+    }
+
+    [Fact]
+    public void Deserialize_NonPositiveTileWidth_ShouldThrow()
+    {
+        Assert.Throws<PrefabLoadException>(() =>
+            MakeLoader()
+                .Parse(
+                    """
+                    { "components": [ { "type": "Tilemap", "texturePath": "Assets/tiles.png", "columns": 4, "width": 1, "height": 1, "tileWidth": 0 } ] }
+                    """
+                )
+        );
+    }
+
+    [Fact]
+    public void Deserialize_WrongTileArrayLength_ShouldThrow()
+    {
+        var tooShort = Assert.Throws<PrefabLoadException>(() =>
+            MakeLoader()
+                .Parse(
+                    """
+                    { "components": [ { "type": "Tilemap", "texturePath": "Assets/tiles.png", "columns": 4, "width": 2, "height": 2, "tiles": [0, 1, 2] } ] }
+                    """
+                )
+        );
+        Assert.Contains("width * height", tooShort.Message);
+
+        var tooLong = Assert.Throws<PrefabLoadException>(() =>
+            MakeLoader()
+                .Parse(
+                    """
+                    { "components": [ { "type": "Tilemap", "texturePath": "Assets/tiles.png", "columns": 4, "width": 2, "height": 2, "tiles": [0, 1, 2, 3, 0] } ] }
+                    """
+                )
+        );
+        Assert.Contains("width * height", tooLong.Message);
+    }
+
+    [Fact]
+    public void Deserialize_TileIndexOutOfRange_ShouldThrow()
+    {
+        // columns 4, rows 1 → valid indices are -1..3, so 4 is out of range.
+        var ex = Assert.Throws<PrefabLoadException>(() =>
+            MakeLoader()
+                .Parse(
+                    """
+                    { "components": [ { "type": "Tilemap", "texturePath": "Assets/tiles.png", "columns": 4, "width": 2, "height": 1, "tiles": [0, 4] } ] }
+                    """
+                )
+        );
+
+        Assert.Contains("tile index", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Deserialize_NonIntegerTile_ShouldThrow()
+    {
+        Assert.Throws<PrefabLoadException>(() =>
+            MakeLoader()
+                .Parse(
+                    """
+                    { "components": [ { "type": "Tilemap", "texturePath": "Assets/tiles.png", "columns": 4, "width": 1, "height": 1, "tiles": [1.5] } ] }
+                    """
+                )
+        );
+    }
+
+    // ── Serialization ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Serialize_DefaultTileSizeAndTint_ShouldOmitOptionalFields()
+    {
+        var registry = new ComponentRegistry().RegisterEngineComponents();
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Tilemap(new Tileset("Assets/tiles.png", 4), 2, 2));
+
+        var json = new SceneSaver(registry).Serialize(world);
+
+        using var doc = JsonDocument.Parse(json);
+        var component = doc.RootElement.GetProperty("entities")[0].GetProperty("components")[0];
+        Assert.False(component.TryGetProperty("tileWidth", out _));
+        Assert.False(component.TryGetProperty("tileHeight", out _));
+        Assert.False(component.TryGetProperty("tint", out _));
+        Assert.Equal(4, component.GetProperty("tiles").GetArrayLength());
+    }
+
+    [Fact]
+    public void SceneSaver_TilemapComponent_ShouldRoundTrip()
+    {
+        var registry = new ComponentRegistry().RegisterEngineComponents();
+        var world = new World();
+        var entity = world.CreateEntity("level");
+        var tilemap = new Tilemap(
+            new Tileset("Assets/tiles.png", columns: 4, rows: 2),
+            width: 3,
+            height: 2,
+            tiles: [0, 1, Tilemap.EmptyTile, 2, 3, 7],
+            tileSize: new Vector2(2f, 0.5f),
+            tint: new Color(10, 20, 30, 40)
+        );
+        world.AddComponent(entity, tilemap);
+
+        var json = new SceneSaver(registry).Serialize(world);
+
+        var reloaded = new World();
+        reloaded.Instantiate(new SceneLoader(registry).Parse(json));
+
+        var reloadedEntity = reloaded.Entities.Single();
+        Assert.True(reloaded.TryGetComponent<Tilemap>(reloadedEntity, out var reloadedMap));
+        Assert.Equal(tilemap.Tileset.TexturePath, reloadedMap.Tileset.TexturePath);
+        Assert.Equal(tilemap.Tileset.Columns, reloadedMap.Tileset.Columns);
+        Assert.Equal(tilemap.Tileset.Rows, reloadedMap.Tileset.Rows);
+        Assert.Equal(tilemap.Width, reloadedMap.Width);
+        Assert.Equal(tilemap.Height, reloadedMap.Height);
+        Assert.Equal(tilemap.TileSize, reloadedMap.TileSize);
+        Assert.Equal(tilemap.Tint, reloadedMap.Tint);
+        Assert.Equal(tilemap.Tiles, reloadedMap.Tiles);
+    }
+}

--- a/tests/Yaeger.Tests/ECS/TilemapSerializerTests.cs
+++ b/tests/Yaeger.Tests/ECS/TilemapSerializerTests.cs
@@ -195,6 +195,19 @@ public class TilemapSerializerTests
     }
 
     [Fact]
+    public void Serialize_DefaultConstructedTilemap_ShouldFailWithClearMessage()
+    {
+        var registry = new ComponentRegistry().RegisterEngineComponents();
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, default(Tilemap));
+
+        var ex = Assert.Throws<SceneSaveException>(() => new SceneSaver(registry).Serialize(world));
+
+        Assert.Contains("default-constructed", ex.InnerException?.Message);
+    }
+
+    [Fact]
     public void SceneSaver_TilemapComponent_ShouldRoundTrip()
     {
         var registry = new ComponentRegistry().RegisterEngineComponents();

--- a/tests/Yaeger.Tests/Graphics/TilemapTests.cs
+++ b/tests/Yaeger.Tests/Graphics/TilemapTests.cs
@@ -1,0 +1,160 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Graphics;
+
+public class TilemapTests
+{
+    private const string TexturePath = "Assets/tiles.png";
+
+    private static Tileset MakeTileset(int columns = 4, int rows = 2) =>
+        new(TexturePath, columns, rows);
+
+    [Fact]
+    public void Constructor_ShouldFillWithEmptyTiles()
+    {
+        var tilemap = new Tilemap(MakeTileset(), width: 3, height: 2);
+
+        Assert.Equal(3, tilemap.Width);
+        Assert.Equal(2, tilemap.Height);
+        Assert.Equal(6, tilemap.Tiles.Length);
+        Assert.All(tilemap.Tiles, tile => Assert.Equal(Tilemap.EmptyTile, tile));
+    }
+
+    [Fact]
+    public void Constructor_Defaults_ShouldBeUnitTileSizeAndWhiteTint()
+    {
+        var tilemap = new Tilemap(MakeTileset(), width: 1, height: 1);
+
+        Assert.Equal(Vector2.One, tilemap.TileSize);
+        Assert.Equal(Color.White, tilemap.Tint);
+    }
+
+    [Fact]
+    public void Constructor_WithTiles_ShouldUseArrayDirectly()
+    {
+        var tiles = new[] { 0, 1, Tilemap.EmptyTile, 7 };
+
+        var tilemap = new Tilemap(MakeTileset(), width: 2, height: 2, tiles);
+
+        Assert.Same(tiles, tilemap.Tiles);
+    }
+
+    [Fact]
+    public void Constructor_DefaultTileset_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new Tilemap(default, width: 1, height: 1));
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveDimensions_ShouldThrow()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tilemap(MakeTileset(), width: 0, height: 1)
+        );
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tilemap(MakeTileset(), width: 1, height: 0)
+        );
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveTileSize_ShouldThrow()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tilemap(MakeTileset(), width: 1, height: 1, tileSize: new Vector2(0f, 1f))
+        );
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tilemap(MakeTileset(), width: 1, height: 1, tileSize: new Vector2(1f, -1f))
+        );
+    }
+
+    [Fact]
+    public void Constructor_WrongTileArrayLength_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Tilemap(MakeTileset(), width: 2, height: 2, tiles: [0, 1, 2])
+        );
+    }
+
+    [Fact]
+    public void Constructor_TileIndexOutOfRange_ShouldThrow()
+    {
+        // Tileset is 4x2 = 8 tiles, so 8 is one past the end and -2 is below the sentinel.
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tilemap(MakeTileset(), width: 2, height: 1, tiles: [0, 8])
+        );
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tilemap(MakeTileset(), width: 2, height: 1, tiles: [-2, 0])
+        );
+    }
+
+    [Fact]
+    public void GetTile_ShouldReadRowMajorFromTopRow()
+    {
+        // 3 wide, 2 high: row 0 (top) is [0, 1, 2], row 1 (bottom) is [3, 4, 5].
+        var tilemap = new Tilemap(MakeTileset(), width: 3, height: 2, tiles: [0, 1, 2, 3, 4, 5]);
+
+        Assert.Equal(0, tilemap.GetTile(column: 0, row: 0));
+        Assert.Equal(2, tilemap.GetTile(column: 2, row: 0));
+        Assert.Equal(3, tilemap.GetTile(column: 0, row: 1));
+        Assert.Equal(5, tilemap.GetTile(column: 2, row: 1));
+    }
+
+    [Fact]
+    public void SetTile_ShouldRoundTripThroughGetTile()
+    {
+        var tilemap = new Tilemap(MakeTileset(), width: 3, height: 2);
+
+        tilemap.SetTile(column: 1, row: 1, tileIndex: 5);
+
+        Assert.Equal(5, tilemap.GetTile(column: 1, row: 1));
+        Assert.Equal(Tilemap.EmptyTile, tilemap.GetTile(column: 0, row: 0));
+    }
+
+    [Fact]
+    public void SetTile_EmptySentinel_ShouldClearCell()
+    {
+        var tilemap = new Tilemap(MakeTileset(), width: 1, height: 1, tiles: [3]);
+
+        tilemap.SetTile(column: 0, row: 0, Tilemap.EmptyTile);
+
+        Assert.Equal(Tilemap.EmptyTile, tilemap.GetTile(column: 0, row: 0));
+    }
+
+    [Fact]
+    public void SetTile_InvalidIndex_ShouldThrow()
+    {
+        var tilemap = new Tilemap(MakeTileset(), width: 1, height: 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => tilemap.SetTile(0, 0, 8));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tilemap.SetTile(0, 0, -2));
+    }
+
+    [Fact]
+    public void GetTile_OutOfBoundsCell_ShouldThrow()
+    {
+        var tilemap = new Tilemap(MakeTileset(), width: 2, height: 2);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => tilemap.GetTile(-1, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tilemap.GetTile(2, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tilemap.GetTile(0, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tilemap.GetTile(0, 2));
+    }
+
+    [Fact]
+    public void SetTile_OnComponentCopy_ShouldBeVisibleThroughWorld()
+    {
+        // The tile array is shared between copies of the struct, so mutating a copy
+        // retrieved from the world updates the stored component too (like Animation.Frames).
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Tilemap(MakeTileset(), width: 2, height: 2));
+
+        var copy = world.GetComponent<Tilemap>(entity);
+        copy.SetTile(column: 1, row: 0, tileIndex: 4);
+
+        var reread = world.GetComponent<Tilemap>(entity);
+        Assert.Equal(4, reread.GetTile(column: 1, row: 0));
+    }
+}

--- a/tests/Yaeger.Tests/Graphics/TilemapTests.cs
+++ b/tests/Yaeger.Tests/Graphics/TilemapTests.cs
@@ -70,6 +70,22 @@ public class TilemapTests
     }
 
     [Fact]
+    public void Constructor_NonFiniteTileSize_ShouldThrow()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tilemap(MakeTileset(), width: 1, height: 1, tileSize: new Vector2(float.NaN, 1f))
+        );
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tilemap(
+                MakeTileset(),
+                width: 1,
+                height: 1,
+                tileSize: new Vector2(1f, float.PositiveInfinity)
+            )
+        );
+    }
+
+    [Fact]
     public void Constructor_WrongTileArrayLength_ShouldThrow()
     {
         Assert.Throws<ArgumentException>(() =>

--- a/tests/Yaeger.Tests/Graphics/TilesetTests.cs
+++ b/tests/Yaeger.Tests/Graphics/TilesetTests.cs
@@ -1,0 +1,95 @@
+using Yaeger.Graphics;
+
+namespace Yaeger.Tests.Graphics;
+
+public class TilesetTests
+{
+    private const string TexturePath = "Assets/tiles.png";
+
+    [Fact]
+    public void Constructor_ShouldExposeGridProperties()
+    {
+        var tileset = new Tileset(TexturePath, columns: 4, rows: 2);
+
+        Assert.Equal(TexturePath, tileset.TexturePath);
+        Assert.Equal(4, tileset.Columns);
+        Assert.Equal(2, tileset.Rows);
+        Assert.Equal(8, tileset.TileCount);
+    }
+
+    [Fact]
+    public void Constructor_RowsDefault_ShouldBeOne()
+    {
+        var tileset = new Tileset(TexturePath, columns: 3);
+
+        Assert.Equal(1, tileset.Rows);
+        Assert.Equal(3, tileset.TileCount);
+    }
+
+    [Fact]
+    public void Constructor_EmptyTexturePath_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new Tileset("", columns: 1));
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveColumns_ShouldThrow()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Tileset(TexturePath, columns: 0));
+    }
+
+    [Fact]
+    public void Default_ShouldHaveZeroTileCount()
+    {
+        var tileset = default(Tileset);
+
+        Assert.Equal(0, tileset.TileCount);
+    }
+
+    [Fact]
+    public void GetTileUv_FirstTile_ShouldBeTopLeft()
+    {
+        var tileset = new Tileset(TexturePath, columns: 2, rows: 2);
+
+        var (uvMin, uvMax) = tileset.GetTileUv(0);
+
+        Assert.Equal(0f, uvMin.X, 0.0001f);
+        Assert.Equal(0.5f, uvMin.Y, 0.0001f);
+        Assert.Equal(0.5f, uvMax.X, 0.0001f);
+        Assert.Equal(1f, uvMax.Y, 0.0001f);
+    }
+
+    [Fact]
+    public void GetTileUv_LastTile_ShouldBeBottomRight()
+    {
+        var tileset = new Tileset(TexturePath, columns: 2, rows: 2);
+
+        var (uvMin, uvMax) = tileset.GetTileUv(3);
+
+        Assert.Equal(0.5f, uvMin.X, 0.0001f);
+        Assert.Equal(0f, uvMin.Y, 0.0001f);
+        Assert.Equal(1f, uvMax.X, 0.0001f);
+        Assert.Equal(0.5f, uvMax.Y, 0.0001f);
+    }
+
+    [Fact]
+    public void GetTileUv_ShouldMatchSpriteSheetFrameUv()
+    {
+        var tileset = new Tileset(TexturePath, columns: 4, rows: 3);
+        var sheet = new SpriteSheet(TexturePath, columns: 4, rows: 3);
+
+        for (var i = 0; i < tileset.TileCount; i++)
+        {
+            Assert.Equal(sheet.GetFrameUv(i), tileset.GetTileUv(i));
+        }
+    }
+
+    [Fact]
+    public void GetTileUv_OutOfRangeIndex_ShouldThrow()
+    {
+        var tileset = new Tileset(TexturePath, columns: 2, rows: 2);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => tileset.GetTileUv(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => tileset.GetTileUv(4));
+    }
+}

--- a/tests/Yaeger.Tests/Graphics/TilesetTests.cs
+++ b/tests/Yaeger.Tests/Graphics/TilesetTests.cs
@@ -39,6 +39,16 @@ public class TilesetTests
     }
 
     [Fact]
+    public void Constructor_ColumnsTimesRowsOverflowingInt_ShouldThrow()
+    {
+        // 100000 * 100000 wraps to a positive-but-wrong int; the constructor must reject it
+        // instead of exposing a bogus TileCount.
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Tileset(TexturePath, columns: 100_000, rows: 100_000)
+        );
+    }
+
+    [Fact]
     public void Default_ShouldHaveZeroTileCount()
     {
         var tileset = default(Tileset);

--- a/tests/Yaeger.Tests/Systems/UnifiedRenderSystemTilemapTests.cs
+++ b/tests/Yaeger.Tests/Systems/UnifiedRenderSystemTilemapTests.cs
@@ -247,6 +247,21 @@ public class UnifiedRenderSystemTilemapTests
     }
 
     [Fact]
+    public void GetVisibleTileRange_NonPositiveTileSize_ShouldFallBackToFullMap()
+    {
+        // TileSize is a mutable field, so it can be zeroed after construction; culling must
+        // not divide by it in that case.
+        var map = new Tilemap(MakeTileset(), width: 10, height: 10);
+        map.TileSize = Vector2.Zero;
+        var transform = new Transform2D(Vector2.Zero);
+        var camera = new Camera2D(new Vector2(100f, 100f));
+
+        var range = UnifiedRenderSystem.GetVisibleTileRange(map, transform, camera, 1f);
+
+        Assert.Equal((0, 9, 0, 9), range);
+    }
+
+    [Fact]
     public void GetVisibleTileRange_RotatedMapTransform_ShouldFallBackToFullMap()
     {
         var map = new Tilemap(MakeTileset(), width: 10, height: 10);

--- a/tests/Yaeger.Tests/Systems/UnifiedRenderSystemTilemapTests.cs
+++ b/tests/Yaeger.Tests/Systems/UnifiedRenderSystemTilemapTests.cs
@@ -1,0 +1,304 @@
+using System.Numerics;
+using Yaeger.ECS;
+using Yaeger.Graphics;
+using Yaeger.Platform;
+using Yaeger.Systems;
+
+namespace Yaeger.Tests.Systems;
+
+public class UnifiedRenderSystemTilemapTests
+{
+    private const string TexturePath = "Assets/tiles.png";
+
+    private sealed class FakeRenderSurface : IRenderSurface
+    {
+        public readonly List<(
+            Matrix4x4 Transform,
+            string TexturePath,
+            Vector2 UvMin,
+            Vector2 UvMax,
+            Vector4 Color
+        )> Quads = [];
+
+        public void BeginFrame() { }
+
+        public void EndFrame() { }
+
+        public void FlushQueuedQuads() { }
+
+        public void SetCamera(Matrix4x4 viewProjection) { }
+
+        public void SubmitQuad(Matrix4x4 transform, string texturePath, Vector4 color) =>
+            Quads.Add((transform, texturePath, Vector2.Zero, Vector2.One, color));
+
+        public void SubmitQuad(
+            Matrix4x4 transform,
+            string texturePath,
+            Vector2 uvMin,
+            Vector2 uvMax,
+            Vector4 color
+        ) => Quads.Add((transform, texturePath, uvMin, uvMax, color));
+    }
+
+    private static Tileset MakeTileset() => new(TexturePath, columns: 2, rows: 2);
+
+    // ── Rendering ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Render_ShouldSubmitOneQuadPerNonEmptyTile()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            entity,
+            new Tilemap(MakeTileset(), width: 2, height: 2, tiles: [0, Tilemap.EmptyTile, 1, 2])
+        );
+
+        var surface = new FakeRenderSurface();
+        new UnifiedRenderSystem(surface, null, world).Render();
+
+        Assert.Equal(3, surface.Quads.Count);
+        Assert.All(surface.Quads, quad => Assert.Equal(TexturePath, quad.TexturePath));
+    }
+
+    [Fact]
+    public void Render_ShouldPositionTilesBottomLeftOriginWithTopRowFirst()
+    {
+        // 2x2 map at world position (10, 20) with unit tiles. Row 0 is the top row, so
+        // tile (column 0, row 0) is centred at (10.5, 21.5) and (column 1, row 1) at (11.5, 20.5).
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(new Vector2(10f, 20f)));
+        world.AddComponent(
+            entity,
+            new Tilemap(
+                MakeTileset(),
+                width: 2,
+                height: 2,
+                tiles: [0, Tilemap.EmptyTile, Tilemap.EmptyTile, 1]
+            )
+        );
+
+        var surface = new FakeRenderSurface();
+        new UnifiedRenderSystem(surface, null, world).Render();
+
+        Assert.Equal(2, surface.Quads.Count);
+        var topLeft = surface.Quads[0].Transform;
+        Assert.Equal(10.5f, topLeft.M41, 0.0001f);
+        Assert.Equal(21.5f, topLeft.M42, 0.0001f);
+        var bottomRight = surface.Quads[1].Transform;
+        Assert.Equal(11.5f, bottomRight.M41, 0.0001f);
+        Assert.Equal(20.5f, bottomRight.M42, 0.0001f);
+    }
+
+    [Fact]
+    public void Render_ShouldScaleQuadsToTileSize()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            entity,
+            new Tilemap(MakeTileset(), width: 1, height: 1, tiles: [0], new Vector2(2f, 0.5f))
+        );
+
+        var surface = new FakeRenderSurface();
+        new UnifiedRenderSystem(surface, null, world).Render();
+
+        var transform = Assert.Single(surface.Quads).Transform;
+        // Unit quad scaled to tile size: X basis length 2, Y basis length 0.5, centred in the cell.
+        Assert.Equal(2f, transform.M11, 0.0001f);
+        Assert.Equal(0.5f, transform.M22, 0.0001f);
+        Assert.Equal(1f, transform.M41, 0.0001f);
+        Assert.Equal(0.25f, transform.M42, 0.0001f);
+    }
+
+    [Fact]
+    public void Render_ShouldUseTilesetUvForEachTileIndex()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Tilemap(MakeTileset(), width: 1, height: 1, tiles: [3]));
+
+        var surface = new FakeRenderSurface();
+        new UnifiedRenderSystem(surface, null, world).Render();
+
+        var quad = Assert.Single(surface.Quads);
+        var (expectedMin, expectedMax) = MakeTileset().GetTileUv(3);
+        Assert.Equal(expectedMin, quad.UvMin);
+        Assert.Equal(expectedMax, quad.UvMax);
+    }
+
+    [Fact]
+    public void Render_ShouldApplyTintToAllTiles()
+    {
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            entity,
+            new Tilemap(
+                MakeTileset(),
+                width: 2,
+                height: 1,
+                tiles: [0, 1],
+                tint: new Color(255, 0, 0, 255)
+            )
+        );
+
+        var surface = new FakeRenderSurface();
+        new UnifiedRenderSystem(surface, null, world).Render();
+
+        Assert.All(
+            surface.Quads,
+            quad => Assert.Equal(new Color(255, 0, 0, 255).ToVector4(), quad.Color)
+        );
+    }
+
+    [Fact]
+    public void Render_ShouldOrderTilemapsBySpriteRenderLayer()
+    {
+        var world = new World();
+
+        var foregroundSprite = world.CreateEntity();
+        world.AddComponent(foregroundSprite, new Transform2D(Vector2.Zero));
+        world.AddComponent(foregroundSprite, new Sprite("Assets/player.png"));
+        world.AddComponent(foregroundSprite, new RenderLayer(1));
+
+        var backgroundMap = world.CreateEntity();
+        world.AddComponent(backgroundMap, new Transform2D(Vector2.Zero));
+        world.AddComponent(
+            backgroundMap,
+            new Tilemap(MakeTileset(), width: 1, height: 1, tiles: [0])
+        );
+        world.AddComponent(backgroundMap, new RenderLayer(0));
+
+        var surface = new FakeRenderSurface();
+        new UnifiedRenderSystem(surface, null, world).Render();
+
+        // Layer 0 tilemap first, layer 1 sprite on top.
+        Assert.Equal(2, surface.Quads.Count);
+        Assert.Equal(TexturePath, surface.Quads[0].TexturePath);
+        Assert.Equal("Assets/player.png", surface.Quads[1].TexturePath);
+    }
+
+    // ── Culling ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetVisibleTileRange_CameraInsideMap_ShouldReturnSurroundingCells()
+    {
+        var map = new Tilemap(MakeTileset(), width: 200, height: 30);
+        var transform = new Transform2D(Vector2.Zero);
+        // Zoom 1, aspect 1 → visible world span is [99, 101] × [14, 16].
+        var camera = new Camera2D(new Vector2(100f, 15f));
+
+        var (columnMin, columnMax, rowMin, rowMax) = UnifiedRenderSystem.GetVisibleTileRange(
+            map,
+            transform,
+            camera,
+            aspectRatio: 1f
+        );
+
+        Assert.Equal(99, columnMin);
+        Assert.Equal(100, columnMax);
+        // Rows count from the top: world Y 14..16 is rows 14..15 of a 30-tall map.
+        Assert.Equal(14, rowMin);
+        Assert.Equal(15, rowMax);
+    }
+
+    [Fact]
+    public void GetVisibleTileRange_ZoomAndAspect_ShouldShrinkAndWidenSpan()
+    {
+        var map = new Tilemap(MakeTileset(), width: 10, height: 10);
+        var transform = new Transform2D(Vector2.Zero);
+        // Zoom 2, aspect 2 → half extents (1, 0.5): visible span [4, 6] × [4.5, 5.5].
+        var camera = new Camera2D(new Vector2(5f, 5f), Zoom: 2f);
+
+        var (columnMin, columnMax, rowMin, rowMax) = UnifiedRenderSystem.GetVisibleTileRange(
+            map,
+            transform,
+            camera,
+            aspectRatio: 2f
+        );
+
+        Assert.Equal(4, columnMin);
+        Assert.Equal(5, columnMax);
+        Assert.Equal(4, rowMin);
+        Assert.Equal(5, rowMax);
+    }
+
+    [Fact]
+    public void GetVisibleTileRange_MapFullyOffScreen_ShouldReturnEmptyRange()
+    {
+        var map = new Tilemap(MakeTileset(), width: 10, height: 10);
+        var transform = new Transform2D(Vector2.Zero);
+        var camera = new Camera2D(new Vector2(-50f, 5f));
+
+        var (columnMin, columnMax, _, _) = UnifiedRenderSystem.GetVisibleTileRange(
+            map,
+            transform,
+            camera,
+            aspectRatio: 1f
+        );
+
+        Assert.True(columnMin > columnMax);
+    }
+
+    [Fact]
+    public void GetVisibleTileRange_RotatedMapTransform_ShouldFallBackToFullMap()
+    {
+        var map = new Tilemap(MakeTileset(), width: 10, height: 10);
+        var transform = new Transform2D(Vector2.Zero, rotation: 0.5f);
+        var camera = new Camera2D(new Vector2(100f, 100f));
+
+        var range = UnifiedRenderSystem.GetVisibleTileRange(map, transform, camera, 1f);
+
+        Assert.Equal((0, 9, 0, 9), range);
+    }
+
+    [Fact]
+    public void GetVisibleTileRange_ScaledMapTransform_ShouldMapViewIntoLocalCells()
+    {
+        var map = new Tilemap(MakeTileset(), width: 10, height: 10);
+        // Scale 2 → each cell covers 2 world units; view [3, 5] × [3, 5] is local [1.5, 2.5].
+        var transform = new Transform2D(Vector2.Zero, scale: new Vector2(2f, 2f));
+        var camera = new Camera2D(new Vector2(4f, 4f));
+
+        var (columnMin, columnMax, rowMin, rowMax) = UnifiedRenderSystem.GetVisibleTileRange(
+            map,
+            transform,
+            camera,
+            aspectRatio: 1f
+        );
+
+        Assert.Equal(1, columnMin);
+        Assert.Equal(2, columnMax);
+        Assert.Equal(7, rowMin);
+        Assert.Equal(8, rowMax);
+    }
+
+    [Fact]
+    public void GetVisibleTileRange_RotatedCamera_ShouldExpandToConservativeBounds()
+    {
+        var map = new Tilemap(MakeTileset(), width: 100, height: 100);
+        var transform = new Transform2D(Vector2.Zero);
+        // 90° camera rotation with aspect 2 swaps the extents: (2, 1) → (1, 2).
+        var camera = new Camera2D(new Vector2(50f, 50f), Rotation: MathF.PI / 2f);
+
+        var (columnMin, columnMax, rowMin, rowMax) = UnifiedRenderSystem.GetVisibleTileRange(
+            map,
+            transform,
+            camera,
+            aspectRatio: 2f
+        );
+
+        // The ideal span is columns 49-50 and rows 48-51; the AABB is conservative and
+        // float imprecision in cos/sin may widen it by a cell, but never shrink it.
+        Assert.InRange(columnMin, 48, 49);
+        Assert.InRange(columnMax, 50, 51);
+        Assert.InRange(rowMin, 47, 48);
+        Assert.InRange(rowMax, 51, 52);
+    }
+}

--- a/tests/Yaeger.Tests/Systems/UnifiedRenderSystemTilemapTests.cs
+++ b/tests/Yaeger.Tests/Systems/UnifiedRenderSystemTilemapTests.cs
@@ -20,6 +20,8 @@ public class UnifiedRenderSystemTilemapTests
             Vector4 Color
         )> Quads = [];
 
+        public List<string>? CallLog { get; init; }
+
         public void BeginFrame() { }
 
         public void EndFrame() { }
@@ -28,8 +30,11 @@ public class UnifiedRenderSystemTilemapTests
 
         public void SetCamera(Matrix4x4 viewProjection) { }
 
-        public void SubmitQuad(Matrix4x4 transform, string texturePath, Vector4 color) =>
+        public void SubmitQuad(Matrix4x4 transform, string texturePath, Vector4 color)
+        {
+            CallLog?.Add("quad");
             Quads.Add((transform, texturePath, Vector2.Zero, Vector2.One, color));
+        }
 
         public void SubmitQuad(
             Matrix4x4 transform,
@@ -37,7 +42,30 @@ public class UnifiedRenderSystemTilemapTests
             Vector2 uvMin,
             Vector2 uvMax,
             Vector4 color
-        ) => Quads.Add((transform, texturePath, uvMin, uvMax, color));
+        )
+        {
+            CallLog?.Add("quad");
+            Quads.Add((transform, texturePath, uvMin, uvMax, color));
+        }
+    }
+
+    private sealed class FakeTextRenderSurface(List<string> callLog) : ITextRenderSurface
+    {
+        public void DrawText(
+            string text,
+            Matrix4x4 transform,
+            FontHandle font,
+            int fontSize,
+            Color color
+        ) => callLog.Add("text");
+
+        public void DrawText(
+            string text,
+            Matrix4x4 transform,
+            IFontHandle font,
+            int fontSize,
+            Color color
+        ) => callLog.Add("text");
     }
 
     private static Tileset MakeTileset() => new(TexturePath, columns: 2, rows: 2);
@@ -182,6 +210,24 @@ public class UnifiedRenderSystemTilemapTests
         Assert.Equal(2, surface.Quads.Count);
         Assert.Equal(TexturePath, surface.Quads[0].TexturePath);
         Assert.Equal("Assets/player.png", surface.Quads[1].TexturePath);
+    }
+
+    [Fact]
+    public void Render_EntityWithTilemapAndText_ShouldDrawTilesBeforeText()
+    {
+        // Text must sort after quad kinds on the same entity/layer: text execution flushes
+        // queued quads before drawing, so quads submitted afterwards would paint over it.
+        var world = new World();
+        var entity = world.CreateEntity();
+        world.AddComponent(entity, new Transform2D(Vector2.Zero));
+        world.AddComponent(entity, new Tilemap(MakeTileset(), width: 1, height: 1, tiles: [0]));
+        world.AddComponent(entity, new Text("score", new FontHandle("test-font"), 12, Color.White));
+
+        var log = new List<string>();
+        var surface = new FakeRenderSurface { CallLog = log };
+        new UnifiedRenderSystem(surface, new FakeTextRenderSurface(log), world).Render();
+
+        Assert.Equal(["quad", "text"], log);
     }
 
     // ── Culling ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #128 (part of epic #127).

Adds a first-class tilemap: a rectangular grid of tile indices referencing a shared tileset texture, rendered through the existing batched pipeline without one entity per tile.

## What's included

- **`Tileset`** (`Graphics/Tileset.cs`) — a texture divided into a uniform grid of equally-sized tiles with per-tile UV lookup. Composes a `SpriteSheet` internally, so `GetTileUv` genuinely reuses the existing `GetFrameUv` math.
- **`Tilemap`** (`Graphics/Tilemap.cs`) — struct component holding `Width × Height` tile indices, world-unit `TileSize`, and a `Tint`. `Tilemap.EmptyTile` (`-1`) marks empty cells. `GetTile`/`SetTile` provide validated access; the backing array is shared between component copies (same pattern as `Animation.Frames`), so runtime edits show up without re-adding the component.
- **Rendering via `UnifiedRenderSystem`** — tilemaps join the shared `RenderLayer`-sorted pass as **one command per map**, expanded into per-tile quads at execution time. The per-frame sort stays proportional to entity count, and since every tile shares the tileset texture, a map collapses into a single draw call in the batched renderer. Multiple tilemap entities + `RenderLayer` = background/foreground layers ordered against sprites and text.
- **Camera culling** — with an active `Camera2D`, only tiles intersecting the camera's visible span are submitted (`GetVisibleTileRange` maps the view's world AABB into tile cells, handling zoom, aspect ratio, camera rotation, and map translation/scale). Rotated map transforms conservatively fall back to the full map; a map fully off-screen submits nothing.
- **`TilemapSerializer`** — registered in `RegisterEngineComponents()` under type id `"Tilemap"`, so tilemaps load from prefab/scene JSON and round-trip through `SceneSaver`. Optional fields (`rows`, `tileWidth`/`tileHeight`, `tiles`, `tint`) follow the existing serializer conventions, with `PrefabLoadException` validation for malformed input.
- **Docs** — `docs/tilemaps.md` (coordinate conventions, layering, culling, JSON format) added to the mkdocs nav, plus a short CLAUDE.md note.

## Coordinate conventions

- `Transform2D.Position` is the **bottom-left corner** of the map in world space (Y-up friendly).
- Tile indices are row-major with **row 0 at the top** — the order a grid reads when authored as text or exported from Tiled, which keeps future importer work (#130) straightforward.

## Acceptance criteria from #128

- ✅ A wide level renders in one draw call per tilemap layer (shared texture through the batched renderer) and scrolls with `Camera2D` — off-screen tiles are culled
- ✅ Tilemaps round-trip through `SceneSaver`/`SceneLoader`
- ✅ Unit tests for grid indexing, UV lookup, and serialization

## Testing

35 new tests (677 total, all passing): `TilesetTests` (UV math, validation, parity with `SpriteSheet`), `TilemapTests` (constructor validation, row-major/top-row indexing, `SetTile` semantics through the `World`), `TilemapSerializerTests` (prefab loading, defaults, error cases, `SceneSaver` round-trip), and `UnifiedRenderSystemTilemapTests` (quad positions/UVs/tint via a fake `IRenderSurface`, `RenderLayer` ordering against sprites, and culling ranges for zoom/aspect/rotation/scale/off-screen cases). `dotnet csharpier check` passes.

Out of scope (per the issue): collision (#129), Tiled/LDtk import (#130), animated tiles, auto-tiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSj8JdpUoTbj2KCE1eLTzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSj8JdpUoTbj2KCE1eLTzp)_